### PR TITLE
Chore/nodev8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,14 +8,14 @@ services:
 
 install:
     - docker login quay.io -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD"
-    - docker pull quay.io/cdis/bpa-data-portal:latest
+    - docker pull quay.io/cdis/bpa-data-portal:master
 
 script:
     - |
       set -e
-      docker build --cache-from quay.io/cdis/bpa-data-portal:latest --build-arg APP=bpa -t quay.io/cdis/bpa-data-portal:${TRAVIS_BRANCH/\//_} .
-      docker build --cache-from quay.io/cdis/bpa-data-portal:latest --build-arg APP=edc --build-arg BASENAME="/portal/" -t quay.io/cdis/edc-data-portal:${TRAVIS_BRANCH/\//_} .
-      docker build --cache-from quay.io/cdis/bpa-data-portal:latest --build-arg APP=acct -t quay.io/cdis/acct-data-portal:${TRAVIS_BRANCH/\//_} .
+      docker build --cache-from quay.io/cdis/bpa-data-portal:master --build-arg APP=bpa -t quay.io/cdis/bpa-data-portal:${TRAVIS_BRANCH/\//_} .
+      docker build --cache-from quay.io/cdis/bpa-data-portal:master --build-arg APP=edc --build-arg BASENAME="/portal/" -t quay.io/cdis/edc-data-portal:${TRAVIS_BRANCH/\//_} .
+      docker build --cache-from quay.io/cdis/bpa-data-portal:master --build-arg APP=acct -t quay.io/cdis/acct-data-portal:${TRAVIS_BRANCH/\//_} .
       set +e
 
 after_success:

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,6 @@
 FROM ubuntu:16.04
 
 ENV DEBIAN_FRONTEND=noninteractive
-ARG APP=dev
-ARG BASENAME
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     build-essential \
@@ -20,6 +18,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && npm install webpack -g \
     && ln -sf /dev/stdout /var/log/nginx/access.log \
     && ln -sf /dev/stderr /var/log/nginx/error.log
+
+ARG APP=dev
+ARG BASENAME
 
 COPY . /data-portal
 WORKDIR /data-portal


### PR DESCRIPTION
Use node8 & use cached docker builds to speed building.
Close #72 for now, unless this PR fails to resolve issues.