### PR TITLE
fix(dd-style): use consistent thead

### DIFF
--- a/src/DataDictionary/component.js
+++ b/src/DataDictionary/component.js
@@ -24,11 +24,11 @@ const CategoryTable = ({dictionary, nodes, category}) =>{
   return (
     <Table>
       <TableHead>
-        <tr>
-          <td>
+        <TableRow>
+          <TableData first_cr>
           {category}
-          </td>
-        </tr>
+          </TableData>
+        </TableRow>
       </TableHead>
 
       <tbody>

--- a/src/theme.js
+++ b/src/theme.js
@@ -90,7 +90,6 @@ export const TableHead = styled.thead`
     -ms-user-select: none;
     user-select: none;
     text-align: left;
-    padding: 5px 5px;
 `;
 
 export const TableRow = styled.tr`


### PR DESCRIPTION
in previous style, the header in node page has an unexpected white padding
I removed the padding and used the same style for both node and summary page
r? @arespinos 