### PR TITLE
Chore/js local

### DIFF
--- a/boot.js
+++ b/boot.js
@@ -1,0 +1,7 @@
+(function() {
+  const buildSrc = sessionStorage.getItem( "locaDevMode" ) !== "true" ? "/bundle.js" : "https://localhost/bundle.js";
+  const scriptNode = document.createElement( 'script' );
+  scriptNode.src = buildSrc;
+  scriptNode.type = "text/javascript";
+  document.body.appendChild( scriptNode );
+})();

--- a/boot.js
+++ b/boot.js
@@ -1,5 +1,6 @@
 (function() {
-  const buildSrc = sessionStorage.getItem( "locaDevMode" ) !== "true" ? "/bundle.js" : "https://localhost/bundle.js";
+  const isDevMode = !! location.pathname.match( /^\/dev.html/ );
+  const buildSrc = isDevMode ? "https://localhost/bundle.js" : "/bundle.js"; 
   const scriptNode = document.createElement( 'script' );
   scriptNode.src = buildSrc;
   scriptNode.type = "text/javascript";

--- a/boot.js
+++ b/boot.js
@@ -1,8 +1,8 @@
-(function() {
-  const isDevMode = !! location.pathname.match( /^\/dev.html/ );
-  const buildSrc = isDevMode ? "https://localhost/bundle.js" : "/bundle.js"; 
-  const scriptNode = document.createElement( 'script' );
+(function () {
+  const isDevMode = !!location.pathname.match(/^\/dev.html/);
+  const buildSrc = isDevMode ? 'https://localhost/bundle.js' : '/bundle.js';
+  const scriptNode = document.createElement('script');
   scriptNode.src = buildSrc;
-  scriptNode.type = "text/javascript";
-  document.body.appendChild( scriptNode );
-})();
+  scriptNode.type = 'text/javascript';
+  document.body.appendChild(scriptNode);
+}());

--- a/dev.html
+++ b/dev.html
@@ -2,7 +2,7 @@
 <html>
   <head>
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; img-src 'self' data: https://www.google-analytics.com; script-src 'self' 'unsafe-eval' https://www.google-analytics.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; object-src 'none'; font-src 'self' data: https://fonts.googleapis.com https://fonts.gstatic.com">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; img-src 'self' data: https://www.google-analytics.com; script-src 'self' 'unsafe-eval' https://www.google-analytics.com localhost; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; object-src 'none'; font-src 'self' data: https://fonts.googleapis.com https://fonts.gstatic.com">
     <meta name="viewport" content="width=device-width" />
   
     <link rel="stylesheet" type="text/css" media="all" href="/src/css/bootstrap.min.css">
@@ -17,5 +17,5 @@
   </head>
   <body>
       <div id="root"></div>
-  <script type="text/javascript" src="/bundle.js"></script></body>
+  <script type="text/javascript" src="/boot.js"></script></body>
 </html>

--- a/dev.html
+++ b/dev.html
@@ -17,5 +17,5 @@
   </head>
   <body>
       <div id="root"></div>
-  <script type="text/javascript" src="/boot.js"></script></body>
+  <script type="text/javascript" src="./boot.js"></script></body>
 </html>

--- a/nginx.conf
+++ b/nginx.conf
@@ -4,6 +4,9 @@ server {
     root /data-portal;
     index index.html index.htm;
 
+    # dev.html signals dev mode - for developer testing
+    rewrite ^/dev.html.+$ /dev.html;
+
     location ~* \.(?:manifest|appcache|html?|xml|json)$ {
       expires -1;
       # access_log logs/static.log; # I don't usually include a static log

--- a/src/index.ejs
+++ b/src/index.ejs
@@ -2,7 +2,7 @@
 <html>
   <head>
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; img-src 'self' data: https://www.google-analytics.com; script-src 'self' 'unsafe-eval' https://www.google-analytics.com localhost; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; object-src 'none'; font-src 'self' data: https://fonts.googleapis.com https://fonts.gstatic.com">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; img-src 'self' data: https://www.google-analytics.com; script-src 'self' 'unsafe-eval' https://www.google-analytics.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; object-src 'none'; font-src 'self' data: https://fonts.googleapis.com https://fonts.gstatic.com">
     <meta name="viewport" content="width=device-width" />
       
     <link rel="stylesheet" type="text/css" media="all" href="<%= htmlWebpackPlugin.options.basename %>/src/css/bootstrap.min.css">

--- a/src/index.ejs
+++ b/src/index.ejs
@@ -2,7 +2,7 @@
 <html>
   <head>
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; img-src 'self' data: https://www.google-analytics.com; script-src 'self' 'unsafe-eval' https://www.google-analytics.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; object-src 'none'; font-src 'self' data: https://fonts.googleapis.com https://fonts.gstatic.com">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; img-src 'self' data: https://www.google-analytics.com; script-src 'self' 'unsafe-eval' https://www.google-analytics.com localhost; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; object-src 'none'; font-src 'self' data: https://fonts.googleapis.com https://fonts.gstatic.com">
     <meta name="viewport" content="width=device-width" />
       
     <link rel="stylesheet" type="text/css" media="all" href="<%= htmlWebpackPlugin.options.basename %>/src/css/bootstrap.min.css">

--- a/src/localconf.js
+++ b/src/localconf.js
@@ -18,8 +18,8 @@ function buildConfig(opts) {
   // Override default basename if loading via /dev.html
   // dev.html loads bundle.js via https://localhost...
   //
-  if ( typeof location !== "undefined" && location.pathname.indexOf( defaults.basename + 'dev.html' ) === 0 ) {
-    defaults.basename = defaults.basename + 'dev.html';
+  if (typeof location !== 'undefined' && location.pathname.indexOf(`${defaults.basename}dev.html`) === 0) {
+    defaults.basename += 'dev.html';
   }
 
   const { dev, mockStore, app, basename, hostname } = Object.assign({}, defaults, opts);

--- a/src/localconf.js
+++ b/src/localconf.js
@@ -14,6 +14,14 @@ function buildConfig(opts) {
     hostname: typeof window !== 'undefined' ? `${window.location.protocol}//${window.location.hostname}/` : 'http://localhost/',
   };
 
+  //
+  // Override default basename if loading via /dev.html
+  // dev.html loads bundle.js via https://localhost...
+  //
+  if ( typeof location !== "undefined" && location.pathname.indexOf( defaults.basename + 'dev.html' ) === 0 ) {
+    defaults.basename = defaults.basename + 'dev.html';
+  }
+
   const { dev, mockStore, app, basename, hostname } = Object.assign({}, defaults, opts);
 
   let userapiPath = `${hostname}user/`;


### PR DESCRIPTION
Small tweaks so that loading https://commons/dev.html
triggers loading of https://localhost/bundle.js
rather than https://commons/bundle.js - which allows us
to test UX code under local development against production data.

I added instructions for setting up a self-signed certificate for https://localhost to the wiki (pull request pending):
```
--- a/dev/Local-development-for-Gen3.md
+++ b/dev/Local-development-for-Gen3.md
@@ -91,6 +91,18 @@ http {
 
     listen         80;
 
+    #
+    # Optional ssl setup - allows dev-mode bundle.js load
+    # at https://localhost/bundle.js
+    # For self signed certificate generation instructions see:
+    #     https://www.digitalocean.com/community/tutorials/how-to-create-an-ssl-certificate-on-nginx-for-ubuntu-14-04
+    #
+    listen 443 ssl;
+
+    server_name localhost;
+    ssl_certificate /etc/nginx/ssl/nginx.crt;
+    ssl_certificate_key /etc/nginx/ssl/nginx.key;
+
```