### PR TITLE
fix(dependency): update graphiql version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3613,8 +3613,7 @@
     "entities": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.1.tgz",
-      "integrity": "sha1-blwtClYhtdra7O+AuQ7ftc13cvA=",
-      "dev": true
+      "integrity": "sha1-blwtClYhtdra7O+AuQ7ftc13cvA="
     },
     "enzyme": {
       "version": "3.2.0",
@@ -5118,13 +5117,13 @@
       "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
     },
     "graphiql": {
-      "version": "0.11.5",
-      "resolved": "https://registry.npmjs.org/graphiql/-/graphiql-0.11.5.tgz",
-      "integrity": "sha512-iBczReJNhx0qabYrz24a/tewQw0m+WvzLiayuZhsLcJygvsnJD8IA/+R/azhiZZ2fJSfPOY8FmFzPcX90mHITQ==",
+      "version": "0.11.11",
+      "resolved": "https://registry.npmjs.org/graphiql/-/graphiql-0.11.11.tgz",
+      "integrity": "sha512-+r8qY2JRRs+uaZcrZOxpNhdlCZoS8yS5KQ6X53Twc8WecZ6VtAn+MVHroLOd4u9HVPxTXZ9RUd9+556EpTc0xA==",
       "requires": {
         "codemirror": "5.30.0",
         "codemirror-graphql": "0.6.11",
-        "marked": "0.3.6"
+        "markdown-it": "8.4.0"
       }
     },
     "graphql": {
@@ -7858,6 +7857,14 @@
         "type-check": "0.3.2"
       }
     },
+    "linkify-it": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-2.0.3.tgz",
+      "integrity": "sha1-2UpGSPmxwXnWT6lykSaL22zpQ08=",
+      "requires": {
+        "uc.micro": "1.0.3"
+      }
+    },
     "load-json-file": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
@@ -8108,10 +8115,27 @@
         "object-visit": "1.0.1"
       }
     },
-    "marked": {
-      "version": "0.3.6",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.6.tgz",
-      "integrity": "sha1-ssbGGPzOzk74bE/Gy4p8v1rtqNc="
+    "markdown-it": {
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-8.4.0.tgz",
+      "integrity": "sha512-tNuOCCfunY5v5uhcO2AUMArvKAyKMygX8tfup/JrgnsDqcCATQsAExBq7o5Ml9iMmO82bk6jYNLj6khcrl0JGA==",
+      "requires": {
+        "argparse": "1.0.9",
+        "entities": "1.1.1",
+        "linkify-it": "2.0.3",
+        "mdurl": "1.0.1",
+        "uc.micro": "1.0.3"
+      },
+      "dependencies": {
+        "argparse": {
+          "version": "1.0.9",
+          "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
+          "integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
+          "requires": {
+            "sprintf-js": "1.0.3"
+          }
+        }
+      }
     },
     "material-design-icons": {
       "version": "3.0.1",
@@ -8180,6 +8204,11 @@
           }
         }
       }
+    },
+    "mdurl": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-1.0.1.tgz",
+      "integrity": "sha1-/oWy7HWlkDfyrf7BAP1sYBdhFS4="
     },
     "media-typer": {
       "version": "0.3.0",
@@ -13307,8 +13336,7 @@
     "sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
-      "dev": true
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
     },
     "sshpk": {
       "version": "1.13.1",
@@ -13398,7 +13426,8 @@
     "strict-uri-encode": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
-      "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM="
+      "integrity": "sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=",
+      "dev": true
     },
     "string-extended": {
       "version": "0.0.8",
@@ -14059,6 +14088,11 @@
       "version": "0.7.17",
       "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.17.tgz",
       "integrity": "sha512-uRdSdu1oA1rncCQL7sCj8vSyZkgtL7faaw9Tc9rZ3mGgraQ7+Pdx7w5mnOSF3gw9ZNG6oc+KXfkon3bKuROm0g=="
+    },
+    "uc.micro": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.3.tgz",
+      "integrity": "sha1-ftUNXg+an7ClczeSWfKndFjVAZI="
     },
     "uglify-js": {
       "version": "3.1.4",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "d3-selection": "^1.1.0",
     "fast-csv": "^2.4.0",
     "file-saver": "^1.3.3",
-    "graphiql": "^0.11.5",
+    "graphiql": "^0.11.11",
     "graphql": "^0.8.2",
     "history": "^4.7.2",
     "ignore-loader": "^0.1.2",


### PR DESCRIPTION
eliminates dependency on marked which github was
flagging due to a known vulnerability (that didn't affect us,
but update anyway)