### PR TITLE
fix(login): better handle new empty commons

### DIFF
--- a/src/DataModelGraph/ReduxDataModelGraph.js
+++ b/src/DataModelGraph/ReduxDataModelGraph.js
@@ -100,7 +100,7 @@ export const getCounts = (typeList, project, dictionary) => {
           };
         }
       },
-      (err) => { return { type: 'FETCH_ERROR', error: err }; },
+      err => ({ type: 'FETCH_ERROR', error: err }),
     )
     .then((msg) => { dispatch(msg); });
 };

--- a/src/DataModelGraph/ReduxDataModelGraph.js
+++ b/src/DataModelGraph/ReduxDataModelGraph.js
@@ -100,6 +100,7 @@ export const getCounts = (typeList, project, dictionary) => {
           };
         }
       },
+      (err) => { return { type: 'FETCH_ERROR', error: err }; },
     )
     .then((msg) => { dispatch(msg); });
 };

--- a/src/Login/ProtectedContent.jsx
+++ b/src/Login/ProtectedContent.jsx
@@ -173,7 +173,7 @@ class ProtectedContent extends React.Component {
       return Promise.resolve(newState);
     }
     return store.dispatch(fetchProjects())
-      .then(() => {
+      .then((info) => {
         //
         // The assumption here is that fetchProjects either succeeds or fails.
         // If it fails (we won't have any project data), then we need to refresh our api token ...
@@ -182,8 +182,16 @@ class ProtectedContent extends React.Component {
         if (projects) {
           // user already has a valid token
           return Promise.resolve(newState);
+        } else if (info.status !== 403) {
+          // do not authenticate unless we have a 403
+          // there may be no projects at startup time,
+          // or some other weirdness ...
+          // The oauth dance below is only relevent for legacy commons - pre jwt
+          return Promise.resolve(newState);
         }
         // else do the oauth dance
+        // NOTE: this is DEPRECATED now - jwt access token
+        //      works across all services
         return store.dispatch(fetchOAuthURL(submissionApiOauthPath))
           .then(
             oauthUrl => fetchJsonOrText({ path: oauthUrl, dispatch: store.dispatch.bind(store) }))

--- a/src/Submission/ProjectSubmission.jsx
+++ b/src/Submission/ProjectSubmission.jsx
@@ -44,7 +44,7 @@ const ProjectSubmission = (props) => {
       <MySubmitForm />
       <MySubmitTSV project={props.project} />
       { !props.dataIsReady
-        ? <Spinner /> :
+        ? ((props.project !== '_root') ? <Spinner /> : null) :
         <MyDataModelGraph project={props.project} /> }
     </div>
   );

--- a/src/actions.js
+++ b/src/actions.js
@@ -228,11 +228,13 @@ export const fetchProjects = () => dispatch =>
           return {
             type: 'RECEIVE_PROJECTS',
             data: data.data.project,
+            status,
           };
         default:
           return {
             type: 'FETCH_ERROR',
             error: data,
+            status,
           };
         }
       })


### PR DESCRIPTION
Data-portal freaks out when new commons comes up with no projects.
Also fixes to avoid gdcapi oauth dance (now deprecated with jwt) for non-403 peregrine responses.