### PR TITLE
fix(dockerStart): set up listen loop for getSchema

### DIFF
--- a/dockerStart.sh
+++ b/dockerStart.sh
@@ -30,7 +30,7 @@ rm -rf custom
 npm run schema
 until [$? -eq 0]
 do
-    sleep 5
+    sleep 1
     npm run schema
 done
 npm run relay

--- a/dockerStart.sh
+++ b/dockerStart.sh
@@ -28,6 +28,11 @@ rm -rf custom
 #    to fetch the dictionary from at startup
 #
 npm run schema
+until [$? -eq 0]
+do
+    sleep 5
+    npm run schema
+done
 npm run relay
 npm run params
 NODE_ENV=production ./node_modules/.bin/webpack --bail

--- a/dockerStart.sh
+++ b/dockerStart.sh
@@ -3,7 +3,7 @@
 # Little startup script fetches data dictionary, and runs the relay
 # compiler, then webpack before launching nginx
 #
-set -eu
+# set -eu
 
 if [ -f custom/favicon/$APP-favicon.ico ]; then
   cp custom/favicon/$APP-favicon.ico src/img/favicon.ico


### PR DESCRIPTION
This PR was made so that dataportal will not crash on getSchema failure in docker containers. 

WARNING: This will make "npm run schema" loop infinitely until it finishes successfully, meaning manual exit will be required if the wrong GDC_SUBPATH is given.