### PR TITLE
PXD-1262 Fix dictionary graph crashing

### DIFF
--- a/src/DataModelGraph/utils.js
+++ b/src/DataModelGraph/utils.js
@@ -118,6 +118,31 @@ export function findRoot(nodes, edges) {
 }
 
 /**
+ * Detect and keep track of cycles in the graph to avoid infinite loops
+ * @method findCycles
+ * @param nodes
+ * @param edges
+ * @return {Map} map of cycles for easy lookup
+ */
+export function isAncestor(node, currentNode, name2EdgesIn, visitedNodes) {
+  console.log('comparing', node, 'to', currentNode);
+  if (node === currentNode || visitedNodes.has(node)) {
+    console.log(node, currentNode, 'heyyyy');
+    return true;
+  }
+  console.log('edges for', node, name2EdgesIn[node]);
+  visitedNodes.add(node);
+  if (name2EdgesIn[node].length > 0) {
+    name2EdgesIn[node].forEach(edge => {
+      const sourceName = typeof edge.source === 'object' ? edge.source.id : edge.source;
+      return isAncestor(sourceName, currentNode, name2EdgesIn, visitedNodes);
+    })
+  } else {
+    return false;
+  }
+}
+
+/**
  * Arrange nodes in dictionary graph breadth first, and build level database.
  * If a node links to multiple parents, then place it under the highest parent ...
  * Exported for testing.
@@ -168,24 +193,28 @@ export function nodesBreadthFirst(nodes, edges) {
   if (!name2EdgesIn[root]) {
     name2EdgesIn[root] = [];
   }
+  console.log(name2EdgesIn);
+  //console.log('is ancestor?', isAncestor('annotation', 'analysis_metadata', name2EdgesIn, new Set()));
+  console.log(isAncestor('analysis_metadata', 'annotation', name2EdgesIn, new Set()));
 
   const name2ActualLvl = {};
-  // Run through this once to determine the actual level of each node
-  for (let head = 0; head < queue.length; head += 1) {
-    const { query, level } = queue[head]; // breadth first
-    name2ActualLvl[query] = level;
-    name2EdgesIn[query].forEach((edge) => {
-      // At some point the d3 force layout converts edge.source
-      //   and edge.target into node references ...
-      const sourceName = typeof edge.source === 'object' ? edge.source.id : edge.source;
-      if (name2EdgesIn[sourceName]) {
-        queue.push({ query: sourceName, level: level + 1 });
-      } else {
-        console.log(`Edge comes from unknown node ${sourceName}`);
-      }
-    },
-    );
-  }
+  // //Run through this once to determine the actual level of each node
+  // for (let head = 0; head < queue.length; head += 1) {
+  //   const { query, level, edge } = queue[head]; // breadth first
+  //   name2ActualLvl[query] = level;
+  //   name2EdgesIn[query].forEach((edge) => {
+  //     // At some point the d3 force layout converts edge.source
+  //     //   and edge.target into node references ...
+  //     const sourceName = typeof edge.source === 'object' ? edge.source.id : edge.source;
+  //     console.log('checking ancestry of', sourceName, 'for node', query);
+  //     if (!isAncestor(sourceName, query, name2EdgesIn, new Set()) && name2EdgesIn[sourceName]) {
+  //       queue.push({ query: sourceName, level: level + 1, edge: edge });
+  //     } else {
+  //       console.log(`Edge comes from unknown node ${sourceName}`);
+  //     }
+  //   },
+  //   );
+  // }
 
   // Reset and run for real
   queue = [];

--- a/src/DataModelGraph/utils.js
+++ b/src/DataModelGraph/utils.js
@@ -154,8 +154,7 @@ function getTreeHierarchyHelper(node, name2EdgesIn, hierarchy) {
  * @return {map}
  */
 export function getTreeHierarchy(root, name2EdgesIn) {
-  const hierarchy = getTreeHierarchyHelper(root, name2EdgesIn, new Map());
-  return hierarchy;
+  return getTreeHierarchyHelper(root, name2EdgesIn, new Map());
 }
 
 /**

--- a/src/DataModelGraph/utils.js
+++ b/src/DataModelGraph/utils.js
@@ -126,28 +126,23 @@ export function findRoot(nodes, edges) {
  * @return {boolean}
  */
 export function isAncestor(currentNode, source, name2EdgesIn) {
-  console.log('is', source, 'an ancestor of', currentNode, '?');
   const visitedNodes = new Set();
   let stack = [source];
   while (stack.length > 0) {
     let head = stack.length - 1;
     let node = stack[head];
     if (node === currentNode) {
-      console.log('yep!')
       return true;
     }
     stack.pop();
     visitedNodes.add(node);
-    console.log('edges in', node);
     name2EdgesIn[node].forEach(edge => {
-      console.log(edge);
       const sourceName = typeof edge.source === 'object' ? edge.source.id : edge.source;
       if (!visitedNodes.has(sourceName)) {
         stack.push(sourceName);
       }
     });
   }
-  console.log('nope!')
   return false;
 }
 
@@ -203,16 +198,11 @@ export function nodesBreadthFirst(nodes, edges) {
     name2EdgesIn[root] = [];
   }
 
-  console.log('edges', edges.map(edge => { edge.source, edge.target }));
-  console.log('project', name2EdgesIn['project']);
-  console.log('program', name2EdgesIn['program']);
-
   const name2ActualLvl = {};
   let ancestorsMap = new Map();
   //Run through this once to determine the actual level of each node
   for (let head = 0; head < queue.length; head += 1) {
     const { query, level } = queue[head]; // breadth first
-    console.log('looking at', query);
     name2ActualLvl[query] = level;
     name2EdgesIn[query].forEach((edge) => {
       // At some point the d3 force layout converts edge.source
@@ -221,14 +211,11 @@ export function nodesBreadthFirst(nodes, edges) {
       if (name2EdgesIn[sourceName]) {
         let ancestor = ancestorsMap.get([sourceName, query]) === undefined ? isAncestor(query, sourceName, name2EdgesIn) : ancestorsMap.get([sourceName, query]);
         if (!ancestor) { // only push node if it is not an ancestor of the current node, or else --> cycle
-          console.log(sourceName, 'is NOT an ancestor of', query);
           ancestorsMap.set([sourceName, query], false);
           queue.push({ query: sourceName, level: level + 1 });
         } else {
-          console.log(sourceName, 'is an ancestor of', query);
           ancestorsMap.set([sourceName, query], true);
         }
-        console.log('ancestors map:', ancestorsMap);
       } else {
         console.log(`Edge comes from unknown node ${sourceName}`);
       }

--- a/src/DataModelGraph/utils.js
+++ b/src/DataModelGraph/utils.js
@@ -118,19 +118,6 @@ export function findRoot(nodes, edges) {
 }
 
 /**
- * Returns the hierarchy of the tree in the form of a map
- * Each (key, value) consists of (node, node's descendants including the node itself)
- * @method getTreeHierarchy
- * @param root
- * @param name2EdgesIn
- * @return {map}
- */
-export function getTreeHierarchy(root, name2EdgesIn) {
-  let hierarchy = getTreeHierarchyHelper(root, name2EdgesIn, new Map());
-  return hierarchy;
-}
-
-/**
  * Recursive helper function for getTreeHierarchy
  * Returns the hierarchy of the tree in the form of a map
  * Each (key, value) consists of (node, node's descendants including the node itself)
@@ -141,20 +128,33 @@ export function getTreeHierarchy(root, name2EdgesIn) {
  * @return {map}
  */
 function getTreeHierarchyHelper(node, name2EdgesIn, hierarchy) {
-  let descendants = new Set();
+  const descendants = new Set();
   descendants.add(node);
   hierarchy.set(node, descendants);
-  name2EdgesIn[node].forEach(edge => {
+  name2EdgesIn[node].forEach((edge) => {
     const sourceName = typeof edge.source === 'object' ? edge.source.id : edge.source;
     if (!hierarchy.get(sourceName)) { // don't want to visit node again
       hierarchy = getTreeHierarchyHelper(sourceName, name2EdgesIn, hierarchy);
       descendants.add(sourceName);
-      hierarchy.get(sourceName).forEach(n => {
+      hierarchy.get(sourceName).forEach((n) => {
         descendants.add(n);
-      })
+      });
     }
-  })
+  });
   hierarchy.set(node, descendants);
+  return hierarchy;
+}
+
+/**
+ * Returns the hierarchy of the tree in the form of a map
+ * Each (key, value) consists of (node, node's descendants including the node itself)
+ * @method getTreeHierarchy
+ * @param root
+ * @param name2EdgesIn
+ * @return {map}
+ */
+export function getTreeHierarchy(root, name2EdgesIn) {
+  const hierarchy = getTreeHierarchyHelper(root, name2EdgesIn, new Map());
   return hierarchy;
 }
 
@@ -211,8 +211,8 @@ export function nodesBreadthFirst(nodes, edges) {
   }
 
   const name2ActualLvl = {};
-  let hierarchy = getTreeHierarchy(root, name2EdgesIn);
-  //Run through this once to determine the actual level of each node
+  const hierarchy = getTreeHierarchy(root, name2EdgesIn);
+  // Run through this once to determine the actual level of each node
   for (let head = 0; head < queue.length; head += 1) {
     const { query, level } = queue[head]; // breadth first
     name2ActualLvl[query] = level;
@@ -221,8 +221,9 @@ export function nodesBreadthFirst(nodes, edges) {
       //   and edge.target into node references ...
       const sourceName = typeof edge.source === 'object' ? edge.source.id : edge.source;
       if (name2EdgesIn[sourceName]) {
-        let isAncestor = hierarchy.get(sourceName).has(query);
-        if (!isAncestor) { // only push node if it is not an ancestor of the current node, or else --> cycle
+        const isAncestor = hierarchy.get(sourceName).has(query);
+        // only push node if it is not an ancestor of the current node, or else --> cycle
+        if (!isAncestor) {
           queue.push({ query: sourceName, level: level + 1 });
         }
       } else {

--- a/src/DataModelGraph/utils.test.js
+++ b/src/DataModelGraph/utils.test.js
@@ -3,26 +3,27 @@ import { buildTestData } from './testData';
 
 
 describe('the DataModelGraph utils helper', () => {
-  // it('can find the root of a graph', () => {
-  //   const { nodes, edges } = buildTestData();
-  //   expect(findRoot(nodes, edges)).toBe('project');
-  // });
-  //
-  // it('extracts nodes and edges from a dictionary', () => {
-  //   const testData = buildTestData();
-  //   const { nodes, edges } = createNodesAndEdges({ dictionary: testData.dictionary }, true);
-  //   expect(nodes.length).toBe(testData.nodes.length);
-  //   expect(edges.length).toBe(testData.edges.length);
-  // });
-  //
-  // it('can ignore a node type in the dictionary', () => {
-  //   const testData = buildTestData();
-  //   const { nodes, edges } = createNodesAndEdges({ dictionary: testData.dictionary }, true, ['project']);
-  //   expect(nodes.length).toBe(testData.nodes.length - 1);
-  //   expect(edges.length).toBe(testData.edges.length - 2);
-  // });
+  it('can find the root of a graph', () => {
+    const { nodes, edges } = buildTestData();
+    expect(findRoot(nodes, edges)).toBe('project');
+  });
+
+  it('extracts nodes and edges from a dictionary', () => {
+    const testData = buildTestData();
+    const { nodes, edges } = createNodesAndEdges({ dictionary: testData.dictionary }, true);
+    expect(nodes.length).toBe(testData.nodes.length);
+    expect(edges.length).toBe(testData.edges.length);
+  });
+
+  it('can ignore a node type in the dictionary', () => {
+    const testData = buildTestData();
+    const { nodes, edges } = createNodesAndEdges({ dictionary: testData.dictionary }, true, ['project']);
+    expect(nodes.length).toBe(testData.nodes.length - 1);
+    expect(edges.length).toBe(testData.edges.length - 2);
+  });
 
   it('can determine if one node is an ancestor of another', () => {
+    console.log('ANCESTOR TEST');
     const { nodes, edges } = buildTestData();
     const name2EdgesIn = edges.reduce(
       (db, edge) => {
@@ -38,58 +39,59 @@ describe('the DataModelGraph utils helper', () => {
       nodes.reduce((emptyDb, node) => { const res = emptyDb; res[node.id] = []; return res; }, {}),
     );
     edges.forEach(edge => {
-      expect(isAncestor(edge.target, edge.source, name2EdgesIn)).toBe(true);
-    })
-  })
-  //
-  // it('knows how to order nodes breadth first', () => {
-  //   const { nodes, edges } = buildTestData();
-  //   const { bfOrder, treeLevel2Names, name2Level } = nodesBreadthFirst(nodes, edges);
-  //   console.log('tree info', treeLevel2Names);
-  //   expect(bfOrder.length).toBe(nodes.length - 1); // node z is floating ...
-  //   expect(treeLevel2Names.length).toBe(4);
-  //   expect(treeLevel2Names[0].length).toBe(1); // project
-  //   expect(treeLevel2Names[1].length).toBe(1);
-  //   expect(treeLevel2Names[2].length).toBe(4); // a, c, x, y
-  //   expect(name2Level.d).toBe(3); // d on level 3
-  //   for (let level = 0; level < treeLevel2Names.length; level += 1) {
-  //     treeLevel2Names[level].forEach(
-  //       (nodeName) => {
-  //         expect(name2Level[nodeName]).toBe(level);
-  //       },
-  //     );
-  //   }
-  // });
+      expect(isAncestor(edge.source, edge.target, name2EdgesIn)).toBe(true);
+      expect(isAncestor(edge.target, edge.source, name2EdgesIn)).toBe(false);
+    });
+  });
 
-  // it('assigns positions to nodes', () => {
-  //   const { nodes, edges } = buildTestData();
-  //   assignNodePositions(nodes, edges);
-  //   nodes.filter(nd => nd.position).forEach(
-  //     (node) => {
-  //       const { treeLevel2Names, name2Level } = nodesBreadthFirst(nodes, edges);
-  //
-  //       expect(Array.isArray(node.position)).toBe(true);
-  //       expect(node.position[0] > 0 && node.position[0] <= 1).toBe(true);
-  //       expect(node.position[1] > 0 && node.position[1] <= 1).toBe(true);
-  //       expect(node.positionIndex[1]).toBe(name2Level[node.id]);
-  //       expect(treeLevel2Names[node.positionIndex[1]][node.positionIndex[0]]).toBe(node.id);
-  //     },
-  //   );
-  // });
-  //
-  // it('can organize nodes into rows', () => {
-  //   const { nodes, edges } = buildTestData();
-  //   assignNodePositions(nodes, edges, { numPerRow: 2 });
-  //   // up to 2 nodes per row, root on own row
-  //   const maxRows = 1 + Math.round((nodes.length - 1) / 2);
-  //   nodes.filter(nd => nd.position).forEach(
-  //     (node) => {
-  //       expect(Array.isArray(node.position)).toBe(true);
-  //       expect(node.position[0] > 0 && node.position[0] <= 1).toBe(true);
-  //       expect(node.position[1] > 0 && node.position[1] <= 1).toBe(true);
-  //       expect(node.positionIndex[0] < 2).toBe(true); // at most 2 nodes per row
-  //       expect(node.positionIndex[1]).toBeLessThan(maxRows);
-  //     },
-  //   );
-  // });
+  it('knows how to order nodes breadth first', () => {
+    const { nodes, edges } = buildTestData();
+    const { bfOrder, treeLevel2Names, name2Level } = nodesBreadthFirst(nodes, edges);
+    console.log('tree info', treeLevel2Names);
+    expect(bfOrder.length).toBe(nodes.length - 1); // node z is floating ...
+    expect(treeLevel2Names.length).toBe(4);
+    expect(treeLevel2Names[0].length).toBe(1); // project
+    expect(treeLevel2Names[1].length).toBe(1);
+    expect(treeLevel2Names[2].length).toBe(4); // a, c, x, y
+    expect(name2Level.d).toBe(3); // d on level 3
+    for (let level = 0; level < treeLevel2Names.length; level += 1) {
+      treeLevel2Names[level].forEach(
+        (nodeName) => {
+          expect(name2Level[nodeName]).toBe(level);
+        },
+      );
+    }
+  });
+
+  it('assigns positions to nodes', () => {
+    const { nodes, edges } = buildTestData();
+    assignNodePositions(nodes, edges);
+    nodes.filter(nd => nd.position).forEach(
+      (node) => {
+        const { treeLevel2Names, name2Level } = nodesBreadthFirst(nodes, edges);
+
+        expect(Array.isArray(node.position)).toBe(true);
+        expect(node.position[0] > 0 && node.position[0] <= 1).toBe(true);
+        expect(node.position[1] > 0 && node.position[1] <= 1).toBe(true);
+        expect(node.positionIndex[1]).toBe(name2Level[node.id]);
+        expect(treeLevel2Names[node.positionIndex[1]][node.positionIndex[0]]).toBe(node.id);
+      },
+    );
+  });
+
+  it('can organize nodes into rows', () => {
+    const { nodes, edges } = buildTestData();
+    assignNodePositions(nodes, edges, { numPerRow: 2 });
+    // up to 2 nodes per row, root on own row
+    const maxRows = 1 + Math.round((nodes.length - 1) / 2);
+    nodes.filter(nd => nd.position).forEach(
+      (node) => {
+        expect(Array.isArray(node.position)).toBe(true);
+        expect(node.position[0] > 0 && node.position[0] <= 1).toBe(true);
+        expect(node.position[1] > 0 && node.position[1] <= 1).toBe(true);
+        expect(node.positionIndex[0] < 2).toBe(true); // at most 2 nodes per row
+        expect(node.positionIndex[1]).toBeLessThan(maxRows);
+      },
+    );
+  });
 });

--- a/src/DataModelGraph/utils.test.js
+++ b/src/DataModelGraph/utils.test.js
@@ -23,7 +23,6 @@ describe('the DataModelGraph utils helper', () => {
   });
 
   it('can determine if one node is an ancestor of another', () => {
-    console.log('ANCESTOR TEST');
     const { nodes, edges } = buildTestData();
     const name2EdgesIn = edges.reduce(
       (db, edge) => {

--- a/src/DataModelGraph/utils.test.js
+++ b/src/DataModelGraph/utils.test.js
@@ -37,7 +37,7 @@ describe('the DataModelGraph utils helper', () => {
       // initialize emptyDb - include nodes that have no incoming edges (leaves)
       nodes.reduce((emptyDb, node) => { const res = emptyDb; res[node.id] = []; return res; }, {}),
     );
-    let hierarchy = getTreeHierarchy(findRoot(nodes, edges), name2EdgesIn);
+    const hierarchy = getTreeHierarchy(findRoot(nodes, edges), name2EdgesIn);
     expect(hierarchy.get('project').size).toBe(7);
     expect(hierarchy.get('b').size).toBe(6);
     expect(hierarchy.get('c').size).toBe(2);

--- a/src/DataModelGraph/utils.test.js
+++ b/src/DataModelGraph/utils.test.js
@@ -1,4 +1,4 @@
-import { assignNodePositions, createNodesAndEdges, findRoot, nodesBreadthFirst, isAncestor } from './utils';
+import { assignNodePositions, createNodesAndEdges, findRoot, nodesBreadthFirst, getTreeHierarchy } from './utils';
 import { buildTestData } from './testData';
 
 
@@ -22,7 +22,7 @@ describe('the DataModelGraph utils helper', () => {
     expect(edges.length).toBe(testData.edges.length - 2);
   });
 
-  it('can determine if one node is an ancestor of another', () => {
+  it('can determines the hierarchy of a tree', () => {
     const { nodes, edges } = buildTestData();
     const name2EdgesIn = edges.reduce(
       (db, edge) => {
@@ -37,10 +37,14 @@ describe('the DataModelGraph utils helper', () => {
       // initialize emptyDb - include nodes that have no incoming edges (leaves)
       nodes.reduce((emptyDb, node) => { const res = emptyDb; res[node.id] = []; return res; }, {}),
     );
-    edges.forEach(edge => {
-      expect(isAncestor(edge.source, edge.target, name2EdgesIn)).toBe(true);
-      expect(isAncestor(edge.target, edge.source, name2EdgesIn)).toBe(false);
-    });
+    let hierarchy = getTreeHierarchy(findRoot(nodes, edges), name2EdgesIn);
+    expect(hierarchy.get('project').size).toBe(7);
+    expect(hierarchy.get('b').size).toBe(6);
+    expect(hierarchy.get('c').size).toBe(2);
+    expect(hierarchy.get('d').size).toBe(1);
+    expect(hierarchy.get('a').size).toBe(1);
+    expect(hierarchy.get('x').size).toBe(1);
+    expect(hierarchy.get('y').size).toBe(1);
   });
 
   it('knows how to order nodes breadth first', () => {

--- a/src/DataModelGraph/utils.test.js
+++ b/src/DataModelGraph/utils.test.js
@@ -1,75 +1,95 @@
-import { assignNodePositions, createNodesAndEdges, findRoot, nodesBreadthFirst } from './utils';
+import { assignNodePositions, createNodesAndEdges, findRoot, nodesBreadthFirst, isAncestor } from './utils';
 import { buildTestData } from './testData';
 
 
 describe('the DataModelGraph utils helper', () => {
-  it('can find the root of a graph', () => {
+  // it('can find the root of a graph', () => {
+  //   const { nodes, edges } = buildTestData();
+  //   expect(findRoot(nodes, edges)).toBe('project');
+  // });
+  //
+  // it('extracts nodes and edges from a dictionary', () => {
+  //   const testData = buildTestData();
+  //   const { nodes, edges } = createNodesAndEdges({ dictionary: testData.dictionary }, true);
+  //   expect(nodes.length).toBe(testData.nodes.length);
+  //   expect(edges.length).toBe(testData.edges.length);
+  // });
+  //
+  // it('can ignore a node type in the dictionary', () => {
+  //   const testData = buildTestData();
+  //   const { nodes, edges } = createNodesAndEdges({ dictionary: testData.dictionary }, true, ['project']);
+  //   expect(nodes.length).toBe(testData.nodes.length - 1);
+  //   expect(edges.length).toBe(testData.edges.length - 2);
+  // });
+
+  it('can determine if one node is an ancestor of another', () => {
     const { nodes, edges } = buildTestData();
-    expect(findRoot(nodes, edges)).toBe('project');
-  });
-
-  it('extracts nodes and edges from a dictionary', () => {
-    const testData = buildTestData();
-    const { nodes, edges } = createNodesAndEdges({ dictionary: testData.dictionary }, true);
-    expect(nodes.length).toBe(testData.nodes.length);
-    expect(edges.length).toBe(testData.edges.length);
-  });
-
-  it('can ignore a node type in the dictionary', () => {
-    const testData = buildTestData();
-    const { nodes, edges } = createNodesAndEdges({ dictionary: testData.dictionary }, true, ['project']);
-    expect(nodes.length).toBe(testData.nodes.length - 1);
-    expect(edges.length).toBe(testData.edges.length - 2);
-  });
-
-  it('knows how to order nodes breadth first', () => {
-    const { nodes, edges } = buildTestData();
-    const { bfOrder, treeLevel2Names, name2Level } = nodesBreadthFirst(nodes, edges);
-    console.log('tree info', treeLevel2Names);
-    expect(bfOrder.length).toBe(nodes.length - 1); // node z is floating ...
-    expect(treeLevel2Names.length).toBe(4);
-    expect(treeLevel2Names[0].length).toBe(1); // project
-    expect(treeLevel2Names[1].length).toBe(1);
-    expect(treeLevel2Names[2].length).toBe(4); // a, c, x, y
-    expect(name2Level.d).toBe(3); // d on level 3
-    for (let level = 0; level < treeLevel2Names.length; level += 1) {
-      treeLevel2Names[level].forEach(
-        (nodeName) => {
-          expect(name2Level[nodeName]).toBe(level);
-        },
-      );
-    }
-  });
-
-  it('assigns positions to nodes', () => {
-    const { nodes, edges } = buildTestData();
-    assignNodePositions(nodes, edges);
-    nodes.filter(nd => nd.position).forEach(
-      (node) => {
-        const { treeLevel2Names, name2Level } = nodesBreadthFirst(nodes, edges);
-
-        expect(Array.isArray(node.position)).toBe(true);
-        expect(node.position[0] > 0 && node.position[0] <= 1).toBe(true);
-        expect(node.position[1] > 0 && node.position[1] <= 1).toBe(true);
-        expect(node.positionIndex[1]).toBe(name2Level[node.id]);
-        expect(treeLevel2Names[node.positionIndex[1]][node.positionIndex[0]]).toBe(node.id);
+    const name2EdgesIn = edges.reduce(
+      (db, edge) => {
+        const targetName = typeof edge.target === 'object' ? edge.target.id : edge.target;
+        if (db[targetName]) {
+          db[targetName].push(edge);
+        } else {
+          console.error(`Edge points to unknown node: ${targetName}`);
+        }
+        return db;
       },
+      // initialize emptyDb - include nodes that have no incoming edges (leaves)
+      nodes.reduce((emptyDb, node) => { const res = emptyDb; res[node.id] = []; return res; }, {}),
     );
-  });
+    edges.forEach(edge => {
+      expect(isAncestor(edge.target, edge.source, name2EdgesIn)).toBe(true);
+    })
+  })
+  //
+  // it('knows how to order nodes breadth first', () => {
+  //   const { nodes, edges } = buildTestData();
+  //   const { bfOrder, treeLevel2Names, name2Level } = nodesBreadthFirst(nodes, edges);
+  //   console.log('tree info', treeLevel2Names);
+  //   expect(bfOrder.length).toBe(nodes.length - 1); // node z is floating ...
+  //   expect(treeLevel2Names.length).toBe(4);
+  //   expect(treeLevel2Names[0].length).toBe(1); // project
+  //   expect(treeLevel2Names[1].length).toBe(1);
+  //   expect(treeLevel2Names[2].length).toBe(4); // a, c, x, y
+  //   expect(name2Level.d).toBe(3); // d on level 3
+  //   for (let level = 0; level < treeLevel2Names.length; level += 1) {
+  //     treeLevel2Names[level].forEach(
+  //       (nodeName) => {
+  //         expect(name2Level[nodeName]).toBe(level);
+  //       },
+  //     );
+  //   }
+  // });
 
-  it('can organize nodes into rows', () => {
-    const { nodes, edges } = buildTestData();
-    assignNodePositions(nodes, edges, { numPerRow: 2 });
-    // up to 2 nodes per row, root on own row
-    const maxRows = 1 + Math.round((nodes.length - 1) / 2);
-    nodes.filter(nd => nd.position).forEach(
-      (node) => {
-        expect(Array.isArray(node.position)).toBe(true);
-        expect(node.position[0] > 0 && node.position[0] <= 1).toBe(true);
-        expect(node.position[1] > 0 && node.position[1] <= 1).toBe(true);
-        expect(node.positionIndex[0] < 2).toBe(true); // at most 2 nodes per row
-        expect(node.positionIndex[1]).toBeLessThan(maxRows);
-      },
-    );
-  });
+  // it('assigns positions to nodes', () => {
+  //   const { nodes, edges } = buildTestData();
+  //   assignNodePositions(nodes, edges);
+  //   nodes.filter(nd => nd.position).forEach(
+  //     (node) => {
+  //       const { treeLevel2Names, name2Level } = nodesBreadthFirst(nodes, edges);
+  //
+  //       expect(Array.isArray(node.position)).toBe(true);
+  //       expect(node.position[0] > 0 && node.position[0] <= 1).toBe(true);
+  //       expect(node.position[1] > 0 && node.position[1] <= 1).toBe(true);
+  //       expect(node.positionIndex[1]).toBe(name2Level[node.id]);
+  //       expect(treeLevel2Names[node.positionIndex[1]][node.positionIndex[0]]).toBe(node.id);
+  //     },
+  //   );
+  // });
+  //
+  // it('can organize nodes into rows', () => {
+  //   const { nodes, edges } = buildTestData();
+  //   assignNodePositions(nodes, edges, { numPerRow: 2 });
+  //   // up to 2 nodes per row, root on own row
+  //   const maxRows = 1 + Math.round((nodes.length - 1) / 2);
+  //   nodes.filter(nd => nd.position).forEach(
+  //     (node) => {
+  //       expect(Array.isArray(node.position)).toBe(true);
+  //       expect(node.position[0] > 0 && node.position[0] <= 1).toBe(true);
+  //       expect(node.position[1] > 0 && node.position[1] <= 1).toBe(true);
+  //       expect(node.positionIndex[0] < 2).toBe(true); // at most 2 nodes per row
+  //       expect(node.positionIndex[1]).toBeLessThan(maxRows);
+  //     },
+  //   );
+  // });
 });


### PR DESCRIPTION
A node can be visited more than once, as we want it to go to its lowest possible level in the tree, but we still want to detect cycles that could cause infinite loops. By mapping out the descendants of each node beforehand, we can avoid reprocessing nodes that are further up the tree than a given node and avoid cycles. This adds O(n) time up front.