### PR TITLE
PXD-1514 fix(explorer): use sqon to calculate actual number of selected items

### DIFF
--- a/src/DataExplorer/DataExplorerVisualizations.jsx
+++ b/src/DataExplorer/DataExplorerVisualizations.jsx
@@ -22,7 +22,7 @@ class DataExplorerVisualizations extends React.Component {
 
   render() {
     const charts = this.props.arrangerData ?
-      getCharts(this.props.arrangerData, this.props.arrangerConfig)
+      getCharts(this.props.arrangerData, this.props.arrangerConfig, this.props.sqon)
       : null;
     return (
       <div className='data-explorer__visualizations'>
@@ -66,11 +66,13 @@ class DataExplorerVisualizations extends React.Component {
 DataExplorerVisualizations.propTypes = {
   arrangerData: PropTypes.object,
   arrangerConfig: PropTypes.object,
+  sqon: PropTypes.object,
 };
 
 DataExplorerVisualizations.defaultProps = {
   arrangerData: null,
   arrangerConfig: {},
+  sqon: null,
 };
 
 export default DataExplorerVisualizations;

--- a/src/components/charts/helper.test.js
+++ b/src/components/charts/helper.test.js
@@ -54,6 +54,26 @@ describe('helper', () => {
     expect(helper.getDataKey(false)).toBe('value');
   });
 
+  const noSelectSqonCount = Infinity;
+  const noSelectSqonValues = undefined;
+
+  const selectWhiteSqon = {
+    op: 'and',
+    content: [
+      {
+        op: 'in',
+        content: {
+          field: 'ethnicity',
+          value: [
+            'White',
+          ],
+        },
+      },
+    ],
+  };
+  const selectWhiteSqonCount = 1;
+  const selectWhiteSqonValues = ['White'];
+
   const ethnicityFieldJSON = {
     buckets: [
       { doc_count: 4, key: 'White' },
@@ -110,15 +130,17 @@ describe('helper', () => {
   };
 
   it('returns chart data as expected', () => {
-    expect(helper.transformArrangerDataToChart(ethnicityFieldJSON)).toEqual(ethnicityChartData);
+    expect(helper.transformArrangerDataToChart(ethnicityFieldJSON, noSelectSqonValues))
+      .toEqual(ethnicityChartData);
   });
 
   it('returns count data as expected', () => {
-    expect(helper.transformDataToCount(ethnicityFieldJSON, 'Ethnicity')).toEqual(ethnicityCountData);
+    expect(helper.transformDataToCount(ethnicityFieldJSON, 'Ethnicity', noSelectSqonCount))
+      .toEqual(ethnicityCountData);
   });
 
   it('returns chart summaries as expected', () => {
-    expect(helper.transformArrangerDataToSummary(ethnicityFieldJSON, 'pie', 'Ethnicity')).toEqual(summaryData);
+    expect(helper.transformArrangerDataToSummary(ethnicityFieldJSON, 'pie', 'Ethnicity', noSelectSqonValues)).toEqual(summaryData);
   });
 
   it('gets charts', () => {
@@ -126,5 +148,10 @@ describe('helper', () => {
     expect(charts.countItems).toEqual([projectCountData]);
     expect(charts.summaries).toEqual([summaryData]);
     expect(charts.stackedBarCharts).toEqual([]);
+  });
+
+  it('return sqon count and values as expected', () => {
+    expect(helper.getSQONCount(selectWhiteSqon, 'ethnicity')).toEqual(selectWhiteSqonCount);
+    expect(helper.getSQONValues(selectWhiteSqon, 'ethnicity')).toEqual(selectWhiteSqonValues);
   });
 });

--- a/src/components/charts/helper.test.js
+++ b/src/components/charts/helper.test.js
@@ -94,7 +94,12 @@ describe('helper', () => {
     { name: 'Black', value: 5 },
   ];
 
+  const ethnicityChartDataWithOnlyWhiteSelected = [
+    { name: 'White', value: 4 },
+  ];
+
   const ethnicityCountData = { label: 'Ethnicity', value: 3 };
+  const ethnicityCountDataWithOnlyWhiteSelected = { label: 'Ethnicity', value: 1 };
 
   const projectCountData = { label: 'Projects', value: 4 };
 
@@ -102,6 +107,12 @@ describe('helper', () => {
     title: 'Ethnicity',
     type: 'pie',
     data: ethnicityChartData,
+  };
+
+  const summaryDataWithOnlyWhiteSelected = {
+    title: 'Ethnicity',
+    type: 'pie',
+    data: ethnicityChartDataWithOnlyWhiteSelected,
   };
 
   const rawData = {
@@ -129,15 +140,21 @@ describe('helper', () => {
   it('returns chart data as expected', () => {
     expect(helper.transformArrangerDataToChart(ethnicityFieldJSON, noSelectSqonValues))
       .toEqual(ethnicityChartData);
+    expect(helper.transformArrangerDataToChart(ethnicityFieldJSON, selectWhiteSqonValues))
+      .toEqual(ethnicityChartDataWithOnlyWhiteSelected);
   });
 
   it('returns count data as expected', () => {
     expect(helper.transformDataToCount(ethnicityFieldJSON, 'Ethnicity', noSelectSqonValues))
       .toEqual(ethnicityCountData);
+    expect(helper.transformDataToCount(ethnicityFieldJSON, 'Ethnicity', selectWhiteSqonValues))
+      .toEqual(ethnicityCountDataWithOnlyWhiteSelected);
   });
 
   it('returns chart summaries as expected', () => {
     expect(helper.transformArrangerDataToSummary(ethnicityFieldJSON, 'pie', 'Ethnicity', noSelectSqonValues)).toEqual(summaryData);
+    expect(helper.transformArrangerDataToSummary(ethnicityFieldJSON, 'pie', 'Ethnicity',
+      selectWhiteSqonValues)).toEqual(summaryDataWithOnlyWhiteSelected);
   });
 
   it('gets charts', () => {
@@ -149,5 +166,6 @@ describe('helper', () => {
 
   it('return selecetd values from SQON as expected', () => {
     expect(helper.getSQONValues(selectWhiteSqon, 'ethnicity')).toEqual(selectWhiteSqonValues);
+    expect(helper.getSQONValues(noSelectSqonValues, 'ethnicity')).toEqual(null);
   });
 });

--- a/src/components/charts/helper.test.js
+++ b/src/components/charts/helper.test.js
@@ -54,9 +54,7 @@ describe('helper', () => {
     expect(helper.getDataKey(false)).toBe('value');
   });
 
-  const noSelectSqonCount = Infinity;
-  const noSelectSqonValues = undefined;
-
+  const noSelectSqonValues = null;
   const selectWhiteSqon = {
     op: 'and',
     content: [
@@ -71,7 +69,6 @@ describe('helper', () => {
       },
     ],
   };
-  const selectWhiteSqonCount = 1;
   const selectWhiteSqonValues = ['White'];
 
   const ethnicityFieldJSON = {
@@ -135,7 +132,7 @@ describe('helper', () => {
   });
 
   it('returns count data as expected', () => {
-    expect(helper.transformDataToCount(ethnicityFieldJSON, 'Ethnicity', noSelectSqonCount))
+    expect(helper.transformDataToCount(ethnicityFieldJSON, 'Ethnicity', noSelectSqonValues))
       .toEqual(ethnicityCountData);
   });
 
@@ -150,8 +147,7 @@ describe('helper', () => {
     expect(charts.stackedBarCharts).toEqual([]);
   });
 
-  it('return sqon count and values as expected', () => {
-    expect(helper.getSQONCount(selectWhiteSqon, 'ethnicity')).toEqual(selectWhiteSqonCount);
+  it('return selecetd values from SQON as expected', () => {
     expect(helper.getSQONValues(selectWhiteSqon, 'ethnicity')).toEqual(selectWhiteSqonValues);
   });
 });


### PR DESCRIPTION
Current counts and charts in visualizations only shows bucket numbers in the filters, but we want the visualization result shows actual number of selected items in the filters. To solve this, we use `sqon` to calculate the correct numbers. 