### PR TITLE
PXD-1944 Hide table search bar

### DIFF
--- a/src/components/tables/DataExplorerTable/DataExplorerTable.less
+++ b/src/components/tables/DataExplorerTable/DataExplorerTable.less
@@ -24,7 +24,9 @@
   }
 
   .tableToolbar .inputWrapper {
-    border: none;
+    visibility: hidden;
+    height: 0;
+    width: 0;
   }
 
   .tableToolbar .group {


### PR DESCRIPTION
Hid it in the CSS because I didn't see an "enabled prop" in Arranger for the search bar ¯\_(ツ)_/¯