### PR TITLE
Only query fields for charts

### DIFF
--- a/src/Arranger/ArrangerWrapper.jsx
+++ b/src/Arranger/ArrangerWrapper.jsx
@@ -34,6 +34,14 @@ class ArrangerWrapper extends React.Component {
     )
   );
 
+  filterAggregationFields = (aggs) => {
+    if (this.props.charts) {
+      return aggs.filter(agg => Object.keys(this.props.charts).includes(agg.field));
+    } else {
+      return aggs.filter(agg => agg.field !== 'name');
+    }
+  }
+
   render() {
     return (
       <Arranger
@@ -52,7 +60,7 @@ class ArrangerWrapper extends React.Component {
                 projectId={arrangerArgs.projectId}
                 index={arrangerArgs.graphqlField}
                 sqon={arrangerArgs.sqon}
-                aggs={stateArgs.aggs.filter(agg => agg.field !== 'name')}
+                aggs={this.filterAggregationFields(stateArgs.aggs)}
                 render={({ data }) => (
                   <React.Fragment>
                     {this.renderComponent({ ...arrangerArgs, arrangerData: data })}
@@ -71,10 +79,15 @@ ArrangerWrapper.propTypes = {
   index: PropTypes.string.isRequired,
   graphqlField: PropTypes.string.isRequired,
   projectId: PropTypes.string.isRequired,
+  charts: PropTypes.object,
   children: PropTypes.oneOfType([
     PropTypes.object,
     PropTypes.array,
   ]).isRequired,
+};
+
+ArrangerWrapper.defaultProps = {
+  charts: null,
 };
 
 export default ArrangerWrapper;

--- a/src/Arranger/ArrangerWrapper.jsx
+++ b/src/Arranger/ArrangerWrapper.jsx
@@ -27,20 +27,19 @@ import arrangerApi from './utils';
 */
 
 class ArrangerWrapper extends React.Component {
+  filterAggregationFields = (aggs) => {
+    if (this.props.charts) {
+      return aggs.filter(agg => Object.keys(this.props.charts).includes(agg.field));
+    }
+    return aggs.filter(agg => agg.field !== 'name');
+  };
+
   renderComponent = props => (
     React.Children.map(this.props.children, child =>
       React.cloneElement(child, { ...props },
       ),
     )
   );
-
-  filterAggregationFields = (aggs) => {
-    if (this.props.charts) {
-      return aggs.filter(agg => Object.keys(this.props.charts).includes(agg.field));
-    } else {
-      return aggs.filter(agg => agg.field !== 'name');
-    }
-  }
 
   render() {
     return (

--- a/src/DataExplorer/index.jsx
+++ b/src/DataExplorer/index.jsx
@@ -17,6 +17,7 @@ class DataExplorer extends React.Component {
           graphqlField={arrangerConfig.graphqlField}
           projectId={arrangerConfig.projectId}
           api={arrangerApi}
+          charts={arrangerConfig.charts}
         >
           <DataExplorerFilters arrangerConfig={arrangerConfig} api={arrangerApi} />
           <DataExplorerVisualizations


### PR DESCRIPTION
`qa-mickey` was loading very slowly because `ArrangerWrapper` was querying all fields (~800) in order to render the charts, when it only needed 3 fields. This fixes that.

I think that the Arranger code needs to be refactored overall, so this is just a fix for before I leave for vacation. I've created a ticket (PXD-2172) to refactor the code to be more intuitive (and faster!) for when I get back.