### PR TITLE
fix(recharts): recharts measurement span is supposed to be hidden

### DIFF
--- a/src/components/charts/SummaryHorizontalBarChart/SummaryHorizontalBarChart.less
+++ b/src/components/charts/SummaryHorizontalBarChart/SummaryHorizontalBarChart.less
@@ -43,3 +43,7 @@
   width: 80%;
   height: 100%;
 }
+
+#recharts_measurement_span {
+  display: none;
+}

--- a/src/components/charts/SummaryPieChart/SummaryPieChart.less
+++ b/src/components/charts/SummaryPieChart/SummaryPieChart.less
@@ -43,3 +43,7 @@
   overflow-x: hidden;
   text-overflow: ellipsis;
 }
+
+#recharts_measurement_span {
+  display: none;
+}


### PR DESCRIPTION
Add `display: hidden` style for rechart's measurement span element to hide it.

### New Features


### Breaking Changes


### Bug Fixes
- Hide the measurement div from recharts 

### Improvements


### Dependency updates


### Deployment changes

