### PR TITLE
fix(spelling): button in dictionary viewer

### DIFF
--- a/src/DataDictionary/DataModelStructure/DataModelStructure.jsx
+++ b/src/DataDictionary/DataModelStructure/DataModelStructure.jsx
@@ -59,7 +59,7 @@ class DataModelStructure extends React.Component {
           this.props.isGraphView && (
             <Button
               onClick={this.handleClickOverlayPropertyButton}
-              label={this.props.overlayPropertyHidden ? 'Open properties' : 'Close perperties'}
+              label={this.props.overlayPropertyHidden ? 'Open properties' : 'Close properties'}
               className='data-model-structure__table-button'
               rightIcon='list'
               buttonType='primary'


### PR DESCRIPTION
Fix spelling on a button in the dictionary viewer.

### New Features

### Breaking Changes

### Bug Fixes

Spelling fix.

### Improvements

### Dependency updates

### Deployment changes