### PR TITLE
fix(nginx.conf): ignore . in folder names

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -39,7 +39,7 @@ server {
     }
 
     # Any route containing a file extension (e.g. /devicesfile.js)
-    location ~ ^.+\..+$ {
+    location ~ ^.+\.[^/]+$ {
       try_files $uri =404;
     }
 


### PR DESCRIPTION
pidgin has paths like `/file/bla.foo/id` - so the nginx rule that treats any path with `.` as a file and 404 if it doesn't exist needs update