### PR TITLE
fix(file-img): display the right file type image

### DIFF
--- a/src/components/FileTypePicture.jsx
+++ b/src/components/FileTypePicture.jsx
@@ -6,7 +6,7 @@ import './FileTypePicture.less';
 function dataFormatToFileType(dictIcons, dataFormat) {
   const fileTypes = Object.keys(dictIcons); // list of available types
   const format = dataFormat.toLowerCase();
-  return format in fileTypes ? format : 'file';
+  return fileTypes.includes(format) ? format : 'file';
 }
 
 class FileTypePicture extends Component {


### PR DESCRIPTION
Display the right file type image in the core metadata landing page

### Bug Fixes
The default image was displayed all the time