### PR TITLE
removing tap event that was removed in newer versions of react

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25584,14 +25584,6 @@
         "classnames": "^2.2.5"
       }
     },
-    "react-tap-event-plugin": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/react-tap-event-plugin/-/react-tap-event-plugin-3.0.3.tgz",
-      "integrity": "sha1-vF/Q7j/Tq1IkwcL/bwdQIEromAI=",
-      "requires": {
-        "fbjs": "^0.8.6"
-      }
-    },
     "react-test-renderer": {
       "version": "16.4.1",
       "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-16.4.1.tgz",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,6 @@
     "react-router-dom": "^4.2.2",
     "react-select": "^1.3.0",
     "react-svg-loader": "^2.1.0",
-    "react-tap-event-plugin": "^3.0.2",
     "recharts": "^1.0.0-beta.10",
     "redux": "^3.7.0",
     "redux-devtools": "^3.3.1",

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -4,7 +4,6 @@ import { Provider } from 'react-redux';
 import { BrowserRouter, Route, Switch } from 'react-router-dom';
 import { ThemeProvider } from 'styled-components';
 import MuiThemeProvider from 'material-ui/styles/MuiThemeProvider';
-import injectTapEventPlugin from 'react-tap-event-plugin';
 import 'react-select/dist/react-select.css';
 import querystring from 'querystring';
 import { library } from '@fortawesome/fontawesome-svg-core';
@@ -45,10 +44,6 @@ import Workspace from './Workspace';
 
 // monitor user's session
 sessionMonitor.start();
-
-// Needed for onTouchTap
-// http://stackoverflow.com/a/34015469/988941
-injectTapEventPlugin();
 
 // render the app after the store is configured
 async function init() {


### PR DESCRIPTION
Description about what this pull request does.

Please make sure to follow the [DEV guidelines](https://gen3.org/resources/developer/dev-introduction/) before asking for review.

### New Features
- Implemented XXX

### Breaking Changes


### Bug Fixes
Using older versions of react you can start the webpack with no problem but with newer versions there is no support for the onTap listener

### Improvements


### Dependency updates


### Deployment changes

