### PR TITLE
fix(download)

### DIFF
--- a/src/CoreMetadata/CoreMetadataHeader.jsx
+++ b/src/CoreMetadata/CoreMetadataHeader.jsx
@@ -51,7 +51,7 @@ class CoreMetadataHeader extends Component {
       const canDownload = canUserDownload(user, projectAvail, projectId);
       let downloadButton = null;
       if (canDownload) {
-        const downloadLink = `/user/data/download/${this.props.metadata.object_id}?expires_in=10&redirect`;
+        const downloadLink = `/user/data/download/${this.props.metadata.object_id}?expires_in=900&redirect`;
 
         downloadButton = (
           <a href={downloadLink}>


### PR DESCRIPTION
If we use `expires_in=10`, we get the following error:
Fail to reach AWS: Parameter validation failed: Invalid range for parameter DurationSeconds, value: 10, valid range: 900-inf

### Bug Fixes
- set `expires_in` to 900 when requesting a presigned URL for file download
