### PR TITLE
Chore/devstuff

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,11 +26,11 @@ npm run-script schema -- https://dev.bionimbus.org/api/v0/submission/getschema
 The portal's `/dev.html` path loads javascript and most css
 from `localhost`.  Test code under local development with this procedure:
 * `npm install`
-* launch the webpack dev server, and configure local code with the same configuration as the server to test against.  For example - if we intend to test against qa-brian, then:
+* launch the webpack dev server, and configure local code with the same configuration as the server to test against.  For example - if we intend to test against dev.planx-pla.net, then:
 ```
 HOSTNAME=dev.planx-pla.net APP=bhc NODE_ENV=dev bash ./runWebpack.sh
 ```
-or
+, or for qa-brain:
 ```
 HOSTNAME=qa-brain.planx-pla.net APP=bhc NODE_ENV=dev bash ./runWebpack.sh
 ```

--- a/README.md
+++ b/README.md
@@ -40,6 +40,10 @@ HOSTNAME=qa-brain.planx-pla.net APP=bhc NODE_ENV=dev bash ./runWebpack.sh
 * Load the test environment's `/dev.html` - ex: https://qa-brian.planx-pla.net/dev.html
 
 
+### Local development and gitops
+
+Most production commons currently load custom configuration via gitops.  The configuration for a production commons is available in that commons' gitops repository (mostly https://github.com/uc-cdis/cdis-manifest), and can be copied for local development.
+
 ### Component story books
 
 To run Storybook:

--- a/README.md
+++ b/README.md
@@ -28,11 +28,11 @@ from `localhost`.  Test code under local development with this procedure:
 * `npm install`
 * launch the webpack dev server, and configure local code with the same configuration as the server to test against.  For example - if we intend to test against dev.planx-pla.net, then:
 ```
-HOSTNAME=dev.planx-pla.net APP=bhc NODE_ENV=dev bash ./runWebpack.sh
+HOSTNAME=dev.planx-pla.net NODE_ENV=auto bash ./runWebpack.sh
 ```
 , or for qa-brain:
 ```
-HOSTNAME=qa-brain.planx-pla.net APP=bhc NODE_ENV=dev bash ./runWebpack.sh
+HOSTNAME=qa-brain.planx-pla.net NODE_ENV=auto bash ./runWebpack.sh
 ```
 
 * Accept the self-signed certificate at https://localhost:9443/bundle.js
@@ -42,7 +42,15 @@ HOSTNAME=qa-brain.planx-pla.net APP=bhc NODE_ENV=dev bash ./runWebpack.sh
 
 ### Local development and gitops
 
-Most production commons currently load custom configuration via gitops.  The configuration for a production commons is available in that commons' gitops repository (mostly https://github.com/uc-cdis/cdis-manifest), and can be copied for local development.
+Most production commons currently load custom configuration via gitops.  The configuration for a production commons is available in that commons' gitops repository (mostly https://github.com/uc-cdis/cdis-manifest), and can be copied for local development.  The `runWebpack.sh` script automates this process when `NODE_ENV` is set to `auto` - ex:
+```
+HOSTNAME=qa-brain.planx-pla.net NODE_ENV=auto bash ./runWebpack.sh
+```
+
+Note: the legacy `dev` NODE_ENV is still available, but the `APP` environment must also be manually set to load the configuration that matches the dictionary from HOSTNAME - ex:
+```
+HOSTNAME=dev.planx-pla.net NODE_ENV=dev APP=dev bash ./runWebpack.sh
+```
 
 ### Component story books
 

--- a/README.md
+++ b/README.md
@@ -21,35 +21,26 @@ Use the parameter to point to remote url (e.g. https://dev.bionimbus.org/api/v0/
 npm run-script schema -- https://dev.bionimbus.org/api/v0/submission/getschema
 ```
 
-### dev.html
+### Local development and dev.html
 
 The portal's `/dev.html` path loads javascript and most css
 from `localhost`.  Test code under local development with this procedure:
-* install nginx locally with a self signed SSL certificate: https://github.com/uc-cdis/cdis-wiki/blob/master/dev/Local-development-for-Gen3.md#nginx-installation
-* load https://localhost, and accept the self signed certificate 
-* launch webpack in `dev -hot` mode - configuring local code with the same configuration as the server to test against.  For example - if we intend to test against qa-brian, then:
+* `npm install`
+* launch the webpack dev server, and configure local code with the same configuration as the server to test against.  For example - if we intend to test against qa-brian, then:
+```
+HOSTNAME=dev.planx-pla.net APP=bhc NODE_ENV=dev bash ./runWebpack.sh
+```
+or
 ```
 HOSTNAME=qa-brain.planx-pla.net APP=bhc NODE_ENV=dev bash ./runWebpack.sh
 ```
+
+* Accept the self-signed certificate at https://localhost:9443/bundle.js
+
 * Load the test environment's `/dev.html` - ex: https://qa-brian.planx-pla.net/dev.html
 
-### Running
-To run for development:
-```
-export NODE_ENV=dev
-export MOCK_STORE=true
-npm run schema
-npm run relay
-npm run params
-./node_modules/.bin/webpack-dev-server --hot
-```
-or easier:
-```
-# HOSTNAME == where to download the dictionary from, should match APP
-HOSTNAME=qa-dcp.planx-pla.net APP=gtex NODE_ENV=dev bash ./runWebpack.sh
-```
 
-Then browse to http://localhost:8080/webpack-dev-server/ . Since we are running it without APIs, this will only render static pages but any submission actions to APIs will fail.
+### Component story books
 
 To run Storybook:
 `npm run storybook`

--- a/boot.js
+++ b/boot.js
@@ -1,6 +1,6 @@
 (function () {
   const isDevMode = !!location.pathname.match(/^\/dev.html/);
-  const buildSrc = isDevMode ? 'https://localhost/bundle.js' : '/bundle.js';
+  const buildSrc = isDevMode ? 'https://localhost:9443/bundle.js' : '/bundle.js';
   const scriptNode = document.createElement('script');
   scriptNode.src = buildSrc;
   scriptNode.type = 'text/javascript';

--- a/dev.html
+++ b/dev.html
@@ -2,7 +2,7 @@
 <html>
   <head>
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self' blob:; img-src 'self' data: https://*.s3.amazonaws.com https://www.google-analytics.com; script-src 'self' 'unsafe-eval' https://www.google-analytics.com localhost;  worker-src 'self' blob:; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; object-src 'none'; font-src 'self' data: https://fonts.googleapis.com https://fonts.gstatic.com; frame-src 'self';">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self' blob:; img-src 'self' data: https://*.s3.amazonaws.com https://www.google-analytics.com; script-src 'self' 'unsafe-eval' https://www.google-analytics.com localhost https://localhost:9443;  worker-src 'self' blob:; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; object-src 'none'; font-src 'self' data: https://fonts.googleapis.com https://fonts.gstatic.com; frame-src 'self';">
     <meta name="viewport" content="width=device-width" />
     <link href="https://fonts.googleapis.com/icon?family=Source+Sans+Pro" rel="stylesheet">
     <link rel="stylesheet/less" type="text/css" media="all" href="/src/css/base.less">
@@ -16,6 +16,6 @@
     <div id="append-root" class="spacer"></div>
     <script type="text/javascript" src="/boot.js"></script>
     <link id="gen3-theme-overrides" rel="stylesheet" type="text/css" href="/src/css/themeoverrides.css"/>
-    <link rel="stylesheet" type="text/css" href="https://localhost/src/css/themeoverrides.css"/>
+    <link rel="stylesheet" type="text/css" href="https://localhost:9443/src/css/themeoverrides.css"/>
   </body>
 </html>

--- a/dev.html
+++ b/dev.html
@@ -2,7 +2,7 @@
 <html>
   <head>
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self' blob:; img-src 'self' data: https://*.s3.amazonaws.com https://www.google-analytics.com; script-src 'self' 'unsafe-eval' https://www.google-analytics.com localhost https://localhost:9443;  worker-src 'self' blob:; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; object-src 'none'; font-src 'self' data: https://fonts.googleapis.com https://fonts.gstatic.com; frame-src 'self';">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self' blob:; img-src 'self' data: https://*.s3.amazonaws.com https://www.google-analytics.com; script-src 'self' 'unsafe-eval' https://www.google-analytics.com localhost https://localhost:9443;  worker-src 'self' blob:; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com localhost https://localhost:9443; object-src 'none'; font-src 'self' data: https://fonts.googleapis.com https://fonts.gstatic.com; frame-src 'self';">
     <meta name="viewport" content="width=device-width" />
     <link href="https://fonts.googleapis.com/icon?family=Source+Sans+Pro" rel="stylesheet">
     <link rel="stylesheet/less" type="text/css" media="all" href="/src/css/base.less">

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,13 +1,35 @@
 ##
-# Logging Settings
 # Note that this file actually winds up at
 #    /etc/nginx/conf.d/nginx.conf
 # , and is loaded by /etc/nginx/nginx.conf in an http{} block
 ##
+
+##
+# Logging Settings
+# The http_x_* headers are set by the gen3 reverse proxy:
+#    kube/services/revproxy/
+##
+log_format json '{"gen3log": "nginx", '
+        '"date_access": "$time_iso8601", '
+        '"user_id": "$http_x_userid", '
+        '"request_id": "$http_x_reqid", '
+        '"session_id": "$http_x_sessionid", '
+        '"visitor_id": "$http_x_visitorid", '
+        '"network_client_ip": "$http_x_forwarded_for", '
+        '"network_bytes_write": $body_bytes_sent, '
+        '"http_response_time": "$request_time", '
+        '"http_status_code": $status, '
+        '"http_request": "$request_uri", '
+        '"http_verb": "$request_method", '
+        '"http_referer": "$http_referer", '
+        '"http_useragent": "$http_user_agent", '
+        '"message": "$request"}';
+
 log_format aws   '$http_x_forwarded_for - $http_x_userid [$time_local] '
             '"$request" $status $body_bytes_sent '
             '"$http_referer" "$http_user_agent"';
-access_log /dev/stdout aws;
+            
+access_log /dev/stdout json;
   
 server {
     listen 80 default_server;

--- a/runWebpack.sh
+++ b/runWebpack.sh
@@ -1,32 +1,147 @@
 #!/bin/bash
 #
-# Fetch schema, relay compile, customize, and run webpack.
-# If NODE_ENV is 'dev', then run webpack -hot server.
-# Script assumes npm install or npm ci has already run.
+# Runtime deployment helper.  Keys on environment variables:
+#  NODE_ENV = auto|dev|production
+#  APP = commons specific
+#  HOSTNAME = where to download graphql schema from
+#
+# Script assumes npm install or npm ci has already run, and jq is installed.
 #
 
 export APP="${APP:-dev}"
 export NODE_ENV="${NODE_ENV:-dev}"
 export HOSTNAME="${HOSTNAME:-"revproxy-service"}"
 
+
+# lib -----------------------------
+
+declare -a gitopsFiles=(
+  gitops.json data/config/gitops.json 
+  gitops-logo.png custom/logo/gitops-logo.png
+  gitops-createdby.png custom/createdby/gitops.png
+  gitops-favicon.ico custom/favicon/gitops-favicon.ico
+  gitops.css custom/css/gitops.css
+  gitops-sponsors custom/sponsors/gitops-sponsors
+)
+
+#
+# Given the HOSTNAME of a public environment,
+# set the APP environment variable and copy gitops
+# config files into the local space
+#
+# @param hostname
+#
+gitops_config() {
+  local hostname
+  local gitRepo
+  local manifestFile
+  local portalApp
+  local portalGitopsFolder 
+
+  gitRepo="cdis-manifest"
+  hostname="$1"
+  shift
+
+  if [[ -z "$hostname" ]]; then
+    echo "ERROR: gitops_config requires hostname arg"
+    return 1
+  fi
+  if [[ "$hostname" =~ ^qa- ]]; then
+    gitRepo="gitops-qa"
+  elif [[ "$hostname" =~ planx-pla.net$ ]]; then
+    gitRepo="gitops-dev"
+  fi
+  if [[ ! -d "../$gitRepo" ]]; then
+	  # git clone
+    echo "ERROR: ../$gitRepo does not exist - please clone https://github.com/uc-cdis/${gitRepo}.git"
+    return 1
+  fi
+  manifestFile="../$gitRepo/$hostname/manifest.json"
+  if [[ ! -f "$manifestFile" ]]; then
+    echo "ERROR: gitops_config - manifest does not exist $manifestFile"
+    return 1
+  fi
+  portalApp="$(jq -r .global.portal_app < $manifestFile)"
+  if [[ -z "$portalApp" ]]; then
+    echo "ERROR: unable to determine portal_app from manifest at $manifestFile"
+    return 1
+  fi
+  echo "INFO: gitops_config - setting APP=$portalApp"
+  export HOSTNAME="$hostname"
+  export APP="$portalApp"
+  if [[ "$portalApp" == "gitops" ]]; then
+    portalGitopsFolder="../$gitRepo/$hostname/portal"
+    local it=0
+    local copySource
+    local copyDest
+    while [[ $it -lt "${#gitopsFiles[@]}" ]]; do
+      copySource="$portalGitopsFolder/${gitopsFiles[$it]}"
+      let it=$it+1
+      copyDest="./${gitopsFiles[$it]}"
+      let it=$it+1
+      if [[ -z "$copySource" || -z "$copyDest" ]]; then
+        echo "ERROR: internal gitops processing error"
+        return 1
+      fi
+      if [[ -f "$copySource" ]]; then
+        echo "INFO: gitops_config - cp $copySource $copyDest"
+        cp "$copySource" "$copyDest"
+      elif [[ -d "$copySource" ]]; then
+        echo "INFO: gitops_config - mkdir -p $copyDest"
+        mkdir -p "$copyDest"
+        echo "INFO: gitops_config - cp $copySource/*.* $copyDest/"
+        cp $copySource/*.* $copyDest/
+      fi
+    done
+  fi
+}
+
+# main -------------------
+
+# make sure we're in the right directory
 cd "$(dirname "${BASH_SOURCE}")"
+
+if [[ "$NODE_ENV" == "auto" ]]; then
+  if ! which jq > /dev/null; then
+    echo "ERROR: NODE_ENV=auto requires the jq tool"
+    echo "Install jq on ubuntu: sudo apt install jq"
+    echo "   or download from https://stedolan.github.io/jq/"
+    exit 1
+  fi
+  if [[ -z "$HOSTNAME" || "$HOSTNAME" == "revproxy-service" ]]; then
+    echo "ERROR: NODE_ENV=auto requires a valid HOSTNAME environment: $HOSTNAME"
+    exit 1
+  fi
+  if ! gitops_config "$HOSTNAME"; then
+    exit 1
+  fi
+fi
+
+#
+# this script copies files from custom/ to src/ based
+# on the current APP environment - ugh
+#
 bash custom/customize.sh
 
-#
-# Note: GDC_SUBPATH environment variable specifies the submission-api endpoint
-#    to fetch the dictionary from at startup
-#
+# download the graphql schema for the commons from HOSTNAME
 npm run schema
+# run the relay compiler against the graphql schema
 npm run relay
+# generate a parameters.json file by overlaying $APP.json on default.json
 npm run params
 
+# try to keep the arranger components in line
 #export STORYBOOK_ARRANGER_API=localhost:3000
 export STORYBOOK_PROJECT_ID=search
 export REACT_APP_ARRANGER_API=/api/v0/flat-search
 export REACT_APP_PROJECT_ID=search
 export REACT_APP_DISABLE_SOCKET=true
 
-if [[ "$NODE_ENV" == "dev" ]]; then
+#
+# finally either launch the webpack-dev-server or 
+# run webpack to generate a static bundle.js
+#
+if [[ "$NODE_ENV" == "dev" || "$NODE_ENV" == "auto" ]]; then
   echo ./node_modules/.bin/webpack-dev-server 
   ./node_modules/.bin/webpack-dev-server
 else

--- a/runWebpack.sh
+++ b/runWebpack.sh
@@ -91,6 +91,8 @@ gitops_config() {
         mkdir -p "$copyDest"
         echo "INFO: gitops_config - cp $copySource/*.* $copyDest/"
         cp $copySource/*.* $copyDest/
+      else
+        echo "INFO: gitops_config - no $copySource in gitops"
       fi
     done
   fi

--- a/runWebpack.sh
+++ b/runWebpack.sh
@@ -27,8 +27,8 @@ export REACT_APP_PROJECT_ID=search
 export REACT_APP_DISABLE_SOCKET=true
 
 if [[ "$NODE_ENV" == "dev" ]]; then
-  echo ./node_modules/.bin/webpack-dev-server --hot 
-  ./node_modules/.bin/webpack-dev-server --hot 
+  echo ./node_modules/.bin/webpack-dev-server 
+  ./node_modules/.bin/webpack-dev-server
 else
   export NODE_ENV="production"
   echo ./node_modules/.bin/webpack --bail

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -65,6 +65,10 @@ module.exports = {
       index: 'dev.html',
     },
     disableHostCheck: true,
+    compress: true,
+    hot: true,
+    port: 9443,
+    https: true,
   },
   module: {
     target: 'node',

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -44,7 +44,7 @@ const plugins = [
   new webpack.optimize.AggressiveMergingPlugin(), //Merge chunks
 ];
 
-if (process.env.NODE_ENV !== 'dev') {
+if (process.env.NODE_ENV !== 'dev' && process.env.NODE_ENV !== 'auto' ) {
   // This slows things down a lot, so avoid when running local dev environment
   plugins.push(new webpack.optimize.UglifyJsPlugin({
     mangle: false,


### PR DESCRIPTION
Eliminate the need for nginx and self-signed certificate generation by leveraging built-in functionality of webpack-dev-server:

* enable webpack-dev-server https on port 9443
    https://webpack.js.org/configuration/dev-server/#devserverhttps
* update dev.html and boot.js to reference https://localhost:9443/

Also setup json format logging in nginx

### New Features

### Breaking Changes

Until deployed everywhere - localhost nginx install needs to be patched to proxy the webpack-dev-server at https://localhost:9443/ instead of http://localhost:8080/

### Bug Fixes


### Improvements


### Dependency updates


### Deployment changes

