### PR TITLE
fix(loop): avoid loop in route finding

### DIFF
--- a/src/DataDictionary/graph/GraphCalculator/graphStructureHelper.js
+++ b/src/DataDictionary/graph/GraphCalculator/graphStructureHelper.js
@@ -398,19 +398,22 @@ export const getAllRoutesBetweenTwoNodes = (
   const resultRoutes = [];
   const takeOneStep = (curID, curPath) => {
     if (curID === endingNodeID) {
-      curPath.reverse(); // we actually want route from top to bottom
-      resultRoutes.push(curPath);
+      const resultPath = Array.from(curPath);
+      resultPath.reverse(); // we actually want route from top to bottom
+      resultRoutes.push(resultPath);
       return;
     }
     const curNode = wholeGraphNodes.find(n => n.id === curID);
     curNode.outLinks.forEach((oid) => {
-      if (curPath.includes(oid)) return; // avoid loop
+      if (curPath.has(oid)) return; // avoid loop
       if (!subgraphNodeIDs.includes(oid)) return;
       if (!subgraphEdges.find(e => e.target === oid && e.source === curID)) return;
-      takeOneStep(oid, curPath.concat(oid));
+      curPath.add(oid);
+      takeOneStep(oid, curPath);
+      curPath.delete(oid);
     });
   };
-  takeOneStep(startingNodeID, [startingNodeID]);
+  takeOneStep(startingNodeID, new Set([startingNodeID]));
   return resultRoutes;
 };
 

--- a/src/DataDictionary/graph/GraphCalculator/graphStructureHelper.js
+++ b/src/DataDictionary/graph/GraphCalculator/graphStructureHelper.js
@@ -404,6 +404,7 @@ export const getAllRoutesBetweenTwoNodes = (
     }
     const curNode = wholeGraphNodes.find(n => n.id === curID);
     curNode.outLinks.forEach((oid) => {
+      if (curPath.includes(oid)) return; // avoid loop
       if (!subgraphNodeIDs.includes(oid)) return;
       if (!subgraphEdges.find(e => e.target === oid && e.source === curID)) return;
       takeOneStep(oid, curPath.concat(oid));


### PR DESCRIPTION

### Bug Fixes
Fix bug: When there's a loop in dictionary, routing finding will cause `Maximum call stack exceeded` error 
