### PR TITLE
Fix Explorer configuration

### DIFF
--- a/data/config/acct.json
+++ b/data/config/acct.json
@@ -110,7 +110,7 @@
     },
     "login": {
       "title": "ACCOuNT Data Commons",
-      "subTitle": "search, compare, and download data",
+      "subTitle": "Explore, Analyze, and Share Data",
       "text": "This website provides a centralized, cloud-based discovery portal for African American pharmacogenomics data and aims to accelerate discovery of novel genetic variants in African Americans related to clinically actionable cardiovascular phenotypes.",
       "contact": "If you have any questions about access or the registration process, please contact support@datacommons.io"
     }

--- a/data/config/anvil.json
+++ b/data/config/anvil.json
@@ -168,7 +168,8 @@
     "arrangerConfig": {
       "projectId": "search",
       "graphqlField": "case",
-      "index": ""
+      "index": "",
+      "nodeCountField": "node_id"
     },
     "table": {
       "enabled": true

--- a/data/config/bhc.json
+++ b/data/config/bhc.json
@@ -112,7 +112,7 @@
     },
     "login": {
       "title": "Brain Commons",
-      "subTitle": "search, compare, and download data",
+      "subTitle": "Explore, Analyze, and Share Data",
       "text": "This website provides a centralized, cloud-based discovery portal for the brain health research community and aims to accelerate discovery and development of therapies, diagnostic tests, and other technologies for the treatment and prevention of diseases impacting the brain.",
       "contact": "If you have any questions about access or the registration process, please contact ",
       "email": "support@datacommons.io"
@@ -161,7 +161,8 @@
     "arrangerConfig": {
       "projectId": "search",
       "graphqlField": "case",
-      "index": ""
+      "index": "",
+      "nodeCountField": "node_id"
     },
     "table": {
       "enabled": true

--- a/data/config/bpa.json
+++ b/data/config/bpa.json
@@ -113,7 +113,7 @@
     },
     "login": {
       "title": "BloodPAC Data Commons",
-      "subTitle": "search, compare, and download data",
+      "subTitle": "Explore, Analyze, and Share Data",
       "text": "This website combines liquid biopsy data from academic, government, and industry partners and aims to accelerate discovery and development of therapies, diagnostic tests, and other technologies for the treatment and prevention of cancer.",
       "contact": "If you have any questions about access or the registration process, please contact ",
       "email": "bpa-support@datacommons.io"

--- a/data/config/dcf.json
+++ b/data/config/dcf.json
@@ -129,7 +129,7 @@
     },
     "login": {
       "title": "National Cancer Institute Data Commons Framework",
-      "subTitle": "search, compare, and download data",
+      "subTitle": "Explore, Analyze, and Share Data",
       "text": "This website supports the management, analysis and sharing of human disease data for the research community and aims to advance basic understanding of the genetic basis of complex traits and accelerate discovery and development of therapies, diagnostic tests, and other technologies for diseases like cancer.",
       "contact": "If you have any questions about access or the registration process, please contact ",
       "email": "support@datacommons.io"

--- a/data/config/default.json
+++ b/data/config/default.json
@@ -143,7 +143,7 @@
     },
     "login": {
       "title": "Generic Data Commons",
-      "subTitle": "search, compare, and download data",
+      "subTitle": "Explore, Analyze, and Share Data",
       "text": "This website supports the management, analysis and sharing of human disease data for the research community and aims to advance basic understanding of the genetic basis of complex traits and accelerate discovery and development of therapies, diagnostic tests, and other technologies for diseases like cancer.",
       "contact": "If you have any questions about access or the registration process, please contact ",
       "email": "support@datacommons.io"
@@ -254,7 +254,8 @@
     "arrangerConfig": {
       "projectId": "search",
       "graphqlField": "subject",
-      "index": ""
+      "index": "",
+      "nodeCountField": "node_id"
     },
     "buttons": [
       {

--- a/data/config/edc.json
+++ b/data/config/edc.json
@@ -106,7 +106,7 @@
     },
     "login": {
       "title": "Environmental Data Commons",
-      "subTitle": "search, compare, and download data",
+      "subTitle": "Explore, Analyze, and Share Data",
       "text": "This website provides a centralized, cloud-based portal for the open redistribution and analysis of environmental datasets and satellite imagery from OCC stakeholders like NASA and NOAA and aims to support the earth science research community as well as human assisted disaster relief.",
       "contact": "If you have any questions about access or the registration process, please contact ",
       "email": "support@datacommons.io"

--- a/data/config/gtex.json
+++ b/data/config/gtex.json
@@ -166,6 +166,8 @@
           "fields": [
             "project_id",
             "consent_codes",
+            "data_type",
+            "data_format",
             "race",
             "ethnicity",
             "gender",

--- a/data/config/gtex.json
+++ b/data/config/gtex.json
@@ -105,7 +105,7 @@
     },
     "login": {
       "title": "Data STAGE",
-      "subTitle": "search, compare, and download data",
+      "subTitle": "Explore, Analyze, and Share Data",
       "text": "This website supports the management, analysis and sharing of human disease data for the research community and aims to advance basic understanding of the genetic basis of complex traits and accelerate discovery and development of therapies, diagnostic tests, and other technologies for diseases like cancer.",
       "contact": "If you have any questions about access or the registration process, please contact ",
       "email": "support@datacommons.io"
@@ -121,7 +121,7 @@
         "chartType": "count",
         "title": "Projects"
       },
-      "node_id": {
+      "case_id": {
         "chartType": "count",
         "title": "Cases"
       },
@@ -214,7 +214,8 @@
     "arrangerConfig": {
       "projectId": "search",
       "graphqlField": "case",
-      "index": ""
+      "index": "",
+      "nodeCountField": "case_id"
     }
   }
 }

--- a/data/config/ibdgc.json
+++ b/data/config/ibdgc.json
@@ -72,7 +72,7 @@
     },
     "login": {
       "title": "IBDGC Portal",
-      "subTitle": "search, compare, and download data",
+      "subTitle": "Explore, Analyze, and Share Data",
       "text": "The Inflammatory Bowel Disease Genetics Consortium Data Commons supports the management, analysis, and sharing of genetic data to support the vision and mission of the IBD genetics consortium.",
       "contact": "If you have any questions about access or the registration process, please contact ",
       "email": "support@datacommons.io"

--- a/data/config/kf.json
+++ b/data/config/kf.json
@@ -100,7 +100,7 @@
     },
     "login": {
       "title": "Kids First Data Catalog",
-      "subTitle": "search, compare, and download data",
+      "subTitle": "Explore, Analyze, and Share Data",
       "text": "The Kids First Data Catalog supports the Kids First Data Resource Center by providing a digital object services that allow interoperability between data commons, including authentication and authorization for controlled access data. For more information about the overall Kids First Data Resource Center see https://kidsfirstdrc.org.",
       "contact": "If you have any questions about access or the registration process, please contact ",
       "email": "support@kidsfirstdrc.org"

--- a/data/config/kfDcfInterop.json
+++ b/data/config/kfDcfInterop.json
@@ -100,7 +100,7 @@
     },
     "login": {
       "title": "Pediatric Cancer Commons Pilot",
-      "subTitle": "search, compare, and download data",
+      "subTitle": "Explore, Analyze, and Share Data",
       "text": "The Pediatric Cancer Commons Pilot is a Trusted Partner of the NIH powered by Gen3. Gen3 is an open source Data Commons platform (https://gen3.org/) supporting a number of large-scale NIH- and non-NIH Commons including the NCI's Genomic Data Commons, NHLBI's Data Stage, the NIH Data Commons Pilot, and the Bloodpac Data Commons. As such the Gen3 Data Catalog supports the Kids First Data Resource Center by providing digital object services that allow interoperability between existing and future Gen3 data commons, including authentication and authorization for controlled access data. For more information about the overall Kids First Data Resource Center and associated tools/portals see https://kidsfirstdrc.org.",
       "contact": "If you have any questions about access or the registration process, please contact ",
       "email": "support@kidsfirstdrc.org"
@@ -158,7 +158,8 @@
     "arrangerConfig": {
       "projectId": "search",
       "graphqlField": "case",
-      "index": ""
+      "index": "",
+      "nodeCountField": "node_id"
     },
     "table": {
       "enabled": true

--- a/data/config/ncrdc-demo.json
+++ b/data/config/ncrdc-demo.json
@@ -178,7 +178,8 @@
     "arrangerConfig": {
       "projectId": "search",
       "graphqlField": "subject",
-      "index": ""
+      "index": "",
+      "nodeCountField": "submitter_id"
     }
   }
 }

--- a/data/config/ndh.json
+++ b/data/config/ndh.json
@@ -117,7 +117,7 @@
     },
     "login": {
       "title": "NIAID Data Hub",
-      "subTitle": "search, compare, and download data",
+      "subTitle": "Explore, Analyze, and Share Data",
       "text": "The website combines government datasets from 3 divisions of NIAID to create clean, easy to navigate visualizations for data-driven discovery within Allergy and Infectious Diseases.",
       "contact": "If you have any questions about access or the registration process, please contact ",
       "email": "support@datacommons.io"
@@ -222,7 +222,8 @@
         "resourceIdField": "object_id",
         "referenceIdFieldInResourceIndex": "subject_id",
         "referenceIdFieldInDataIndex": "node_id"
-      }
+      },
+      "nodeCountField": "submitter_id"
     }
   }
 }

--- a/data/dictionary.json
+++ b/data/dictionary.json
@@ -107,6 +107,7 @@
         "type": "string"
       },
       "md5sum": {
+        "pattern": "^[a-f0-9]{32}$",
         "term": {
           "description": "The 128-bit hash value expressed as a 32 digit hexadecimal number used as a file's digital fingerprint.\n"
         },
@@ -163,14 +164,16 @@
           "description": "The current state of the object.\n"
         }
       },
-      "submitter_id": {
-        "description": "A project-specific identifier for a node. This property is the calling card/nickname/alias for a unit of submission. It can be used in place of the UUID for identifying or recalling a node.\n",
-        "type": [
-          "string"
-        ]
-      },
-      "type": {
+      "state_comment": {
+        "description": "Optional comment about why the file is in the current state, mainly for invalid state.\n",
         "type": "string"
+      },
+      "submitter_id": {
+        "description": "The file ID assigned by the submitter.",
+        "type": [
+          "string",
+          "null"
+        ]
       },
       "updated_datetime": {
         "oneOf": [
@@ -260,31 +263,9 @@
       },
       "type": "object"
     },
-    "foreign_key_project": {
-      "additionalProperties": true,
-      "properties": {
-        "code": {
-          "type": "string"
-        },
-        "id": {
-          "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
-          "term": {
-            "description": "A 128-bit identifier. Depending on the mechanism used to generate it, it is either guaranteed to be different from all other UUIDs/GUIDs generated until 3400 AD or extremely likely to be different. Its relatively small size lends itself well to sorting, ordering, and hashing of all sorts, storing in databases, simple allocation, and ease of programming in general.\n",
-            "termDef": {
-              "cde_id": "C54100",
-              "cde_version": null,
-              "source": "NCIt",
-              "term": "Universally Unique Identifier",
-              "term_url": "https://ncit.nci.nih.gov/ncitbrowser/ConceptReport.jsp?dictionary=NCI_Thesaurus&version=16.02d&ns=NCI_Thesaurus&code=C54100"
-            }
-          },
-          "type": "string"
-        }
-      },
-      "type": "object"
-    },
     "id": "_definitions",
     "md5sum": {
+      "pattern": "^[a-f0-9]{32}$",
       "term": {
         "description": "The 128-bit hash value expressed as a 32 digit hexadecimal number used as a file's digital fingerprint.\n"
       },
@@ -429,60 +410,6 @@
         }
       ]
     },
-    "to_many_project": {
-      "anyOf": [
-        {
-          "items": {
-            "additionalProperties": true,
-            "minItems": 1,
-            "properties": {
-              "code": {
-                "type": "string"
-              },
-              "id": {
-                "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
-                "term": {
-                  "description": "A 128-bit identifier. Depending on the mechanism used to generate it, it is either guaranteed to be different from all other UUIDs/GUIDs generated until 3400 AD or extremely likely to be different. Its relatively small size lends itself well to sorting, ordering, and hashing of all sorts, storing in databases, simple allocation, and ease of programming in general.\n",
-                  "termDef": {
-                    "cde_id": "C54100",
-                    "cde_version": null,
-                    "source": "NCIt",
-                    "term": "Universally Unique Identifier",
-                    "term_url": "https://ncit.nci.nih.gov/ncitbrowser/ConceptReport.jsp?dictionary=NCI_Thesaurus&version=16.02d&ns=NCI_Thesaurus&code=C54100"
-                  }
-                },
-                "type": "string"
-              }
-            },
-            "type": "object"
-          },
-          "type": "array"
-        },
-        {
-          "additionalProperties": true,
-          "properties": {
-            "code": {
-              "type": "string"
-            },
-            "id": {
-              "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
-              "term": {
-                "description": "A 128-bit identifier. Depending on the mechanism used to generate it, it is either guaranteed to be different from all other UUIDs/GUIDs generated until 3400 AD or extremely likely to be different. Its relatively small size lends itself well to sorting, ordering, and hashing of all sorts, storing in databases, simple allocation, and ease of programming in general.\n",
-                "termDef": {
-                  "cde_id": "C54100",
-                  "cde_version": null,
-                  "source": "NCIt",
-                  "term": "Universally Unique Identifier",
-                  "term_url": "https://ncit.nci.nih.gov/ncitbrowser/ConceptReport.jsp?dictionary=NCI_Thesaurus&version=16.02d&ns=NCI_Thesaurus&code=C54100"
-                }
-              },
-              "type": "string"
-            }
-          },
-          "type": "object"
-        }
-      ]
-    },
     "to_one": {
       "anyOf": [
         {
@@ -531,61 +458,6 @@
               "type": "string"
             },
             "submitter_id": {
-              "type": "string"
-            }
-          },
-          "type": "object"
-        }
-      ]
-    },
-    "to_one_project": {
-      "anyOf": [
-        {
-          "items": {
-            "additionalProperties": true,
-            "maxItems": 1,
-            "minItems": 1,
-            "properties": {
-              "code": {
-                "type": "string"
-              },
-              "id": {
-                "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
-                "term": {
-                  "description": "A 128-bit identifier. Depending on the mechanism used to generate it, it is either guaranteed to be different from all other UUIDs/GUIDs generated until 3400 AD or extremely likely to be different. Its relatively small size lends itself well to sorting, ordering, and hashing of all sorts, storing in databases, simple allocation, and ease of programming in general.\n",
-                  "termDef": {
-                    "cde_id": "C54100",
-                    "cde_version": null,
-                    "source": "NCIt",
-                    "term": "Universally Unique Identifier",
-                    "term_url": "https://ncit.nci.nih.gov/ncitbrowser/ConceptReport.jsp?dictionary=NCI_Thesaurus&version=16.02d&ns=NCI_Thesaurus&code=C54100"
-                  }
-                },
-                "type": "string"
-              }
-            },
-            "type": "object"
-          },
-          "type": "array"
-        },
-        {
-          "additionalProperties": true,
-          "properties": {
-            "code": {
-              "type": "string"
-            },
-            "id": {
-              "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
-              "term": {
-                "description": "A 128-bit identifier. Depending on the mechanism used to generate it, it is either guaranteed to be different from all other UUIDs/GUIDs generated until 3400 AD or extremely likely to be different. Its relatively small size lends itself well to sorting, ordering, and hashing of all sorts, storing in databases, simple allocation, and ease of programming in general.\n",
-                "termDef": {
-                  "cde_id": "C54100",
-                  "cde_version": null,
-                  "source": "NCIt",
-                  "term": "Universally Unique Identifier",
-                  "term_url": "https://ncit.nci.nih.gov/ncitbrowser/ConceptReport.jsp?dictionary=NCI_Thesaurus&version=16.02d&ns=NCI_Thesaurus&code=C54100"
-                }
-              },
               "type": "string"
             }
           },
@@ -772,13 +644,11 @@
         }
       },
       "submitter_id": {
-        "description": "A project-specific identifier for a node. This property is the calling card/nickname/alias for a unit of submission. It can be used in place of the UUID for identifying or recalling a node.\n",
+        "description": "The file ID assigned by the submitter.",
         "type": [
-          "string"
+          "string",
+          "null"
         ]
-      },
-      "type": {
-        "type": "string"
       },
       "updated_datetime": {
         "oneOf": [
@@ -793,10 +663,6 @@
         "term": {
           "description": "A combination of date and time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]\n"
         }
-      },
-      "workflow_description": {
-        "description": "A brief description of the workflow or pipeline used to generate the data.",
-        "type": "string"
       },
       "workflow_end_datetime": {
         "oneOf": [
@@ -814,10 +680,6 @@
       },
       "workflow_link": {
         "description": "Link to Github hash for the CWL workflow used.",
-        "type": "string"
-      },
-      "workflow_name": {
-        "description": "The name of an encapsulated bioinformatics workflow or pipeline.",
         "type": "string"
       },
       "workflow_start_datetime": {
@@ -841,8 +703,6 @@
     }
   },
   "_settings": {
-    "_dict_commit": "aee1285f448fa2b5fda6bff0b6c241f339af92bb",
-    "_dict_version": "0.3.2-2-gaee1285",
     "enable_case_cache": false
   },
   "_terms": {
@@ -893,17 +753,7 @@
       "description": "Base sequence of the sequencing adapter.\n"
     },
     "age_at_diagnosis": {
-      "description": "Age at the time of diagnosis expressed in number of days since birth. If the age at diagnosis is greater than 32872 days (89 years), then see 'age_at_diagnosis_gt89'.\n",
-      "termDef": {
-        "cde_id": 3225640,
-        "cde_version": 2,
-        "source": "caDSR",
-        "term": "Patient Diagnosis Age Day Value",
-        "term_url": "https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=3225640&version=2.0"
-      }
-    },
-    "age_at_diagnosis_gt89": {
-      "description": "Indicate if the age at the time of diagnosis expressed in number of days since birth is greater than 32872 days (89 years).\n",
+      "description": "Age at the time of diagnosis expressed in number of days since birth.\n",
       "termDef": {
         "cde_id": 3225640,
         "cde_version": 2,
@@ -1023,7 +873,7 @@
       }
     },
     "aliquot_volume": {
-      "description": "The volume in microliters (ul) of the aliquot(s) derived from the analyte(s) shipped for sequencing and characterization.\n",
+      "description": "The volume in microliters (ml) of the aliquot(s) derived from the analyte(s) shipped for sequencing and characterization.\n",
       "termDef": {
         "cde_id": null,
         "cde_version": null,
@@ -1307,7 +1157,7 @@
       "description": "A combination of date and time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]\n"
     },
     "days_to_birth": {
-      "description": "Time interval from a person's date of birth to the date of index, represented as a calculated negative number of days.\n",
+      "description": "Time interval from a person's date of birth to the date of initial pathologic diagnosis, represented as a calculated negative number of days.\n",
       "termDef": {
         "cde_id": 3008233,
         "cde_version": 1,
@@ -1327,7 +1177,7 @@
       }
     },
     "days_to_death": {
-      "description": "Time interval from a person's date of death to the date of index, represented as a calculated number of days.\n",
+      "description": "Time interval from a person's date of death to the date of initial pathologic diagnosis, represented as a calculated number of days.\n",
       "termDef": {
         "cde_id": 3165475,
         "cde_version": 1,
@@ -1337,7 +1187,7 @@
       }
     },
     "days_to_hiv_diagnosis": {
-      "description": "Time interval from the date of the index to the date of human immunodeficiency diagnosis, represented as a calculated number of days.\n",
+      "description": "Time interval from the date of the initial pathologic diagnosis to the date of human immunodeficiency diagnosis, represented as a calculated number of days.\n",
       "termDef": {
         "cde_id": 4618491,
         "cde_version": 1,
@@ -1347,7 +1197,7 @@
       }
     },
     "days_to_last_follow_up": {
-      "description": "Time interval from the date of last follow up to the date of index, represented as a calculated number of days.\n",
+      "description": "Time interval from the date of last follow up to the date of initial pathologic diagnosis, represented as a calculated number of days.\n",
       "termDef": {
         "cde_id": 3008273,
         "cde_version": 1,
@@ -1357,7 +1207,7 @@
       }
     },
     "days_to_last_known_disease_status": {
-      "description": "Time interval from the date of last follow up to the date of index, represented as a calculated number of days.\n",
+      "description": "Time interval from the date of last follow up to the date of initial pathologic diagnosis, represented as a calculated number of days.\n",
       "termDef": {
         "cde_id": 3008273,
         "cde_version": 1,
@@ -1367,7 +1217,7 @@
       }
     },
     "days_to_new_event": {
-      "description": "Time interval from the date of new tumor event including progression, recurrence and new primary malignacies to the date of index, represented as a calculated number of days.\n",
+      "description": "Time interval from the date of new tumor event including progression, recurrence and new primary malignacies to the date of initial pathologic diagnosis, represented as a calculated number of days.\n",
       "termDef": {
         "cde_id": 3392464,
         "cde_version": 1,
@@ -1377,7 +1227,7 @@
       }
     },
     "days_to_recurrence": {
-      "description": "Time interval from the date of new tumor event including progression, recurrence and new primary malignancies to the date of index, represented as a calculated number of days.\n",
+      "description": "Time interval from the date of new tumor event including progression, recurrence and new primary malignancies to the date of initial pathologic diagnosis, represented as a calculated number of days.\n",
       "termDef": {
         "cde_id": 3392464,
         "cde_version": 1,
@@ -1390,7 +1240,7 @@
       "description": "The number of days from the date the patient was diagnosed to the date of the procedure that produced the sample.\n"
     },
     "days_to_treatment": {
-      "description": "Number of days from date of index that treatment began.\n",
+      "description": "Number of days from date of initial pathologic diagnosis that treatment began.\n",
       "termDef": {
         "cde_id": null,
         "cde_version": null,
@@ -1400,7 +1250,7 @@
       }
     },
     "days_to_treatment_end": {
-      "description": "Time interval from the date of the index to the date of treatment end, represented as a calculated number of days.\n",
+      "description": "Time interval from the date of the initial pathologic diagnosis to the date of treatment end, represented as a calculated number of days.\n",
       "termDef": {
         "cde_id": 5102431,
         "cde_version": 1,
@@ -1410,7 +1260,7 @@
       }
     },
     "days_to_treatment_start": {
-      "description": "Time interval from the date of the index to the start of treatment, represented as a calculated number of days.\n",
+      "description": "Time interval from the date of the initial pathologic diagnosis to the start of treatment, represented as a calculated number of days.\n",
       "termDef": {
         "cde_id": 5102411,
         "cde_version": 1,
@@ -1483,7 +1333,7 @@
       "description": "Submitter-defined name for the experiment.\n"
     },
     "experimental_strategy": {
-      "description": "The experimental strategy used to generate the data file.\n"
+      "description": "The sequencing strategy used to generate the data file.\n"
     },
     "fastq_name": {
       "description": "Names of FASTQs.\n"
@@ -1857,9 +1707,6 @@
         "term_url": "https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=5432636&version=1.0"
       }
     },
-    "object_id": {
-      "description": "The GUID of the object in the index service."
-    },
     "oct_embedded": {
       "description": "Indicator of whether or not the sample was embedded in Optimal Cutting Temperature (OCT) compound.\n",
       "termDef": {
@@ -2133,17 +1980,7 @@
       "description": "The length of the reads.\n"
     },
     "relationship_age_at_diagnosis": {
-      "description": "The age (in years) when the patient's relative was first diagnosed; if age is greater than 89 years, use 'relationship_age_at_diagnosis_gt89'.\n",
-      "termDef": {
-        "cde_id": 5300571,
-        "cde_version": 1,
-        "source": "caDSR",
-        "term": "Relative Diagnosis Age Value",
-        "term_url": "https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=5300571&version=1.0"
-      }
-    },
-    "relationship_age_at_diagnosis_gt89": {
-      "description": "Indicate whether the age (in years) when the patient's relative was first diagnosed is greater than 89 years.\n",
+      "description": "The age (in years) when the patient's relative was first diagnosed.\n",
       "termDef": {
         "cde_id": 5300571,
         "cde_version": 1,
@@ -2425,7 +2262,7 @@
       }
     },
     "tumor_code": {
-      "description": "A specification of a cancer through cellular origin and localization.\n"
+      "description": "Diagnostic tumor code of the tissue sample source.\n"
     },
     "tumor_code_id": {
       "description": "BCR-defined id code for the tumor sample.\n"
@@ -2459,9 +2296,6 @@
         "term": "Tumor Stage",
         "term_url": "https://ncit.nci.nih.gov/ncitbrowser/pages/concept_details.jsf?dictionary=NCI%20Thesaurus&code=C16899"
       }
-    },
-    "universal_molecular_identifier": {
-      "description": "Short sequences or barcodes added to each read for next generation sequencing protocols used to detect and quantify unique transcripts.\n"
     },
     "vascular_invasion_present": {
       "description": "The yes/no indicator to ask if large vessel or venous invasion was detected by surgery or presence in a tumor specimen.\n",
@@ -2563,12 +2397,12 @@
         "target_type": "project"
       }
     ],
-    "namespace": "https://www.bloodpac.org",
+    "namespace": "http://gdc.nci.nih.gov",
     "program": "*",
     "project": "*",
     "properties": {
       "acknowledgee": {
-        "description": "The individual or group being acknowledged by the project.",
+        "description": "The indvidiual or group being acknowledged by the project.",
         "type": "string"
       },
       "created_datetime": {
@@ -2610,9 +2444,6 @@
               "additionalProperties": true,
               "minItems": 1,
               "properties": {
-                "code": {
-                  "type": "string"
-                },
                 "id": {
                   "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
                   "term": {
@@ -2626,6 +2457,9 @@
                     }
                   },
                   "type": "string"
+                },
+                "submitter_id": {
+                  "type": "string"
                 }
               },
               "type": "object"
@@ -2635,9 +2469,6 @@
           {
             "additionalProperties": true,
             "properties": {
-              "code": {
-                "type": "string"
-              },
               "id": {
                 "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
                 "term": {
@@ -2650,6 +2481,9 @@
                     "term_url": "https://ncit.nci.nih.gov/ncitbrowser/ConceptReport.jsp?dictionary=NCI_Thesaurus&version=16.02d&ns=NCI_Thesaurus&code=C54100"
                   }
                 },
+                "type": "string"
+              },
+              "submitter_id": {
                 "type": "string"
               }
             },
@@ -2726,7 +2560,6 @@
     },
     "required": [
       "submitter_id",
-      "type",
       "projects"
     ],
     "submittable": true,
@@ -2758,29 +2591,23 @@
     "id": "aligned_reads_index",
     "links": [
       {
-        "exclusive": false,
+        "backref": "aligned_reads_indexes",
+        "label": "derived_from",
+        "multiplicity": "one_to_one",
+        "name": "submitted_aligned_reads_files",
         "required": true,
-        "subgroup": [
-          {
-            "backref": "aligned_reads_indexes",
-            "label": "data_from",
-            "multiplicity": "one_to_one",
-            "name": "core_metadata_collections",
-            "required": false,
-            "target_type": "core_metadata_collection"
-          },
-          {
-            "backref": "aligned_reads_indexes",
-            "label": "derived_from",
-            "multiplicity": "one_to_one",
-            "name": "submitted_aligned_reads_files",
-            "required": false,
-            "target_type": "submitted_aligned_reads"
-          }
-        ]
+        "target_type": "submitted_aligned_reads"
+      },
+      {
+        "backref": "aligned_reads_indexes",
+        "label": "data_from",
+        "multiplicity": "many_to_many",
+        "name": "core_metadata_collections",
+        "required": false,
+        "target_type": "core_metadata_collection"
       }
     ],
-    "namespace": "https://www.bloodpac.org",
+    "namespace": "http://gdc.nci.nih.gov",
     "program": "*",
     "project": "*",
     "properties": {
@@ -2854,7 +2681,9 @@
       },
       "data_category": {
         "enum": [
-          "Sequencing Reads"
+          "Sequencing Data",
+          "Sequencing Reads",
+          "Raw Sequencing Data"
         ],
         "term": {
           "description": "Broad categorization of the contents of the data file.\n"
@@ -2932,6 +2761,7 @@
         "type": "string"
       },
       "md5sum": {
+        "pattern": "^[a-f0-9]{32}$",
         "term": {
           "description": "The 128-bit hash value expressed as a 32 digit hexadecimal number used as a file's digital fingerprint.\n"
         },
@@ -2987,6 +2817,10 @@
         "term": {
           "description": "The current state of the object.\n"
         }
+      },
+      "state_comment": {
+        "description": "Optional comment about why the file is in the current state, mainly for invalid state.\n",
+        "type": "string"
       },
       "submitted_aligned_reads_files": {
         "anyOf": [
@@ -3044,13 +2878,16 @@
         ]
       },
       "submitter_id": {
-        "description": "A project-specific identifier for a node. This property is the calling card/nickname/alias for a unit of submission. It can be used in place of the UUID for identifying or recalling a node.\n",
+        "description": "The file ID assigned by the submitter.",
         "type": [
-          "string"
+          "string",
+          "null"
         ]
       },
       "type": {
-        "type": "string"
+        "enum": [
+          "aligned_reads_index"
+        ]
       },
       "updated_datetime": {
         "oneOf": [
@@ -3069,13 +2906,13 @@
     },
     "required": [
       "submitter_id",
-      "type",
       "file_name",
       "file_size",
       "md5sum",
       "data_category",
       "data_type",
-      "data_format"
+      "data_format",
+      "submitted_aligned_reads_files"
     ],
     "submittable": true,
     "systemProperties": [
@@ -3088,317 +2925,6 @@
       "error_type"
     ],
     "title": "Aligned Reads Index",
-    "type": "object",
-    "uniqueKeys": [
-      [
-        "id"
-      ],
-      [
-        "project_id",
-        "submitter_id"
-      ]
-    ],
-    "validators": null
-  },
-  "alignment_workflow": {
-    "$schema": "http://json-schema.org/draft-04/schema#",
-    "additionalProperties": false,
-    "category": "analysis",
-    "description": "A description of the specific bioinformatics workflow or pipeline used for sequence alignment.\n",
-    "id": "alignment_workflow",
-    "links": [
-      {
-        "backref": "associated_alignment_workflows",
-        "label": "performed_on",
-        "multiplicity": "many_to_many",
-        "name": "input_submitted_unaligned_reads_files",
-        "required": true,
-        "target_type": "submitted_unaligned_reads"
-      },
-      {
-        "backref": "alignment_workflows",
-        "label": "generate",
-        "multiplicity": "one_to_one",
-        "name": "output_submitted_aligned_reads_files",
-        "required": true,
-        "target_type": "submitted_aligned_reads"
-      }
-    ],
-    "namespace": "https://www.bloodpac.org",
-    "program": "*",
-    "project": "*",
-    "properties": {
-      "created_datetime": {
-        "oneOf": [
-          {
-            "format": "date-time",
-            "type": "string"
-          },
-          {
-            "type": "null"
-          }
-        ],
-        "term": {
-          "description": "A combination of date and time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]\n"
-        }
-      },
-      "id": {
-        "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
-        "systemAlias": "node_id",
-        "term": {
-          "description": "A 128-bit identifier. Depending on the mechanism used to generate it, it is either guaranteed to be different from all other UUIDs/GUIDs generated until 3400 AD or extremely likely to be different. Its relatively small size lends itself well to sorting, ordering, and hashing of all sorts, storing in databases, simple allocation, and ease of programming in general.\n",
-          "termDef": {
-            "cde_id": "C54100",
-            "cde_version": null,
-            "source": "NCIt",
-            "term": "Universally Unique Identifier",
-            "term_url": "https://ncit.nci.nih.gov/ncitbrowser/ConceptReport.jsp?dictionary=NCI_Thesaurus&version=16.02d&ns=NCI_Thesaurus&code=C54100"
-          }
-        },
-        "type": "string"
-      },
-      "input_submitted_unaligned_reads_files": {
-        "anyOf": [
-          {
-            "items": {
-              "additionalProperties": true,
-              "minItems": 1,
-              "properties": {
-                "id": {
-                  "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
-                  "term": {
-                    "description": "A 128-bit identifier. Depending on the mechanism used to generate it, it is either guaranteed to be different from all other UUIDs/GUIDs generated until 3400 AD or extremely likely to be different. Its relatively small size lends itself well to sorting, ordering, and hashing of all sorts, storing in databases, simple allocation, and ease of programming in general.\n",
-                    "termDef": {
-                      "cde_id": "C54100",
-                      "cde_version": null,
-                      "source": "NCIt",
-                      "term": "Universally Unique Identifier",
-                      "term_url": "https://ncit.nci.nih.gov/ncitbrowser/ConceptReport.jsp?dictionary=NCI_Thesaurus&version=16.02d&ns=NCI_Thesaurus&code=C54100"
-                    }
-                  },
-                  "type": "string"
-                },
-                "submitter_id": {
-                  "type": "string"
-                }
-              },
-              "type": "object"
-            },
-            "type": "array"
-          },
-          {
-            "additionalProperties": true,
-            "properties": {
-              "id": {
-                "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
-                "term": {
-                  "description": "A 128-bit identifier. Depending on the mechanism used to generate it, it is either guaranteed to be different from all other UUIDs/GUIDs generated until 3400 AD or extremely likely to be different. Its relatively small size lends itself well to sorting, ordering, and hashing of all sorts, storing in databases, simple allocation, and ease of programming in general.\n",
-                  "termDef": {
-                    "cde_id": "C54100",
-                    "cde_version": null,
-                    "source": "NCIt",
-                    "term": "Universally Unique Identifier",
-                    "term_url": "https://ncit.nci.nih.gov/ncitbrowser/ConceptReport.jsp?dictionary=NCI_Thesaurus&version=16.02d&ns=NCI_Thesaurus&code=C54100"
-                  }
-                },
-                "type": "string"
-              },
-              "submitter_id": {
-                "type": "string"
-              }
-            },
-            "type": "object"
-          }
-        ]
-      },
-      "output_submitted_aligned_reads_files": {
-        "anyOf": [
-          {
-            "items": {
-              "additionalProperties": true,
-              "maxItems": 1,
-              "minItems": 1,
-              "properties": {
-                "id": {
-                  "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
-                  "term": {
-                    "description": "A 128-bit identifier. Depending on the mechanism used to generate it, it is either guaranteed to be different from all other UUIDs/GUIDs generated until 3400 AD or extremely likely to be different. Its relatively small size lends itself well to sorting, ordering, and hashing of all sorts, storing in databases, simple allocation, and ease of programming in general.\n",
-                    "termDef": {
-                      "cde_id": "C54100",
-                      "cde_version": null,
-                      "source": "NCIt",
-                      "term": "Universally Unique Identifier",
-                      "term_url": "https://ncit.nci.nih.gov/ncitbrowser/ConceptReport.jsp?dictionary=NCI_Thesaurus&version=16.02d&ns=NCI_Thesaurus&code=C54100"
-                    }
-                  },
-                  "type": "string"
-                },
-                "submitter_id": {
-                  "type": "string"
-                }
-              },
-              "type": "object"
-            },
-            "type": "array"
-          },
-          {
-            "additionalProperties": true,
-            "properties": {
-              "id": {
-                "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
-                "term": {
-                  "description": "A 128-bit identifier. Depending on the mechanism used to generate it, it is either guaranteed to be different from all other UUIDs/GUIDs generated until 3400 AD or extremely likely to be different. Its relatively small size lends itself well to sorting, ordering, and hashing of all sorts, storing in databases, simple allocation, and ease of programming in general.\n",
-                  "termDef": {
-                    "cde_id": "C54100",
-                    "cde_version": null,
-                    "source": "NCIt",
-                    "term": "Universally Unique Identifier",
-                    "term_url": "https://ncit.nci.nih.gov/ncitbrowser/ConceptReport.jsp?dictionary=NCI_Thesaurus&version=16.02d&ns=NCI_Thesaurus&code=C54100"
-                  }
-                },
-                "type": "string"
-              },
-              "submitter_id": {
-                "type": "string"
-              }
-            },
-            "type": "object"
-          }
-        ]
-      },
-      "project_id": {
-        "term": {
-          "description": "Unique ID for any specific defined piece of work that is undertaken or attempted to meet a single requirement.\n"
-        },
-        "type": "string"
-      },
-      "state": {
-        "default": "validated",
-        "downloadable": [
-          "uploaded",
-          "md5summed",
-          "validating",
-          "validated",
-          "error",
-          "invalid",
-          "released"
-        ],
-        "oneOf": [
-          {
-            "enum": [
-              "uploading",
-              "uploaded",
-              "md5summing",
-              "md5summed",
-              "validating",
-              "error",
-              "invalid",
-              "suppressed",
-              "redacted",
-              "live"
-            ]
-          },
-          {
-            "enum": [
-              "validated",
-              "submitted",
-              "released"
-            ]
-          }
-        ],
-        "public": [
-          "live"
-        ],
-        "term": {
-          "description": "The current state of the object.\n"
-        }
-      },
-      "submitter_id": {
-        "description": "A project-specific identifier for a node. This property is the calling card/nickname/alias for a unit of submission. It can be used in place of the UUID for identifying or recalling a node.\n",
-        "type": [
-          "string"
-        ]
-      },
-      "type": {
-        "type": "string"
-      },
-      "updated_datetime": {
-        "oneOf": [
-          {
-            "format": "date-time",
-            "type": "string"
-          },
-          {
-            "type": "null"
-          }
-        ],
-        "term": {
-          "description": "A combination of date and time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]\n"
-        }
-      },
-      "workflow_description": {
-        "description": "A brief description of the workflow or pipeline used to generate the data.",
-        "type": "string"
-      },
-      "workflow_end_datetime": {
-        "oneOf": [
-          {
-            "format": "date-time",
-            "type": "string"
-          },
-          {
-            "type": "null"
-          }
-        ],
-        "term": {
-          "description": "A combination of date and time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]\n"
-        }
-      },
-      "workflow_link": {
-        "description": "Link to Github hash for the CWL workflow used.",
-        "type": "string"
-      },
-      "workflow_name": {
-        "description": "The name of an encapsulated bioinformatics workflow or pipeline.",
-        "type": "string"
-      },
-      "workflow_start_datetime": {
-        "oneOf": [
-          {
-            "format": "date-time",
-            "type": "string"
-          },
-          {
-            "type": "null"
-          }
-        ],
-        "term": {
-          "description": "A combination of date and time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]\n"
-        }
-      },
-      "workflow_version": {
-        "description": "Major version for a GDC workflow.",
-        "type": "string"
-      }
-    },
-    "required": [
-      "submitter_id",
-      "type",
-      "workflow_name",
-      "workflow_version",
-      "workflow_description"
-    ],
-    "submittable": true,
-    "systemProperties": [
-      "id",
-      "project_id",
-      "created_datetime",
-      "updated_datetime",
-      "state",
-      "file_state",
-      "error_type"
-    ],
-    "title": "Alignment Workflow",
     "type": "object",
     "uniqueKeys": [
       [
@@ -3428,36 +2954,90 @@
         "target_type": "sample"
       }
     ],
-    "namespace": "https://www.bloodpac.org",
     "program": "*",
     "project": "*",
     "properties": {
-      "aliquot_container": {
-        "description": "The device in which the final aliquot is held. Slides or vials.",
-        "enum": [
-          "Serum Card",
-          "Slide",
-          "Vial"
-        ]
-      },
       "aliquot_quantity": {
-        "description": "The quantity in micrograms (ug) of the aliquot derived from the sample and used for experimentation.",
+        "term": {
+          "description": "The quantity in micrograms (ug) of the aliquot(s) derived from the analyte(s) shipped for sequencing and characterization.\n",
+          "termDef": {
+            "cde_id": null,
+            "cde_version": null,
+            "source": null,
+            "term": "Biospecimen Aliquot Quantity",
+            "term_url": null
+          }
+        },
         "type": "number"
       },
       "aliquot_volume": {
-        "description": "The volume in microliters (uL) of the aliquot derived from the sample and used for experimentation.",
+        "term": {
+          "description": "The volume in microliters (ml) of the aliquot(s) derived from the analyte(s) shipped for sequencing and characterization.\n",
+          "termDef": {
+            "cde_id": null,
+            "cde_version": null,
+            "source": null,
+            "term": "Biospecimen Aliquot Volume",
+            "term_url": null
+          }
+        },
         "type": "number"
       },
-      "clinical_or_contrived": {
-        "description": "Is the aliquot clinical or contrived?",
-        "enum": [
-          "Clinical",
-          "Contrived"
-        ]
+      "amount": {
+        "term": {
+          "description": "Weight in grams or volume in mL.\n"
+        },
+        "type": "number"
       },
-      "contrivance_method": {
-        "description": "The name or general description of the contrivance(s) added to the biological aliquot. Alternatively, if you have provided a contrivance protocol, enter its file_name here.\n",
+      "analyte_type": {
+        "term": {
+          "description": "Text term that represents the kind of molecular specimen analyte.\n",
+          "termDef": {
+            "cde_id": 2513915,
+            "cde_version": 2,
+            "source": "caDSR",
+            "term": "Molecular Specimen Type Text Name",
+            "term_url": "https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=2513915&version=2.0"
+          }
+        },
         "type": "string"
+      },
+      "analyte_type_id": {
+        "enum": [
+          "D",
+          "E",
+          "G",
+          "H",
+          "R",
+          "S",
+          "T",
+          "W",
+          "X",
+          "Y"
+        ],
+        "term": {
+          "description": "A single letter code used to identify a type of molecular analyte.\n",
+          "termDef": {
+            "cde_id": 5432508,
+            "cde_version": 1,
+            "source": "caDSR",
+            "term": "Molecular Analyte Identification Code",
+            "term_url": "https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=5432508&version=1.0"
+          }
+        }
+      },
+      "concentration": {
+        "term": {
+          "description": "Numeric value that represents the concentration of an analyte or aliquot extracted from the sample or sample portion, measured in milligrams per milliliter.\n",
+          "termDef": {
+            "cde_id": 5432594,
+            "cde_version": 1,
+            "source": "caDSR",
+            "term": "Biospecimen Analyte or Aliquot Extracted Concentration Milligram per Milliliter Value",
+            "term_url": "https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=5432594&version=1.0"
+          }
+        },
+        "type": "number"
       },
       "created_datetime": {
         "oneOf": [
@@ -3473,42 +3053,6 @@
           "description": "A combination of date and time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]\n"
         }
       },
-      "hours_to_freezer_lower": {
-        "description": "The lower limit on the amount of time, in hours, that it took between the sample being fractionated and the aliquot being frozen or otherwise preserved. If the exact time is known, make this value equal to that of the upper limit. If the time is completely unknown, enter Unknown. If no fractionation was performed on this sample, enter Not Applicable.\n",
-        "oneOf": [
-          {
-            "enum": [
-              "Not Applicable",
-              "Unknown"
-            ]
-          },
-          {
-            "type": "number"
-          }
-        ],
-        "type": [
-          "number",
-          "string"
-        ]
-      },
-      "hours_to_freezer_upper": {
-        "description": "The upper limit on the amount of time, in hours, that it took between the sample being fractionated and the aliquot being frozen or otherwise preserved. If the exact time is known, make this value equal to that of the lower limit. If the time is completely unknown, enter Unknown. If no fractionation was performed on this sample, enter Not Applicable.\n",
-        "oneOf": [
-          {
-            "enum": [
-              "Not Applicable",
-              "Unknown"
-            ]
-          },
-          {
-            "type": "number"
-          }
-        ],
-        "type": [
-          "number",
-          "string"
-        ]
-      },
       "id": {
         "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
         "systemAlias": "node_id",
@@ -3523,31 +3067,6 @@
           }
         },
         "type": "string"
-      },
-      "methanol_added": {
-        "description": "In the preparation of a slide, was methanol added as a fixative? True/False.",
-        "type": "boolean"
-      },
-      "preservation_method": {
-        "enum": [
-          "Cryopreserved",
-          "FFPE",
-          "Fresh",
-          "OCT",
-          "Snap Frozen",
-          "Frozen",
-          "Unknown"
-        ],
-        "term": {
-          "description": "Text term that represents the method used to preserve the sample.\n",
-          "termDef": {
-            "cde_id": 5432521,
-            "cde_version": 1,
-            "source": "caDSR",
-            "term": "Tissue Sample Preservation Method Type",
-            "term_url": "https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=5432521&version=1.0"
-          }
-        }
       },
       "project_id": {
         "term": {
@@ -3610,6 +3129,12 @@
           }
         ]
       },
+      "source_center": {
+        "term": {
+          "description": "Name of the center that provided the item.\n"
+        },
+        "type": "string"
+      },
       "state": {
         "default": "validated",
         "downloadable": [
@@ -3651,14 +3176,11 @@
           "description": "The current state of the object.\n"
         }
       },
-      "storage_temperature": {
-        "description": "The temperature, in centrigrade, at which the aliquot was preserved and/or stored.",
-        "type": "number"
-      },
       "submitter_id": {
-        "description": "A project-specific identifier for a node. This property is the calling card/nickname/alias for a unit of submission. It can be used in place of the UUID for identifying or recalling a node.\n",
+        "description": "The legacy barcode used before prior to the use UUIDs. For TCGA this is bcraliquotbarcode.\n",
         "type": [
-          "string"
+          "string",
+          "null"
         ]
       },
       "type": {
@@ -3681,13 +3203,6 @@
     },
     "required": [
       "submitter_id",
-      "type",
-      "aliquot_container",
-      "clinical_or_contrived",
-      "hours_to_freezer_lower",
-      "hours_to_freezer_upper",
-      "preservation_method",
-      "storage_temperature",
       "samples"
     ],
     "submittable": true,
@@ -3711,1266 +3226,26 @@
     ],
     "validators": []
   },
-  "analyte": {
-    "$schema": "http://json-schema.org/draft-04/schema#",
-    "additionalProperties": false,
-    "category": "biospecimen",
-    "description": "Any aspect of an aliquot used in an analysis or assay to characterize the sample. These aspects range from molecules, such as DNA and RNA, that can be extracted from the aliquot to general descriptions of the aliquot's components, such as cell count and morphology.\n",
-    "id": "analyte",
-    "links": [
-      {
-        "backref": "analytes",
-        "label": "derived_from",
-        "multiplicity": "many_to_many",
-        "name": "aliquots",
-        "required": true,
-        "target_type": "aliquot"
-      },
-      {
-        "backref": "analytes",
-        "label": "analyzed_for",
-        "multiplicity": "many_to_many",
-        "name": "studies",
-        "required": false,
-        "target_type": "study"
-      }
-    ],
-    "namespace": "https://www.bloodpac.org",
-    "program": "*",
-    "project": "*",
-    "properties": {
-      "aliquots": {
-        "anyOf": [
-          {
-            "items": {
-              "additionalProperties": true,
-              "minItems": 1,
-              "properties": {
-                "id": {
-                  "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
-                  "term": {
-                    "description": "A 128-bit identifier. Depending on the mechanism used to generate it, it is either guaranteed to be different from all other UUIDs/GUIDs generated until 3400 AD or extremely likely to be different. Its relatively small size lends itself well to sorting, ordering, and hashing of all sorts, storing in databases, simple allocation, and ease of programming in general.\n",
-                    "termDef": {
-                      "cde_id": "C54100",
-                      "cde_version": null,
-                      "source": "NCIt",
-                      "term": "Universally Unique Identifier",
-                      "term_url": "https://ncit.nci.nih.gov/ncitbrowser/ConceptReport.jsp?dictionary=NCI_Thesaurus&version=16.02d&ns=NCI_Thesaurus&code=C54100"
-                    }
-                  },
-                  "type": "string"
-                },
-                "submitter_id": {
-                  "type": "string"
-                }
-              },
-              "type": "object"
-            },
-            "type": "array"
-          },
-          {
-            "additionalProperties": true,
-            "properties": {
-              "id": {
-                "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
-                "term": {
-                  "description": "A 128-bit identifier. Depending on the mechanism used to generate it, it is either guaranteed to be different from all other UUIDs/GUIDs generated until 3400 AD or extremely likely to be different. Its relatively small size lends itself well to sorting, ordering, and hashing of all sorts, storing in databases, simple allocation, and ease of programming in general.\n",
-                  "termDef": {
-                    "cde_id": "C54100",
-                    "cde_version": null,
-                    "source": "NCIt",
-                    "term": "Universally Unique Identifier",
-                    "term_url": "https://ncit.nci.nih.gov/ncitbrowser/ConceptReport.jsp?dictionary=NCI_Thesaurus&version=16.02d&ns=NCI_Thesaurus&code=C54100"
-                  }
-                },
-                "type": "string"
-              },
-              "submitter_id": {
-                "type": "string"
-              }
-            },
-            "type": "object"
-          }
-        ]
-      },
-      "analyte_isolation_method": {
-        "description": "The name or general description of the method used to isolate the analyte. Alternatively, if you have provided a protocol, put the file_name here.\n",
-        "type": "string"
-      },
-      "analyte_type": {
-        "enum": [
-          "DNA",
-          "RNA",
-          "Peptide",
-          "Protein",
-          "Morphology",
-          "Cell Count"
-        ],
-        "term": {
-          "description": "Text term that represents the kind of molecular specimen analyte.\n",
-          "termDef": {
-            "cde_id": 2513915,
-            "cde_version": 2,
-            "source": "caDSR",
-            "term": "Molecular Specimen Type Text Name",
-            "term_url": "https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=2513915&version=2.0"
-          }
-        }
-      },
-      "cell_identifier": {
-        "description": "The identifying name or number for the cell being identified.\n",
-        "type": "string"
-      },
-      "cell_type": {
-        "description": "In the case of single cell analysis, this is the type of cell being analyzed.\n",
-        "enum": [
-          "All CTC Populations",
-          "Apoptotic CTC",
-          "Biomarker Positive All CTC Populations",
-          "Biomarker Positive Traditional CTC",
-          "Cytokeratin Negative CTC",
-          "Cytokeratin Negative CTC Cluster",
-          "Cytokeratin Positive CTC",
-          "Cytokeratin Positive CTC Cluster",
-          "Nucleated Cell",
-          "Small CTC",
-          "Small CTC Cluster",
-          "Traditional CTC",
-          "Traditional CTC Cluster",
-          "White Blood Cell"
-        ]
-      },
-      "created_datetime": {
-        "oneOf": [
-          {
-            "format": "date-time",
-            "type": "string"
-          },
-          {
-            "type": "null"
-          }
-        ],
-        "term": {
-          "description": "A combination of date and time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]\n"
-        }
-      },
-      "days_to_assay": {
-        "description": "The amount of time, in days, between the date used for index and the assay used to address this analyte.\n",
-        "type": "integer"
-      },
-      "frame_identifier": {
-        "description": "In an analysis of a slide, the frame denotes the region of the slide that is being examined. Within a frame are multiple cells.\n",
-        "type": "string"
-      },
-      "id": {
-        "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
-        "systemAlias": "node_id",
-        "term": {
-          "description": "A 128-bit identifier. Depending on the mechanism used to generate it, it is either guaranteed to be different from all other UUIDs/GUIDs generated until 3400 AD or extremely likely to be different. Its relatively small size lends itself well to sorting, ordering, and hashing of all sorts, storing in databases, simple allocation, and ease of programming in general.\n",
-          "termDef": {
-            "cde_id": "C54100",
-            "cde_version": null,
-            "source": "NCIt",
-            "term": "Universally Unique Identifier",
-            "term_url": "https://ncit.nci.nih.gov/ncitbrowser/ConceptReport.jsp?dictionary=NCI_Thesaurus&version=16.02d&ns=NCI_Thesaurus&code=C54100"
-          }
-        },
-        "type": "string"
-      },
-      "llod": {
-        "description": "The lower limit of detection. lowest quantity of a substance that can be distinguished from the absence of that substance (a blank value) within a stated confidence limit (generally 1%).\n",
-        "oneOf": [
-          {
-            "enum": [
-              "WT"
-            ]
-          },
-          {
-            "type": "number"
-          }
-        ],
-        "type": [
-          "number",
-          "string"
-        ]
-      },
-      "project_id": {
-        "term": {
-          "description": "Unique ID for any specific defined piece of work that is undertaken or attempted to meet a single requirement.\n"
-        },
-        "type": "string"
-      },
-      "run_identifier": {
-        "description": "The identifier given to the run during which this particular analyte was tested or evaluated. If you analyze multiple analytes through the same experimentation run, this is a good way to keep track.\n",
-        "type": "string"
-      },
-      "sensitivity": {
-        "description": "The true positive rate.",
-        "oneOf": [
-          {
-            "enum": [
-              "WT"
-            ]
-          },
-          {
-            "type": "number"
-          }
-        ],
-        "type": [
-          "number",
-          "string"
-        ]
-      },
-      "specificity": {
-        "description": "The true negative rate.",
-        "oneOf": [
-          {
-            "enum": [
-              "WT"
-            ]
-          },
-          {
-            "type": "number"
-          }
-        ],
-        "type": [
-          "number",
-          "string"
-        ]
-      },
-      "state": {
-        "default": "validated",
-        "downloadable": [
-          "uploaded",
-          "md5summed",
-          "validating",
-          "validated",
-          "error",
-          "invalid",
-          "released"
-        ],
-        "oneOf": [
-          {
-            "enum": [
-              "uploading",
-              "uploaded",
-              "md5summing",
-              "md5summed",
-              "validating",
-              "error",
-              "invalid",
-              "suppressed",
-              "redacted",
-              "live"
-            ]
-          },
-          {
-            "enum": [
-              "validated",
-              "submitted",
-              "released"
-            ]
-          }
-        ],
-        "public": [
-          "live"
-        ],
-        "term": {
-          "description": "The current state of the object.\n"
-        }
-      },
-      "studies": {
-        "anyOf": [
-          {
-            "items": {
-              "additionalProperties": true,
-              "minItems": 1,
-              "properties": {
-                "id": {
-                  "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
-                  "term": {
-                    "description": "A 128-bit identifier. Depending on the mechanism used to generate it, it is either guaranteed to be different from all other UUIDs/GUIDs generated until 3400 AD or extremely likely to be different. Its relatively small size lends itself well to sorting, ordering, and hashing of all sorts, storing in databases, simple allocation, and ease of programming in general.\n",
-                    "termDef": {
-                      "cde_id": "C54100",
-                      "cde_version": null,
-                      "source": "NCIt",
-                      "term": "Universally Unique Identifier",
-                      "term_url": "https://ncit.nci.nih.gov/ncitbrowser/ConceptReport.jsp?dictionary=NCI_Thesaurus&version=16.02d&ns=NCI_Thesaurus&code=C54100"
-                    }
-                  },
-                  "type": "string"
-                },
-                "submitter_id": {
-                  "type": "string"
-                }
-              },
-              "type": "object"
-            },
-            "type": "array"
-          },
-          {
-            "additionalProperties": true,
-            "properties": {
-              "id": {
-                "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
-                "term": {
-                  "description": "A 128-bit identifier. Depending on the mechanism used to generate it, it is either guaranteed to be different from all other UUIDs/GUIDs generated until 3400 AD or extremely likely to be different. Its relatively small size lends itself well to sorting, ordering, and hashing of all sorts, storing in databases, simple allocation, and ease of programming in general.\n",
-                  "termDef": {
-                    "cde_id": "C54100",
-                    "cde_version": null,
-                    "source": "NCIt",
-                    "term": "Universally Unique Identifier",
-                    "term_url": "https://ncit.nci.nih.gov/ncitbrowser/ConceptReport.jsp?dictionary=NCI_Thesaurus&version=16.02d&ns=NCI_Thesaurus&code=C54100"
-                  }
-                },
-                "type": "string"
-              },
-              "submitter_id": {
-                "type": "string"
-              }
-            },
-            "type": "object"
-          }
-        ]
-      },
-      "submitter_id": {
-        "description": "A project-specific identifier for a node. This property is the calling card/nickname/alias for a unit of submission. It can be used in place of the UUID for identifying or recalling a node.\n",
-        "type": [
-          "string"
-        ]
-      },
-      "type": {
-        "type": "string"
-      },
-      "updated_datetime": {
-        "oneOf": [
-          {
-            "format": "date-time",
-            "type": "string"
-          },
-          {
-            "type": "null"
-          }
-        ],
-        "term": {
-          "description": "A combination of date and time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]\n"
-        }
-      }
-    },
-    "required": [
-      "submitter_id",
-      "type",
-      "analyte_type",
-      "analyte_isolation_method",
-      "aliquots"
-    ],
-    "submittable": true,
-    "systemProperties": [
-      "id",
-      "project_id",
-      "state",
-      "created_datetime",
-      "updated_datetime"
-    ],
-    "title": "Analyte",
-    "type": "object",
-    "uniqueKeys": [
-      [
-        "id"
-      ],
-      [
-        "project_id",
-        "submitter_id"
-      ]
-    ],
-    "validators": null
-  },
-  "biospecimen": {
-    "$schema": "http://json-schema.org/draft-04/schema#",
-    "additionalProperties": false,
-    "allOf": [
-      {
-        "oneOf": [
-          {
-            "required": [
-              "days_to_collection"
-            ]
-          },
-          {
-            "required": [
-              "days_to_collection_not_reported"
-            ]
-          }
-        ]
-      },
-      {
-        "oneOf": [
-          {
-            "required": [
-              "days_to_procurement"
-            ]
-          },
-          {
-            "required": [
-              "days_to_procurement_not_reported"
-            ]
-          }
-        ]
-      }
-    ],
-    "category": "biospecimen",
-    "description": "Any material sample taken from a biological entity for testing, diagnostic, propagation, treatment or research purposes, including a sample obtained from a living organism or taken from the biological object after halting of all its life functions. Biospecimen can contain one or more components including but not limited to cellular molecules, cells, tissues, organs, body fluids, embryos, and body excretory products. In the case of contrived samples, it describes any material obtained from a normal donor. Link this record to the followup node in order to record patient context variables related to blood draws or biospecimen collection.\n",
-    "id": "biospecimen",
-    "links": [
-      {
-        "backref": "biospecimens",
-        "label": "derived_from",
-        "multiplicity": "many_to_one",
-        "name": "cases",
-        "required": true,
-        "target_type": "case"
-      },
-      {
-        "backref": "biospecimens",
-        "label": "derived_from",
-        "multiplicity": "many_to_one",
-        "name": "followups",
-        "required": false,
-        "target_type": "followup"
-      }
-    ],
-    "namespace": "https://www.bloodpac.org",
-    "program": "*",
-    "project": "*",
-    "properties": {
-      "biospecimen_anatomic_site": {
-        "enum": [
-          "Abdomen",
-          "Abdominal Wall",
-          "Acetabulum",
-          "Adenoid",
-          "Adipose",
-          "Adrenal",
-          "Alveolar Ridge",
-          "Amniotic Fluid",
-          "Ampulla of Vater",
-          "Anal Sphincter",
-          "Ankle",
-          "Anorectum",
-          "Antecubital Fossa",
-          "Antrum",
-          "Anus",
-          "Aorta",
-          "Aortic Body",
-          "Appendix",
-          "Aqueous Fluid",
-          "Arm",
-          "Artery",
-          "Ascending Colon",
-          "Ascending Colon Hepatic Flexure",
-          "Auditory Canal",
-          "Autonomic Nervous System",
-          "Axilla",
-          "Back",
-          "Bile Duct",
-          "Bladder",
-          "Blood",
-          "Blood Vessel",
-          "Bone",
-          "Bone Marrow",
-          "Bowel",
-          "Brain",
-          "Brain Stem",
-          "Breast",
-          "Broad Ligament",
-          "Bronchiole",
-          "Bronchus",
-          "Brow",
-          "Buccal Cavity",
-          "Buccal Mucosa",
-          "Buttock",
-          "Calf",
-          "Capillary",
-          "Cardia",
-          "Carina",
-          "Carotid Artery",
-          "Carotid Body",
-          "Cartilage",
-          "Cecum",
-          "Cell-Line",
-          "Central Nervous System",
-          "Cerebellum",
-          "Cerebral Cortex",
-          "Cerebrospinal Fluid",
-          "Cerebrum",
-          "Cervical Spine",
-          "Cervix",
-          "Chest",
-          "Chest Wall",
-          "Chin",
-          "Clavicle",
-          "Clitoris",
-          "Colon",
-          "Colon (Mucosa Only)",
-          "Common Duct",
-          "Conjunctiva",
-          "Connective Tissue",
-          "Dermal",
-          "Descending Colon",
-          "Diaphragm",
-          "Duodenum",
-          "Ear",
-          "Ear Canal",
-          "Ear, Pinna (External)",
-          "Effusion",
-          "Elbow",
-          "Endocrine Gland",
-          "Epididymis",
-          "Epidural Space",
-          "Esophagogastric Junction",
-          "Esophagus",
-          "Esophagus (Mucosa Only)",
-          "Eye",
-          "Fallopian Tube",
-          "Femoral Artery",
-          "Femoral Vein",
-          "Femur",
-          "Fibroblasts",
-          "Fibula",
-          "Finger",
-          "Floor of Mouth",
-          "Fluid",
-          "Foot",
-          "Forearm",
-          "Forehead",
-          "Foreskin",
-          "Frontal Cortex",
-          "Frontal Lobe",
-          "Fundus of Stomach",
-          "Gallbladder",
-          "Ganglia",
-          "Gastroesophageal Junction",
-          "Gastrointestinal Tract",
-          "Groin",
-          "Gum",
-          "Hand",
-          "Hard Palate",
-          "Head and Neck",
-          "Head (Face Or Neck) NOS",
-          "Heart",
-          "Hepatic",
-          "Hepatic Duct",
-          "Hepatic Vein",
-          "Hip",
-          "Hippocampus",
-          "Humerus",
-          "Hypopharynx",
-          "Ileum",
-          "Ilium",
-          "Index Finger",
-          "Ischium",
-          "Islet Cells",
-          "Jaw",
-          "Jejunum",
-          "Joint",
-          "Kidney",
-          "Knee",
-          "Lacrimal Gland",
-          "Large Bowel",
-          "Laryngopharynx",
-          "Larynx",
-          "Leg",
-          "Leptomeninges",
-          "Ligament",
-          "Lip",
-          "Liver",
-          "Lumbar Spine",
-          "Lung",
-          "Lymph Node",
-          "Lymph Node(s) Axilla",
-          "Lymph Node(s) Cervical",
-          "Lymph Node(s) Distant",
-          "Lymph Node(s) Epitrochlear",
-          "Lymph Node(s) Femoral",
-          "Lymph Node(s) Hilar",
-          "Lymph Node(s) Iliac-Common",
-          "Lymph Node(s) Iliac-External",
-          "Lymph Node(s) Inguinal",
-          "Lymph Node(s) Internal Mammary",
-          "Lymph Node(s) Mammary",
-          "Lymph Node(s) Mesenteric",
-          "Lymph Node(s) Occipital",
-          "Lymph Node(s) Paraaortic",
-          "Lymph Node(s) Parotid",
-          "Lymph Node(s) Pelvic",
-          "Lymph Node(s) Popliteal",
-          "Lymph Node(s) Regional",
-          "Lymph Node(s) Retroperitoneal",
-          "Lymph Node(s) Scalene",
-          "Lymph Node(s) Splenic",
-          "Lymph Node(s) Subclavicular",
-          "Lymph Node(s) Submandibular",
-          "Lymph Node(s) Supraclavicular",
-          "Lymph Nodes(s) Mediastinal",
-          "Mandible",
-          "Maxilla",
-          "Mediastinal Soft Tissue",
-          "Mediastinum",
-          "Mesentery",
-          "Mesothelium",
-          "Middle Finger",
-          "Mitochondria",
-          "Muscle",
-          "Nails",
-          "Nasal Cavity",
-          "Nasal Soft Tissue",
-          "Nasopharynx",
-          "Neck",
-          "Nerve",
-          "Nerve(s) Cranial",
-          "Occipital Cortex",
-          "Ocular Orbits",
-          "Omentum",
-          "Oral Cavity",
-          "Oral Cavity (Mucosa Only)",
-          "Oropharynx",
-          "Other",
-          "Ovary",
-          "Palate",
-          "Pancreas",
-          "Paraspinal Ganglion",
-          "Parathyroid",
-          "Parotid Gland",
-          "Patella",
-          "Pelvis",
-          "Penis",
-          "Pericardium",
-          "Periorbital Soft Tissue",
-          "Peritoneal Cavity",
-          "Peritoneum",
-          "Pharynx",
-          "Pineal",
-          "Pineal Gland",
-          "Pituitary Gland",
-          "Placenta",
-          "Pleura",
-          "Popliteal Fossa",
-          "Prostate",
-          "Pylorus",
-          "Rectosigmoid Junction",
-          "Rectum",
-          "Retina",
-          "Retro-Orbital Region",
-          "Retroperitoneum",
-          "Rib",
-          "Ring Finger",
-          "Round Ligament",
-          "Sacrum",
-          "Salivary Gland",
-          "Scalp",
-          "Scapula",
-          "Sciatic Nerve",
-          "Scrotum",
-          "Seminal Vesicle",
-          "Shoulder",
-          "Sigmoid Colon",
-          "Sinus",
-          "Sinus(es), Maxillary",
-          "Skeletal Muscle",
-          "Skin",
-          "Skull",
-          "Small Bowel",
-          "Small Bowel (Mucosa Only)",
-          "Small Finger",
-          "Soft Tissue",
-          "Spinal Column",
-          "Spinal Cord",
-          "Spleen",
-          "Splenic Flexure",
-          "Sternum",
-          "Stomach",
-          "Stomach (Mucosa Only)",
-          "Subcutaneous Tissue",
-          "Synovium",
-          "Temporal Cortex",
-          "Tendon",
-          "Testis",
-          "Thigh",
-          "Thoracic Spine",
-          "Thorax",
-          "Throat",
-          "Thumb",
-          "Thymus",
-          "Thyroid",
-          "Tibia",
-          "Tongue",
-          "Tonsil",
-          "Tonsil (Pharyngeal)",
-          "Trachea Major Bronchi",
-          "Transverse Colon",
-          "Trunk",
-          "Umbilical Cord",
-          "Ureter",
-          "Urethra",
-          "Urinary Tract",
-          "Uterus",
-          "Uvula",
-          "Vagina",
-          "Vas Deferens",
-          "Vein",
-          "Venous",
-          "Vertebra",
-          "Vulva",
-          "White Blood Cells",
-          "Wrist",
-          "Unknown"
-        ],
-        "term": {
-          "description": "Text term that represents the name of the primary disease site of the submitted tumor sample.\n",
-          "termDef": {
-            "cde_id": 4742851,
-            "cde_version": 1,
-            "source": "caDSR",
-            "term": "Submitted Tumor Sample Primary Anatomic Site",
-            "term_url": "https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=4742851&version=1.0"
-          }
-        }
-      },
-      "biospecimen_type": {
-        "description": "A top level description of the biospecimen. Is the biospecimen a fluid or solid tissue?\n",
-        "enum": [
-          "Fluid",
-          "Solid Tissue"
-        ]
-      },
-      "biospecimen_volume": {
-        "description": "For fluid biospecimens this is the total volume in milliliters.\n",
-        "type": "number"
-      },
-      "biospecimen_weight": {
-        "description": "For solid tissue biospecimens this is the total weight in milligrams.\n",
-        "type": "number"
-      },
-      "blood_draw_method": {
-        "description": "The name or generalized description of the method used to draw a blood biospecimen. Alternatively, if you have provided a blood draw protocol, put the associated file_name here.\n",
-        "type": "string"
-      },
-      "blood_tube_type": {
-        "description": "The kind of tube used to collect the sample(s) taken from a biological entity for testing, diagnostic, propagation, treatment or research purposes.\n",
-        "enum": [
-          "EDTA",
-          "CellSave",
-          "Streck",
-          "Acid Citrate Dextrose (ACD)",
-          "Not Applicable",
-          "Unknown"
-        ]
-      },
-      "cases": {
-        "anyOf": [
-          {
-            "items": {
-              "additionalProperties": true,
-              "maxItems": 1,
-              "minItems": 1,
-              "properties": {
-                "id": {
-                  "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
-                  "term": {
-                    "description": "A 128-bit identifier. Depending on the mechanism used to generate it, it is either guaranteed to be different from all other UUIDs/GUIDs generated until 3400 AD or extremely likely to be different. Its relatively small size lends itself well to sorting, ordering, and hashing of all sorts, storing in databases, simple allocation, and ease of programming in general.\n",
-                    "termDef": {
-                      "cde_id": "C54100",
-                      "cde_version": null,
-                      "source": "NCIt",
-                      "term": "Universally Unique Identifier",
-                      "term_url": "https://ncit.nci.nih.gov/ncitbrowser/ConceptReport.jsp?dictionary=NCI_Thesaurus&version=16.02d&ns=NCI_Thesaurus&code=C54100"
-                    }
-                  },
-                  "type": "string"
-                },
-                "submitter_id": {
-                  "type": "string"
-                }
-              },
-              "type": "object"
-            },
-            "type": "array"
-          },
-          {
-            "additionalProperties": true,
-            "properties": {
-              "id": {
-                "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
-                "term": {
-                  "description": "A 128-bit identifier. Depending on the mechanism used to generate it, it is either guaranteed to be different from all other UUIDs/GUIDs generated until 3400 AD or extremely likely to be different. Its relatively small size lends itself well to sorting, ordering, and hashing of all sorts, storing in databases, simple allocation, and ease of programming in general.\n",
-                  "termDef": {
-                    "cde_id": "C54100",
-                    "cde_version": null,
-                    "source": "NCIt",
-                    "term": "Universally Unique Identifier",
-                    "term_url": "https://ncit.nci.nih.gov/ncitbrowser/ConceptReport.jsp?dictionary=NCI_Thesaurus&version=16.02d&ns=NCI_Thesaurus&code=C54100"
-                  }
-                },
-                "type": "string"
-              },
-              "submitter_id": {
-                "type": "string"
-              }
-            },
-            "type": "object"
-          }
-        ]
-      },
-      "clinical_site": {
-        "description": "The name or identifier for the clinical site at which the biospecimen was taken from the patient.\n",
-        "type": "string"
-      },
-      "collaboration_id": {
-        "description": "In cases where the same biospecimen is used by multiple institutions, a deidenfitied id may provided here to tie those together. Work with your collaborators assure the same id is in all projects.\n",
-        "type": "string"
-      },
-      "created_datetime": {
-        "oneOf": [
-          {
-            "format": "date-time",
-            "type": "string"
-          },
-          {
-            "type": "null"
-          }
-        ],
-        "term": {
-          "description": "A combination of date and time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]\n"
-        }
-      },
-      "days_to_collection": {
-        "description": "The number of days between the index date and the date the biospecimen was collected at laboratory.\n",
-        "type": "integer"
-      },
-      "days_to_collection_not_reported": {
-        "description": "True/False indicator of whether the number of days between the index date and the date the biospecimen was collected at laboratory is reported.\n",
-        "type": "boolean"
-      },
-      "days_to_procurement": {
-        "description": "The number of days between the index date and the date the biospecimen was taken from the patient (such as the blood draw).\n",
-        "type": "integer"
-      },
-      "days_to_procurement_not_reported": {
-        "description": "True/False indicator of whether the number of days between the index date and the date the biospecimen was taken from the patient is reported.\n",
-        "type": "boolean"
-      },
-      "disease_type": {
-        "description": "The primary disease of the patient from which the biospecimen was taken.\n",
-        "enum": [
-          "Blood Cancer",
-          "Breast Cancer",
-          "Colorectal Cancer",
-          "Gastric Cancer",
-          "Kidney Cancer",
-          "Liver Cancer",
-          "Lung Cancer",
-          "Melanoma",
-          "Ovarian Cancer",
-          "Pancreatic Cancer",
-          "Prostate Cancer",
-          "Sarcoma",
-          "Uterine Cancer",
-          "Healthy",
-          "Unknown"
-        ]
-      },
-      "followups": {
-        "anyOf": [
-          {
-            "items": {
-              "additionalProperties": true,
-              "maxItems": 1,
-              "minItems": 1,
-              "properties": {
-                "id": {
-                  "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
-                  "term": {
-                    "description": "A 128-bit identifier. Depending on the mechanism used to generate it, it is either guaranteed to be different from all other UUIDs/GUIDs generated until 3400 AD or extremely likely to be different. Its relatively small size lends itself well to sorting, ordering, and hashing of all sorts, storing in databases, simple allocation, and ease of programming in general.\n",
-                    "termDef": {
-                      "cde_id": "C54100",
-                      "cde_version": null,
-                      "source": "NCIt",
-                      "term": "Universally Unique Identifier",
-                      "term_url": "https://ncit.nci.nih.gov/ncitbrowser/ConceptReport.jsp?dictionary=NCI_Thesaurus&version=16.02d&ns=NCI_Thesaurus&code=C54100"
-                    }
-                  },
-                  "type": "string"
-                },
-                "submitter_id": {
-                  "type": "string"
-                }
-              },
-              "type": "object"
-            },
-            "type": "array"
-          },
-          {
-            "additionalProperties": true,
-            "properties": {
-              "id": {
-                "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
-                "term": {
-                  "description": "A 128-bit identifier. Depending on the mechanism used to generate it, it is either guaranteed to be different from all other UUIDs/GUIDs generated until 3400 AD or extremely likely to be different. Its relatively small size lends itself well to sorting, ordering, and hashing of all sorts, storing in databases, simple allocation, and ease of programming in general.\n",
-                  "termDef": {
-                    "cde_id": "C54100",
-                    "cde_version": null,
-                    "source": "NCIt",
-                    "term": "Universally Unique Identifier",
-                    "term_url": "https://ncit.nci.nih.gov/ncitbrowser/ConceptReport.jsp?dictionary=NCI_Thesaurus&version=16.02d&ns=NCI_Thesaurus&code=C54100"
-                  }
-                },
-                "type": "string"
-              },
-              "submitter_id": {
-                "type": "string"
-              }
-            },
-            "type": "object"
-          }
-        ]
-      },
-      "id": {
-        "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
-        "systemAlias": "node_id",
-        "term": {
-          "description": "A 128-bit identifier. Depending on the mechanism used to generate it, it is either guaranteed to be different from all other UUIDs/GUIDs generated until 3400 AD or extremely likely to be different. Its relatively small size lends itself well to sorting, ordering, and hashing of all sorts, storing in databases, simple allocation, and ease of programming in general.\n",
-          "termDef": {
-            "cde_id": "C54100",
-            "cde_version": null,
-            "source": "NCIt",
-            "term": "Universally Unique Identifier",
-            "term_url": "https://ncit.nci.nih.gov/ncitbrowser/ConceptReport.jsp?dictionary=NCI_Thesaurus&version=16.02d&ns=NCI_Thesaurus&code=C54100"
-          }
-        },
-        "type": "string"
-      },
-      "metastatic_bone": {
-        "description": "True/False indicator of whether metastasis had been confirmed in an area of bone of the patient from which the biospecimen was taken.\n",
-        "type": "boolean"
-      },
-      "metastatic_lymph_node": {
-        "description": "True/False indicator of whether metastasis had been confirmed in the lymph nodes of the patient from which the biospecimen was taken.\n",
-        "type": "boolean"
-      },
-      "metastatic_visceral": {
-        "description": "True/False indicator of whether metastasis had been confirmed in the viscera of the patient from which the biospecimen was taken.\n",
-        "type": "boolean"
-      },
-      "method_of_procurement": {
-        "enum": [
-          "Biopsy",
-          "Blood Draw",
-          "Not Applicable",
-          "Unknown"
-        ],
-        "term": {
-          "description": "The method used to procure the sample used to extract analyte(s).\n",
-          "termDef": {
-            "cde_id": null,
-            "cde_version": null,
-            "source": null,
-            "term": "Method of Sample Procurement",
-            "term_url": null
-          }
-        }
-      },
-      "primary_site": {
-        "description": "The site of the primary tumor for the patient from which the biospecimen was taken.\n",
-        "enum": [
-          "Bone",
-          "Bone Marrow",
-          "Brain",
-          "Breast",
-          "Central Nervous System",
-          "Cervix",
-          "Colorectal",
-          "Corpus Uteri",
-          "Digestive Organs",
-          "Endocrine Gland",
-          "Esophagus",
-          "Eye",
-          "Female Genital Organs",
-          "Head and Neck",
-          "Hematopoietic System",
-          "Integumentary System",
-          "Joints and Articular Cartilage",
-          "Kidney",
-          "Liver",
-          "Lung",
-          "Lymph Node",
-          "Male Genital Organs",
-          "Other Sites",
-          "Ovary",
-          "Pancreas",
-          "Pleura",
-          "Prostate",
-          "Retroperitoneum and Peritoneum",
-          "Skin",
-          "Soft Tissue",
-          "Stomach",
-          "Testis",
-          "Thoracic Organs",
-          "Thymus",
-          "Thyroid",
-          "Unknown",
-          "Urinary System",
-          "Uterus"
-        ]
-      },
-      "procured_or_purchased": {
-        "description": "Was the biospecimen purchased from a vendor or procured from a study participant.\n",
-        "enum": [
-          "Procured",
-          "Purchased"
-        ]
-      },
-      "procurement_temperature": {
-        "description": "The temperature, in centigrade, at which the biospecimen was kept after procuring it from the patient. Use 20 for room temperature; 0 for on ice.\n",
-        "type": "number"
-      },
-      "project_id": {
-        "term": {
-          "description": "Unique ID for any specific defined piece of work that is undertaken or attempted to meet a single requirement.\n"
-        },
-        "type": "string"
-      },
-      "shipping_temperature": {
-        "description": "The temperature, in centigrade, at which the biospecimen was kept while it was being transported from the procurement site to its processing destination.\n",
-        "type": "number"
-      },
-      "state": {
-        "default": "validated",
-        "downloadable": [
-          "uploaded",
-          "md5summed",
-          "validating",
-          "validated",
-          "error",
-          "invalid",
-          "released"
-        ],
-        "oneOf": [
-          {
-            "enum": [
-              "uploading",
-              "uploaded",
-              "md5summing",
-              "md5summed",
-              "validating",
-              "error",
-              "invalid",
-              "suppressed",
-              "redacted",
-              "live"
-            ]
-          },
-          {
-            "enum": [
-              "validated",
-              "submitted",
-              "released"
-            ]
-          }
-        ],
-        "public": [
-          "live"
-        ],
-        "term": {
-          "description": "The current state of the object.\n"
-        }
-      },
-      "submitter_id": {
-        "description": "A project-specific identifier for a node. This property is the calling card/nickname/alias for a unit of submission. It can be used in place of the UUID for identifying or recalling a node.\n",
-        "type": [
-          "string"
-        ]
-      },
-      "tissue_type": {
-        "enum": [
-          "Tumor",
-          "Normal",
-          "Abnormal",
-          "Peritumoral",
-          "Unknown"
-        ],
-        "term": {
-          "description": "Text term that represents a description of the kind of tissue collected with respect to disease status or proximity to tumor tissue.\n",
-          "termDef": {
-            "cde_id": 5432687,
-            "cde_version": 1,
-            "source": "caDSR",
-            "term": "Tissue Sample Description Type",
-            "term_url": "https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=5432687&version=1.0"
-          }
-        }
-      },
-      "tumor_code": {
-        "enum": [
-          "Acinar Cell Neoplasms",
-          "Adenomas and Adenocarcinomas",
-          "Adnexal and Skin Appendage Neoplasms",
-          "Basal Cell Neoplasms",
-          "Blood Vessel Tumors",
-          "Chronic Myeloproliferative Disorders",
-          "Complex Epithelial Neoplasms",
-          "Complex Mixed and Stromal Neoplasms",
-          "Cystic, Mucinous and Serous Neoplasms",
-          "Ductal and Lobular Neoplams",
-          "Epithelial Neoplasms, NOS",
-          "Fibroepithelial Neoplasms",
-          "Fibromatous Neoplasms",
-          "Germ Cell Neoplasms",
-          "Giant Cell Tumors",
-          "Gliomas",
-          "Granular Cell Tumors and Alveolar Soft Part Sarcomas",
-          "Hodgkin Lymphoma",
-          "Immunoproliferative Disease",
-          "Leukemias, NOS",
-          "Lipomatous Neoplasms",
-          "Lymphatic Vessel Tumors",
-          "Lymphoid Leukemias",
-          "Malignant Lymphomas, NOS or Diffuse",
-          "Mast Cell Tumors",
-          "Mature B-Cell Lymphomas",
-          "Mature T- and NK-Cell Lymphomas",
-          "Meningiomas",
-          "Mesonephromas",
-          "Mesothelial Neoplasms",
-          "Miscellaneous Bone Tumors",
-          "Miscellaneous Tumors",
-          "Mucoepidermoid Neoplasms",
-          "Myelodysplastic Syndromes",
-          "Myeloid Leukemias",
-          "Myomatous Neoplasms",
-          "Myxomatous Neoplasms",
-          "Neoplasms",
-          "Neoplasms of Histiocytes and Accessory Lymphoid Cells",
-          "Nerve Sheath Tumors",
-          "Neuroepitheliomatous Neoplasms",
-          "Nevi and Melanomas",
-          "Odontogenic Tumors",
-          "Osseous and Chondromatous Neoplasms",
-          "Other Hematologic Disorders",
-          "Other Leukemias",
-          "Paragangliomas and Glomus Tumors",
-          "Plasma Cell Tumors",
-          "Precursor Cell Lymphoblastic Lymphoma",
-          "Soft Tissue Tumors and Sarcomas, NOS",
-          "Specialized Gonadal Neoplasms",
-          "Squamous Cell Neoplasms",
-          "Synovial-like Neoplasms",
-          "Thymic Epithelial Neoplasms",
-          "Transitional Cell Papillomas and Carcinomas",
-          "Non Cancerous Tissue"
-        ],
-        "term": {
-          "description": "A specification of a cancer through cellular origin and localization.\n"
-        }
-      },
-      "tumor_descriptor": {
-        "enum": [
-          "Metastatic",
-          "Not Applicable",
-          "Primary",
-          "Recurrence",
-          "Xenograft",
-          "NOS",
-          "Unknown"
-        ],
-        "term": {
-          "description": "Text that describes the kind of disease present in the tumor specimen as related to a specific timepoint.\n",
-          "termDef": {
-            "cde_id": 3288124,
-            "cde_version": 1,
-            "source": "caDSR",
-            "term": "Tumor Tissue Disease Description Type",
-            "term_url": "https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=3288124&version=1.0"
-          }
-        }
-      },
-      "tumor_morphology": {
-        "description": "The specific description of the tumor morphology. Please use the ICD-0-3 code name (e.g. \"Neoplasm, benign\", \"Carcinoma, Nos\", or \"Hepatocellular adenoma\").\n",
-        "type": "string"
-      },
-      "type": {
-        "type": "string"
-      },
-      "updated_datetime": {
-        "oneOf": [
-          {
-            "format": "date-time",
-            "type": "string"
-          },
-          {
-            "type": "null"
-          }
-        ],
-        "term": {
-          "description": "A combination of date and time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]\n"
-        }
-      }
-    },
-    "required": [
-      "submitter_id",
-      "type",
-      "cases",
-      "biospecimen_type",
-      "biospecimen_anatomic_site",
-      "blood_tube_type",
-      "method_of_procurement",
-      "procured_or_purchased",
-      "tissue_type"
-    ],
-    "submittable": true,
-    "systemProperties": [
-      "id",
-      "project_id",
-      "state",
-      "created_datetime",
-      "updated_datetime"
-    ],
-    "title": "Biospecimen",
-    "type": "object",
-    "uniqueKeys": [
-      [
-        "id"
-      ],
-      [
-        "project_id",
-        "submitter_id"
-      ]
-    ],
-    "validators": null
-  },
   "case": {
     "$schema": "http://json-schema.org/draft-04/schema#",
     "additionalProperties": false,
     "category": "administrative",
-    "description": "The collection of all data related to a specific subject in the context of a specific experiment.\n",
+    "description": "The collection of all data related to a specific subject in the context of a specific experiment. \n",
     "id": "case",
     "links": [
       {
         "backref": "cases",
         "label": "member_of",
-        "multiplicity": "many_to_many",
-        "name": "studies",
+        "multiplicity": "many_to_one",
+        "name": "experiments",
         "required": true,
-        "target_type": "study"
+        "target_type": "experiment"
       }
     ],
-    "namespace": "https://www.bloodpac.org",
+    "namespace": "http://gdc.nci.nih.gov",
     "program": "*",
     "project": "*",
     "properties": {
-      "collaboration_id": {
-        "description": "For instances in which multiple institutions use the same patient for their respective studies, this space is used as a place to enter in the de-identified barcode, id, or other identifier for the patient. Work with your collaborators to decide on the patient's id.\n",
-        "type": "string"
-      },
       "created_datetime": {
         "oneOf": [
           {
@@ -4985,94 +3260,16 @@
           "description": "A combination of date and time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]\n"
         }
       },
-      "days_to_lost_to_followup": {
-        "description": "The number of days between the date used for index and the date the patient was lost to follow-up.\n",
-        "type": "integer"
-      },
-      "id": {
-        "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
-        "systemAlias": "node_id",
-        "term": {
-          "description": "A 128-bit identifier. Depending on the mechanism used to generate it, it is either guaranteed to be different from all other UUIDs/GUIDs generated until 3400 AD or extremely likely to be different. Its relatively small size lends itself well to sorting, ordering, and hashing of all sorts, storing in databases, simple allocation, and ease of programming in general.\n",
-          "termDef": {
-            "cde_id": "C54100",
-            "cde_version": null,
-            "source": "NCIt",
-            "term": "Universally Unique Identifier",
-            "term_url": "https://ncit.nci.nih.gov/ncitbrowser/ConceptReport.jsp?dictionary=NCI_Thesaurus&version=16.02d&ns=NCI_Thesaurus&code=C54100"
-          }
-        },
+      "disease_type": {
+        "description": "Name of the disease for the case.",
         "type": "string"
       },
-      "index_date": {
-        "description": "The reference or anchor date used during date obfuscation, where a single date is obscured by creating one or more date ranges in relation to this date.\n",
-        "enum": [
-          "Diagnosis",
-          "First Patient Visit",
-          "Study Enrollment",
-          "Not Applicable"
-        ]
-      },
-      "lost_to_followup": {
-        "description": "A yes/no indicator related to whether a patient was unable to be contacted for follow-up.\n",
-        "enum": [
-          "Yes",
-          "No",
-          "Not Applicable"
-        ]
-      },
-      "project_id": {
-        "term": {
-          "description": "Unique ID for any specific defined piece of work that is undertaken or attempted to meet a single requirement.\n"
-        },
-        "type": "string"
-      },
-      "state": {
-        "default": "validated",
-        "downloadable": [
-          "uploaded",
-          "md5summed",
-          "validating",
-          "validated",
-          "error",
-          "invalid",
-          "released"
-        ],
-        "oneOf": [
-          {
-            "enum": [
-              "uploading",
-              "uploaded",
-              "md5summing",
-              "md5summed",
-              "validating",
-              "error",
-              "invalid",
-              "suppressed",
-              "redacted",
-              "live"
-            ]
-          },
-          {
-            "enum": [
-              "validated",
-              "submitted",
-              "released"
-            ]
-          }
-        ],
-        "public": [
-          "live"
-        ],
-        "term": {
-          "description": "The current state of the object.\n"
-        }
-      },
-      "studies": {
+      "experiments": {
         "anyOf": [
           {
             "items": {
               "additionalProperties": true,
+              "maxItems": 1,
               "minItems": 1,
               "properties": {
                 "id": {
@@ -5122,10 +3319,76 @@
           }
         ]
       },
+      "id": {
+        "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
+        "systemAlias": "node_id",
+        "term": {
+          "description": "A 128-bit identifier. Depending on the mechanism used to generate it, it is either guaranteed to be different from all other UUIDs/GUIDs generated until 3400 AD or extremely likely to be different. Its relatively small size lends itself well to sorting, ordering, and hashing of all sorts, storing in databases, simple allocation, and ease of programming in general.\n",
+          "termDef": {
+            "cde_id": "C54100",
+            "cde_version": null,
+            "source": "NCIt",
+            "term": "Universally Unique Identifier",
+            "term_url": "https://ncit.nci.nih.gov/ncitbrowser/ConceptReport.jsp?dictionary=NCI_Thesaurus&version=16.02d&ns=NCI_Thesaurus&code=C54100"
+          }
+        },
+        "type": "string"
+      },
+      "primary_site": {
+        "description": "Primary site for the case.",
+        "type": "string"
+      },
+      "project_id": {
+        "term": {
+          "description": "Unique ID for any specific defined piece of work that is undertaken or attempted to meet a single requirement.\n"
+        },
+        "type": "string"
+      },
+      "state": {
+        "default": "validated",
+        "downloadable": [
+          "uploaded",
+          "md5summed",
+          "validating",
+          "validated",
+          "error",
+          "invalid",
+          "released"
+        ],
+        "oneOf": [
+          {
+            "enum": [
+              "uploading",
+              "uploaded",
+              "md5summing",
+              "md5summed",
+              "validating",
+              "error",
+              "invalid",
+              "suppressed",
+              "redacted",
+              "live"
+            ]
+          },
+          {
+            "enum": [
+              "validated",
+              "submitted",
+              "released"
+            ]
+          }
+        ],
+        "public": [
+          "live"
+        ],
+        "term": {
+          "description": "The current state of the object.\n"
+        }
+      },
       "submitter_id": {
-        "description": "A project-specific identifier for a node. This property is the calling card/nickname/alias for a unit of submission. It can be used in place of the UUID for identifying or recalling a node.\n",
         "type": [
-          "string"
+          "string",
+          "null"
         ]
       },
       "type": {
@@ -5148,9 +3411,7 @@
     },
     "required": [
       "submitter_id",
-      "type",
-      "index_date",
-      "studies"
+      "experiments"
     ],
     "submittable": true,
     "systemProperties": [
@@ -5173,382 +3434,96 @@
     ],
     "validators": null
   },
-  "cell_image": {
+  "clinical_test": {
     "$schema": "http://json-schema.org/draft-04/schema#",
     "additionalProperties": false,
-    "category": "data_file",
-    "description": "Data file containing image of a single cell from a slide.\n",
-    "id": "cell_image",
-    "links": [
-      {
-        "exclusive": false,
-        "required": true,
-        "subgroup": [
-          {
-            "backref": "cell_images",
-            "label": "data_from",
-            "multiplicity": "one_to_one",
-            "name": "core_metadata_collections",
-            "required": false,
-            "target_type": "core_metadata_collection"
-          },
-          {
-            "backref": "cell_images",
-            "label": "data_from",
-            "multiplicity": "one_to_one",
-            "name": "analytes",
-            "required": false,
-            "target_type": "analyte"
-          }
-        ]
-      }
-    ],
-    "namespace": "https://www.bloodpac.org",
-    "program": "*",
-    "project": "*",
-    "properties": {
-      "analytes": {
-        "anyOf": [
-          {
-            "items": {
-              "additionalProperties": true,
-              "maxItems": 1,
-              "minItems": 1,
-              "properties": {
-                "id": {
-                  "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
-                  "term": {
-                    "description": "A 128-bit identifier. Depending on the mechanism used to generate it, it is either guaranteed to be different from all other UUIDs/GUIDs generated until 3400 AD or extremely likely to be different. Its relatively small size lends itself well to sorting, ordering, and hashing of all sorts, storing in databases, simple allocation, and ease of programming in general.\n",
-                    "termDef": {
-                      "cde_id": "C54100",
-                      "cde_version": null,
-                      "source": "NCIt",
-                      "term": "Universally Unique Identifier",
-                      "term_url": "https://ncit.nci.nih.gov/ncitbrowser/ConceptReport.jsp?dictionary=NCI_Thesaurus&version=16.02d&ns=NCI_Thesaurus&code=C54100"
-                    }
-                  },
-                  "type": "string"
-                },
-                "submitter_id": {
-                  "type": "string"
-                }
-              },
-              "type": "object"
-            },
-            "type": "array"
-          },
-          {
-            "additionalProperties": true,
-            "properties": {
-              "id": {
-                "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
-                "term": {
-                  "description": "A 128-bit identifier. Depending on the mechanism used to generate it, it is either guaranteed to be different from all other UUIDs/GUIDs generated until 3400 AD or extremely likely to be different. Its relatively small size lends itself well to sorting, ordering, and hashing of all sorts, storing in databases, simple allocation, and ease of programming in general.\n",
-                  "termDef": {
-                    "cde_id": "C54100",
-                    "cde_version": null,
-                    "source": "NCIt",
-                    "term": "Universally Unique Identifier",
-                    "term_url": "https://ncit.nci.nih.gov/ncitbrowser/ConceptReport.jsp?dictionary=NCI_Thesaurus&version=16.02d&ns=NCI_Thesaurus&code=C54100"
-                  }
-                },
-                "type": "string"
-              },
-              "submitter_id": {
-                "type": "string"
-              }
-            },
-            "type": "object"
-          }
-        ]
-      },
-      "core_metadata_collections": {
-        "anyOf": [
-          {
-            "items": {
-              "additionalProperties": true,
-              "maxItems": 1,
-              "minItems": 1,
-              "properties": {
-                "id": {
-                  "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
-                  "term": {
-                    "description": "A 128-bit identifier. Depending on the mechanism used to generate it, it is either guaranteed to be different from all other UUIDs/GUIDs generated until 3400 AD or extremely likely to be different. Its relatively small size lends itself well to sorting, ordering, and hashing of all sorts, storing in databases, simple allocation, and ease of programming in general.\n",
-                    "termDef": {
-                      "cde_id": "C54100",
-                      "cde_version": null,
-                      "source": "NCIt",
-                      "term": "Universally Unique Identifier",
-                      "term_url": "https://ncit.nci.nih.gov/ncitbrowser/ConceptReport.jsp?dictionary=NCI_Thesaurus&version=16.02d&ns=NCI_Thesaurus&code=C54100"
-                    }
-                  },
-                  "type": "string"
-                },
-                "submitter_id": {
-                  "type": "string"
-                }
-              },
-              "type": "object"
-            },
-            "type": "array"
-          },
-          {
-            "additionalProperties": true,
-            "properties": {
-              "id": {
-                "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
-                "term": {
-                  "description": "A 128-bit identifier. Depending on the mechanism used to generate it, it is either guaranteed to be different from all other UUIDs/GUIDs generated until 3400 AD or extremely likely to be different. Its relatively small size lends itself well to sorting, ordering, and hashing of all sorts, storing in databases, simple allocation, and ease of programming in general.\n",
-                  "termDef": {
-                    "cde_id": "C54100",
-                    "cde_version": null,
-                    "source": "NCIt",
-                    "term": "Universally Unique Identifier",
-                    "term_url": "https://ncit.nci.nih.gov/ncitbrowser/ConceptReport.jsp?dictionary=NCI_Thesaurus&version=16.02d&ns=NCI_Thesaurus&code=C54100"
-                  }
-                },
-                "type": "string"
-              },
-              "submitter_id": {
-                "type": "string"
-              }
-            },
-            "type": "object"
-          }
-        ]
-      },
-      "created_datetime": {
-        "oneOf": [
-          {
-            "format": "date-time",
-            "type": "string"
-          },
-          {
-            "type": "null"
-          }
-        ],
-        "term": {
-          "description": "A combination of date and time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]\n"
-        }
-      },
-      "data_category": {
-        "enum": [
-          "Slide Image"
-        ],
-        "term": {
-          "description": "Broad categorization of the contents of the data file.\n"
-        }
-      },
-      "data_format": {
-        "term": {
-          "description": "Format of the data files.\n"
-        },
-        "type": "string"
-      },
-      "data_type": {
-        "enum": [
-          "Single Cell Image"
-        ],
-        "term": {
-          "description": "Specific content type of the data file.\n"
-        }
-      },
-      "error_type": {
-        "enum": [
-          "file_size",
-          "file_format",
-          "md5sum"
-        ],
-        "term": {
-          "description": "Type of error for the data file object.\n"
-        }
-      },
-      "file_name": {
-        "term": {
-          "description": "The name (or part of a name) of a file (of any type).\n"
-        },
-        "type": "string"
-      },
-      "file_size": {
-        "term": {
-          "description": "The size of the data file (object) in bytes.\n"
-        },
-        "type": "integer"
-      },
-      "file_state": {
-        "default": "registered",
-        "enum": [
-          "registered",
-          "uploading",
-          "uploaded",
-          "validating",
-          "validated",
-          "submitted",
-          "processing",
-          "processed",
-          "released",
-          "error"
-        ],
-        "term": {
-          "description": "The current state of the data file object.\n"
-        }
-      },
-      "id": {
-        "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
-        "systemAlias": "node_id",
-        "term": {
-          "description": "A 128-bit identifier. Depending on the mechanism used to generate it, it is either guaranteed to be different from all other UUIDs/GUIDs generated until 3400 AD or extremely likely to be different. Its relatively small size lends itself well to sorting, ordering, and hashing of all sorts, storing in databases, simple allocation, and ease of programming in general.\n",
-          "termDef": {
-            "cde_id": "C54100",
-            "cde_version": null,
-            "source": "NCIt",
-            "term": "Universally Unique Identifier",
-            "term_url": "https://ncit.nci.nih.gov/ncitbrowser/ConceptReport.jsp?dictionary=NCI_Thesaurus&version=16.02d&ns=NCI_Thesaurus&code=C54100"
-          }
-        },
-        "type": "string"
-      },
-      "md5sum": {
-        "term": {
-          "description": "The 128-bit hash value expressed as a 32 digit hexadecimal number used as a file's digital fingerprint.\n"
-        },
-        "type": "string"
-      },
-      "object_id": {
-        "description": "The GUID of the object in the index service.",
-        "type": "string"
-      },
-      "project_id": {
-        "term": {
-          "description": "Unique ID for any specific defined piece of work that is undertaken or attempted to meet a single requirement.\n"
-        },
-        "type": "string"
-      },
-      "state": {
-        "default": "validated",
-        "downloadable": [
-          "uploaded",
-          "md5summed",
-          "validating",
-          "validated",
-          "error",
-          "invalid",
-          "released"
-        ],
-        "oneOf": [
-          {
-            "enum": [
-              "uploading",
-              "uploaded",
-              "md5summing",
-              "md5summed",
-              "validating",
-              "error",
-              "invalid",
-              "suppressed",
-              "redacted",
-              "live"
-            ]
-          },
-          {
-            "enum": [
-              "validated",
-              "submitted",
-              "released"
-            ]
-          }
-        ],
-        "public": [
-          "live"
-        ],
-        "term": {
-          "description": "The current state of the object.\n"
-        }
-      },
-      "submitter_id": {
-        "description": "A project-specific identifier for a node. This property is the calling card/nickname/alias for a unit of submission. It can be used in place of the UUID for identifying or recalling a node.\n",
-        "type": [
-          "string"
-        ]
-      },
-      "type": {
-        "type": "string"
-      },
-      "updated_datetime": {
-        "oneOf": [
-          {
-            "format": "date-time",
-            "type": "string"
-          },
-          {
-            "type": "null"
-          }
-        ],
-        "term": {
-          "description": "A combination of date and time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]\n"
-        }
-      }
-    },
-    "required": [
-      "submitter_id",
-      "type",
-      "file_name",
-      "file_size",
-      "md5sum",
-      "data_category",
-      "data_type",
-      "data_format"
-    ],
-    "submittable": true,
-    "systemProperties": [
-      "id",
-      "project_id",
-      "created_datetime",
-      "updated_datetime",
-      "state",
-      "file_state",
-      "error_type"
-    ],
-    "title": "Cell Image",
-    "type": "object",
-    "uniqueKeys": [
-      [
-        "id"
-      ],
-      [
-        "project_id",
-        "submitter_id"
-      ]
-    ],
-    "validators": null
-  },
-  "comorbidity": {
-    "additionalProperties": false,
     "category": "clinical",
-    "description": "Diagnosed medical conditions that are not directly related to or pre-date a patient's oncologic history.\n",
-    "id": "comorbidity",
+    "description": "Metadata concerning any clinical tests used in relation to a case diagnosis. \n",
+    "id": "clinical_test",
     "links": [
       {
-        "backref": "comorbidities",
-        "label": "describes",
+        "backref": "clinical_tests",
+        "label": "performed_for",
         "multiplicity": "many_to_one",
         "name": "cases",
         "required": true,
         "target_type": "case"
       },
       {
-        "backref": "comorbidities",
-        "label": "describes",
-        "multiplicity": "many_to_one",
-        "name": "followups",
+        "backref": "clinical_tests",
+        "label": "relates_to",
+        "multiplicity": "many_to_many",
+        "name": "diagnoses",
         "required": false,
-        "target_type": "followup"
+        "target_type": "diagnosis"
       }
     ],
-    "namespace": "https://www.bloodpac.org",
+    "namespace": "http://gdc.nci.nih.gov",
     "program": "*",
     "project": "*",
     "properties": {
+      "biomarker_name": {
+        "term": {
+          "description": "The name of the biomarker being tested for this specimen and set of test results.\n",
+          "termDef": {
+            "cde_id": 5473,
+            "cde_version": 11,
+            "source": "caDSR",
+            "term": "Biomarker Name",
+            "term_url": "https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=5473&version=2.31"
+          }
+        },
+        "type": "string"
+      },
+      "biomarker_result": {
+        "enum": [
+          "Amplification",
+          "Gain",
+          "Loss",
+          "Normal",
+          "Other",
+          "Translocation",
+          "Not Reported",
+          "Not Allowed To Collect",
+          "Pending"
+        ],
+        "term": {
+          "description": "Text term to define the results of genetic testing.\n",
+          "termDef": {
+            "cde_id": 3234680,
+            "cde_version": 1,
+            "source": "caDSR",
+            "term": "Laboratory Procedure Genetic Abnormality Test Result Type",
+            "term_url": "https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=3234680&version=1.0"
+          }
+        }
+      },
+      "biomarker_test_method": {
+        "enum": [
+          "Cytogenetics",
+          "FISH",
+          "IHC",
+          "Karyotype",
+          "NGS",
+          "Nuclear Staining",
+          "Other",
+          "RT-PCR",
+          "Southern",
+          "Not Reported",
+          "Not Allowed To Collect",
+          "Pending"
+        ],
+        "term": {
+          "description": "Text descriptor of a molecular analysis method used for an individual.\n",
+          "termDef": {
+            "cde_id": 3121575,
+            "cde_version": 1,
+            "source": "caDSR",
+            "term": "Disease Detection Molecular Analysis Method Type",
+            "term_url": "https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=3121575&version=1.0"
+          }
+        }
+      },
       "cases": {
         "anyOf": [
           {
@@ -5604,177 +3579,255 @@
           }
         ]
       },
-      "comorbidity": {
-        "description": "Text term to identify a coexistent disease or condition in a person.\n",
+      "cea_level_preoperative": {
+        "term": {
+          "description": "Numeric value of the Carcinoembryonic antigen or CEA at the time before surgery. [Manually- curated]\n",
+          "termDef": {
+            "cde_id": 2716510,
+            "cde_version": 1,
+            "source": "caDSR",
+            "term": "Preoperative Carcinoembryonic Antigen Result Value",
+            "term_url": "https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=2716510&version=1.0"
+          }
+        },
+        "type": "number"
+      },
+      "created_datetime": {
+        "oneOf": [
+          {
+            "format": "date-time",
+            "type": "string"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "term": {
+          "description": "A combination of date and time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]\n"
+        }
+      },
+      "diagnoses": {
+        "anyOf": [
+          {
+            "items": {
+              "additionalProperties": true,
+              "minItems": 1,
+              "properties": {
+                "id": {
+                  "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
+                  "term": {
+                    "description": "A 128-bit identifier. Depending on the mechanism used to generate it, it is either guaranteed to be different from all other UUIDs/GUIDs generated until 3400 AD or extremely likely to be different. Its relatively small size lends itself well to sorting, ordering, and hashing of all sorts, storing in databases, simple allocation, and ease of programming in general.\n",
+                    "termDef": {
+                      "cde_id": "C54100",
+                      "cde_version": null,
+                      "source": "NCIt",
+                      "term": "Universally Unique Identifier",
+                      "term_url": "https://ncit.nci.nih.gov/ncitbrowser/ConceptReport.jsp?dictionary=NCI_Thesaurus&version=16.02d&ns=NCI_Thesaurus&code=C54100"
+                    }
+                  },
+                  "type": "string"
+                },
+                "submitter_id": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "type": "array"
+          },
+          {
+            "additionalProperties": true,
+            "properties": {
+              "id": {
+                "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
+                "term": {
+                  "description": "A 128-bit identifier. Depending on the mechanism used to generate it, it is either guaranteed to be different from all other UUIDs/GUIDs generated until 3400 AD or extremely likely to be different. Its relatively small size lends itself well to sorting, ordering, and hashing of all sorts, storing in databases, simple allocation, and ease of programming in general.\n",
+                  "termDef": {
+                    "cde_id": "C54100",
+                    "cde_version": null,
+                    "source": "NCIt",
+                    "term": "Universally Unique Identifier",
+                    "term_url": "https://ncit.nci.nih.gov/ncitbrowser/ConceptReport.jsp?dictionary=NCI_Thesaurus&version=16.02d&ns=NCI_Thesaurus&code=C54100"
+                  }
+                },
+                "type": "string"
+              },
+              "submitter_id": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          }
+        ]
+      },
+      "dlco_ref_predictive_percent": {
+        "term": {
+          "description": "The value, as a percentage of predicted lung volume, measuring the amount of carbon monoxide detected in a patient's lungs.\n",
+          "termDef": {
+            "cde_id": 2180255,
+            "cde_version": 1,
+            "source": "caDSR",
+            "term": "Lung Carbon Monoxide Diffusing Capability Test Assessment Predictive Value Percentage Value",
+            "term_url": "https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=2180255&version=1.0"
+          }
+        },
+        "type": "number"
+      },
+      "estrogen_receptor_percent_positive_ihc": {
         "enum": [
-          "Acute renal failure",
-          "Adrenocortical Insufficiency",
-          "Allergies",
-          "Anemia",
-          "Anxiety",
-          "Arrhythmia",
-          "Arthritis",
-          "Asthma",
-          "Atrial Fibrillation",
-          "Avascular Necrosis",
-          "Basal Cell Carcinoma",
-          "Blood Clots",
-          "Bone Fracture(s)",
-          "Bronchitis",
-          "Calcium Channel Blockers",
-          "Cancer",
-          "Cataracts",
-          "Cerebrovascular Disease",
-          "Chronic renal failure",
-          "Congestive Heart Failure (CHF)",
-          "Connective Tissue Disorder",
-          "COPD",
-          "Coronary Artery Disease",
-          "Cryptogenic Organizing Pneumonia",
-          "Deep vein thrombosis / Thromboembolism",
-          "Depression",
-          "Diabetes",
-          "Diabetic Neuropathy",
-          "Diet controlled Diabetes",
-          "DVT/PE",
-          "Dyslipidemia",
-          "Epilepsy",
-          "Gastroesophageal reflux disease",
-          "GERD",
-          "Glaucoma",
-          "Gout",
-          "Gonadal dysfunction",
-          "Headache",
-          "Heart disease",
-          "Hemorrhagic Cystitis",
-          "Hepatitis",
-          "Hepatitis B Infection",
-          "Hepatitis C Infection",
-          "HIV / AIDS",
-          "HUS/TTP",
-          "Hypercholesterolemia",
-          "Hypercalcemia",
-          "Hyperglycemia",
-          "Hyperlipidemia",
-          "Hypertension",
-          "Hypothyroidism",
-          "Inflammatory Bowel Disease",
-          "Insulin controlled Diabetes",
-          "Interstitial Pneumontis or ARDS",
-          "Iron Overload",
-          "Ischemic heart disease",
-          "ITP",
-          "Joint replacement",
-          "Kidney Disease",
-          "Liver Cirrhosis (Liver Disease)",
-          "Liver toxicity (non-infectious)",
-          "Lupus",
-          "MAI",
-          "Myocardial Infarction",
-          "None",
-          "Obesity",
-          "Organ transplant (site)",
-          "Osteoarthritis",
-          "Osteoporosis or Osteopenia",
-          "Other",
-          "Other cancer within 5 years",
-          "Other nonmalignant systemic disease",
-          "Other pulmonary complications",
-          "Pancreatitis",
-          "Pain (various)",
-          "Peptic Ulcer (Ulcer)",
-          "Peripheral neuropathy",
-          "Peripheral Vascular Disease",
-          "Pregnancy in patient or partner",
-          "Psoriasis",
-          "Pulmonary Fibrosis",
-          "Pulmonary Hemorrhage",
-          "Renal failure (requiring dialysis)",
-          "Renal dialysis",
-          "Renal Insufficiency",
-          "Rheumatologic Disease",
-          "Sarcoidosis",
-          "Seizure",
-          "Sleep apnea",
-          "Smoking",
-          "Stroke",
-          "Transient ischemic attack",
-          "Tuberculosis",
-          "Ulcerative Colitis"
-        ]
-      },
-      "created_datetime": {
-        "oneOf": [
-          {
-            "format": "date-time",
-            "type": "string"
-          },
-          {
-            "type": "null"
-          }
+          "<1%",
+          "1-10%",
+          "11-20%",
+          "21-30%",
+          "31-40%",
+          "41-50%",
+          "51-60%",
+          "61-70%",
+          "71-80%",
+          "81-90%",
+          "91-100%"
         ],
         "term": {
-          "description": "A combination of date and time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]\n"
+          "description": "Classification to represent ER Positive results expressed as a percentage value.\n",
+          "termDef": {
+            "cde_id": 3128341,
+            "cde_version": 1,
+            "source": "caDSR",
+            "term": "ER Level Cell Percentage Category",
+            "term_url": "https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=3128341&version=1.0"
+          }
         }
       },
-      "days_to_comorbidity": {
-        "description": "Number of days between the date used for index and the date the patient was diagnosed with a comorbidity.\n",
-        "type": "integer"
-      },
-      "followups": {
-        "anyOf": [
-          {
-            "items": {
-              "additionalProperties": true,
-              "maxItems": 1,
-              "minItems": 1,
-              "properties": {
-                "id": {
-                  "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
-                  "term": {
-                    "description": "A 128-bit identifier. Depending on the mechanism used to generate it, it is either guaranteed to be different from all other UUIDs/GUIDs generated until 3400 AD or extremely likely to be different. Its relatively small size lends itself well to sorting, ordering, and hashing of all sorts, storing in databases, simple allocation, and ease of programming in general.\n",
-                    "termDef": {
-                      "cde_id": "C54100",
-                      "cde_version": null,
-                      "source": "NCIt",
-                      "term": "Universally Unique Identifier",
-                      "term_url": "https://ncit.nci.nih.gov/ncitbrowser/ConceptReport.jsp?dictionary=NCI_Thesaurus&version=16.02d&ns=NCI_Thesaurus&code=C54100"
-                    }
-                  },
-                  "type": "string"
-                },
-                "submitter_id": {
-                  "type": "string"
-                }
-              },
-              "type": "object"
-            },
-            "type": "array"
-          },
-          {
-            "additionalProperties": true,
-            "properties": {
-              "id": {
-                "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
-                "term": {
-                  "description": "A 128-bit identifier. Depending on the mechanism used to generate it, it is either guaranteed to be different from all other UUIDs/GUIDs generated until 3400 AD or extremely likely to be different. Its relatively small size lends itself well to sorting, ordering, and hashing of all sorts, storing in databases, simple allocation, and ease of programming in general.\n",
-                  "termDef": {
-                    "cde_id": "C54100",
-                    "cde_version": null,
-                    "source": "NCIt",
-                    "term": "Universally Unique Identifier",
-                    "term_url": "https://ncit.nci.nih.gov/ncitbrowser/ConceptReport.jsp?dictionary=NCI_Thesaurus&version=16.02d&ns=NCI_Thesaurus&code=C54100"
-                  }
-                },
-                "type": "string"
-              },
-              "submitter_id": {
-                "type": "string"
-              }
-            },
-            "type": "object"
+      "estrogen_receptor_result_ihc": {
+        "enum": [
+          "Negative",
+          "Not Performed",
+          "Positive",
+          "Unknown"
+        ],
+        "term": {
+          "description": "Text term to represent the overall result of Estrogen Receptor (ER) testing.\n",
+          "termDef": {
+            "cde_id": 2957359,
+            "cde_version": 2,
+            "source": "caDSR",
+            "term": "Breast Carcinoma Estrogen Receptor Status",
+            "term_url": "https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=2957359&version=2.0"
           }
-        ]
+        }
+      },
+      "fev1_fvc_post_bronch_percent": {
+        "term": {
+          "description": "Percentage value to represent result of Forced Expiratory Volume in 1 second (FEV1) divided by the Forced Vital Capacity (FVC) post-bronchodilator.\n",
+          "termDef": {
+            "cde_id": 3302956,
+            "cde_version": 1,
+            "source": "caDSR",
+            "term": "Post Bronchodilator FEV1/FVC Percent Value",
+            "term_url": "https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=3302956&version=1.0"
+          }
+        },
+        "type": "number"
+      },
+      "fev1_fvc_pre_bronch_percent": {
+        "term": {
+          "description": "Percentage value to represent result of Forced Expiratory Volume in 1 second (FEV1) divided by the Forced Vital Capacity (FVC) pre-bronchodilator.\n",
+          "termDef": {
+            "cde_id": 3302955,
+            "cde_version": 1,
+            "source": "caDSR",
+            "term": "Pre Bronchodilator FEV1/FVC Percent Value",
+            "term_url": "https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=3302955&version=1.0"
+          }
+        },
+        "type": "number"
+      },
+      "fev1_ref_post_bronch_percent": {
+        "term": {
+          "description": "The percentage comparison to a normal value reference range of the volume of air that a patient can forcibly exhale from the lungs in one second post-bronchodilator.\n",
+          "termDef": {
+            "cde_id": 3302948,
+            "cde_version": 1,
+            "source": "caDSR",
+            "term": "Post Bronchodilator Lung Forced Expiratory Volume 1 Test Lab Percentage Value",
+            "term_url": "https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=3302948&version=1.0"
+          }
+        },
+        "type": "number"
+      },
+      "fev1_ref_pre_bronch_percent": {
+        "term": {
+          "description": "The percentage comparison to a normal value reference range of the volume of air that a patient can forcibly exhale from the lungs in one second pre-bronchodilator.\n",
+          "termDef": {
+            "cde_id": 3302947,
+            "cde_version": 1,
+            "source": "caDSR",
+            "term": "Pre Bronchodilator Lung Forced Expiratory Volume 1 Test Lab Percentage Value",
+            "term_url": "https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=3302947&version=1.0"
+          }
+        },
+        "type": "number"
+      },
+      "her2_erbb2_percent_positive_ihc": {
+        "enum": [
+          "<1%",
+          "1-10%",
+          "11-20%",
+          "21-30%",
+          "31-40%",
+          "41-50%",
+          "51-60%",
+          "61-70%",
+          "71-80%",
+          "81-90%",
+          "91-100%"
+        ],
+        "term": {
+          "description": "Classification to represent the number of positive HER2/ERBB2 cells in a specimen or sample.\n",
+          "termDef": {
+            "cde_id": 3086980,
+            "cde_version": 1,
+            "source": "caDSR",
+            "term": "HER2 ERBB Positive Finding Cell Percentage Category",
+            "term_url": "https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=3086980&version=1.0"
+          }
+        }
+      },
+      "her2_erbb2_result_fish": {
+        "enum": [
+          "Negative",
+          "Not Performed",
+          "Positive",
+          "Unknown"
+        ],
+        "term": {
+          "description": "the type of outcome for HER2 as determined by an in situ hybridization (ISH) assay.\n",
+          "termDef": {
+            "cde_id": 2854089,
+            "cde_version": 1,
+            "source": "caDSR",
+            "term": "Laboratory Procedure HER2/neu in situ Hybridization Outcome Type",
+            "term_url": "https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=2854089&version=1.0"
+          }
+        }
+      },
+      "her2_erbb2_result_ihc": {
+        "enum": [
+          "Negative",
+          "Not Performed",
+          "Positive",
+          "Unknown"
+        ],
+        "term": {
+          "description": "Text term to signify the result of the medical procedure that involves testing a sample of blood or tissue for HER2 by histochemical localization of immunoreactive substances using labeled antibodies as reagents.\n",
+          "termDef": {
+            "cde_id": 2957563,
+            "cde_version": 2,
+            "source": "caDSR",
+            "term": "Laboratory Procedure HER2/neu Immunohistochemistry Receptor Status",
+            "term_url": "https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=2957563&version=2.0"
+          }
+        }
       },
       "id": {
         "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
@@ -5790,6 +3843,92 @@
           }
         },
         "type": "string"
+      },
+      "ldh_level_at_diagnosis": {
+        "term": {
+          "description": "The 2 decimal place numeric laboratory value measured, assigned or computed related to the assessment of lactate dehydrogenase in a specimen.\n",
+          "termDef": {
+            "cde_id": 2798766,
+            "cde_version": 1,
+            "source": "caDSR",
+            "term": "Laboratory Procedure Lactate Dehydrogenase Result Integer::2 Decimal Place Value",
+            "term_url": "https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=2798766&version=1.0"
+          }
+        },
+        "type": "number"
+      },
+      "ldh_normal_range_upper": {
+        "term": {
+          "description": "The top value of the range of statistical characteristics that are supposed to represent accepted standard, non-pathological pattern for lactate dehydrogenase (units not specified).\n",
+          "termDef": {
+            "cde_id": 2597015,
+            "cde_version": 1,
+            "source": "caDSR",
+            "term": "Laboratory Procedure Lactate Dehydrogenase Result Upper Limit of Normal Value",
+            "term_url": "https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=2597015&version=1.0"
+          }
+        },
+        "type": "number"
+      },
+      "microsatellite_instability_abnormal": {
+        "enum": [
+          "Yes",
+          "No",
+          "Unknown"
+        ],
+        "term": {
+          "description": "The yes/no indicator to signify the status of a tumor for microsatellite instability.\n",
+          "termDef": {
+            "cde_id": 3123142,
+            "cde_version": 1,
+            "source": "caDSR",
+            "term": "Microsatellite Instability Occurrence Indicator",
+            "term_url": "https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=3123142&version=1.0"
+          }
+        }
+      },
+      "progesterone_receptor_percent_positive_ihc": {
+        "enum": [
+          "<1%",
+          "1-10%",
+          "11-20%",
+          "21-30%",
+          "31-40%",
+          "41-50%",
+          "51-60%",
+          "61-70%",
+          "71-80%",
+          "81-90%",
+          "91-100%"
+        ],
+        "term": {
+          "description": "Classification to represent Progesterone Receptor Positive results expressed as a percentage value.\n",
+          "termDef": {
+            "cde_id": 3128342,
+            "cde_version": 1,
+            "source": "caDSR",
+            "term": "Progesterone Receptor Level Cell Percentage Category",
+            "term_url": "https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=3128342&version=1.0"
+          }
+        }
+      },
+      "progesterone_receptor_result_ihc": {
+        "enum": [
+          "Negative",
+          "Not Performed",
+          "Positive",
+          "Unknown"
+        ],
+        "term": {
+          "description": "Text term to represent the overall result of Progresterone Receptor (PR) testing.\n",
+          "termDef": {
+            "cde_id": 2957357,
+            "cde_version": 2,
+            "source": "caDSR",
+            "term": "Breast Carcinoma Progesterone Receptor Status",
+            "term_url": "https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=2957357&version=2.0"
+          }
+        }
       },
       "project_id": {
         "term": {
@@ -5839,13 +3978,15 @@
         }
       },
       "submitter_id": {
-        "description": "A project-specific identifier for a node. This property is the calling card/nickname/alias for a unit of submission. It can be used in place of the UUID for identifying or recalling a node.\n",
         "type": [
-          "string"
+          "string",
+          "null"
         ]
       },
       "type": {
-        "type": "string"
+        "enum": [
+          "clinical_test"
+        ]
       },
       "updated_datetime": {
         "oneOf": [
@@ -5863,255 +4004,20 @@
       }
     },
     "required": [
-      "submitter_id",
-      "type",
-      "cases",
-      "comorbidity",
-      "days_to_comorbidity"
-    ],
-    "schema": "http://json-schema.org/draft-04/schema#",
-    "submittable": true,
-    "systemProperties": [
-      "id",
-      "project_id",
-      "state",
-      "created_datetime",
-      "updated_datetime"
-    ],
-    "title": "Comorbidity",
-    "type": "object",
-    "uniqueKeys": [
-      [
-        "id"
-      ],
-      [
-        "project_id",
-        "submitter_id"
-      ]
-    ],
-    "validators": null
-  },
-  "contrived_expectation": {
-    "$schema": "http://json-schema.org/draft-04/schema#",
-    "additionalProperties": false,
-    "category": "biospecimen",
-    "description": "Any mutations or other values for a paricular sample that are expected to be observed through experimentation. These expectaions can arise from using a cell line or other gold standard with a known set of variants.\n",
-    "id": "contrived_expectation",
-    "links": [
-      {
-        "backref": "contrived_expectations",
-        "label": "expected_of",
-        "multiplicity": "many_to_many",
-        "name": "aliquots",
-        "required": true,
-        "target_type": "aliquot"
-      }
-    ],
-    "namespace": "https://www.bloodpac.org",
-    "program": "*",
-    "project": "*",
-    "properties": {
-      "aliquots": {
-        "anyOf": [
-          {
-            "items": {
-              "additionalProperties": true,
-              "maxItems": 1,
-              "minItems": 1,
-              "properties": {
-                "id": {
-                  "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
-                  "term": {
-                    "description": "A 128-bit identifier. Depending on the mechanism used to generate it, it is either guaranteed to be different from all other UUIDs/GUIDs generated until 3400 AD or extremely likely to be different. Its relatively small size lends itself well to sorting, ordering, and hashing of all sorts, storing in databases, simple allocation, and ease of programming in general.\n",
-                    "termDef": {
-                      "cde_id": "C54100",
-                      "cde_version": null,
-                      "source": "NCIt",
-                      "term": "Universally Unique Identifier",
-                      "term_url": "https://ncit.nci.nih.gov/ncitbrowser/ConceptReport.jsp?dictionary=NCI_Thesaurus&version=16.02d&ns=NCI_Thesaurus&code=C54100"
-                    }
-                  },
-                  "type": "string"
-                },
-                "submitter_id": {
-                  "type": "string"
-                }
-              },
-              "type": "object"
-            },
-            "type": "array"
-          },
-          {
-            "additionalProperties": true,
-            "properties": {
-              "id": {
-                "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
-                "term": {
-                  "description": "A 128-bit identifier. Depending on the mechanism used to generate it, it is either guaranteed to be different from all other UUIDs/GUIDs generated until 3400 AD or extremely likely to be different. Its relatively small size lends itself well to sorting, ordering, and hashing of all sorts, storing in databases, simple allocation, and ease of programming in general.\n",
-                  "termDef": {
-                    "cde_id": "C54100",
-                    "cde_version": null,
-                    "source": "NCIt",
-                    "term": "Universally Unique Identifier",
-                    "term_url": "https://ncit.nci.nih.gov/ncitbrowser/ConceptReport.jsp?dictionary=NCI_Thesaurus&version=16.02d&ns=NCI_Thesaurus&code=C54100"
-                  }
-                },
-                "type": "string"
-              },
-              "submitter_id": {
-                "type": "string"
-              }
-            },
-            "type": "object"
-          }
-        ]
-      },
-      "created_datetime": {
-        "oneOf": [
-          {
-            "format": "date-time",
-            "type": "string"
-          },
-          {
-            "type": "null"
-          }
-        ],
-        "term": {
-          "description": "A combination of date and time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]\n"
-        }
-      },
-      "expected_allelic_fraction": {
-        "description": "Relative frequency of the expected allele.",
-        "type": "number"
-      },
-      "expected_copy_number": {
-        "description": "The expected copy number ratio at the expected locus.",
-        "type": "number"
-      },
-      "expected_mutation_alt": {
-        "description": "Expected mutated bases/amino acids in the sample.",
-        "type": "string"
-      },
-      "expected_mutation_chromosome": {
-        "description": "The chromosome on which the mutation should be located.",
-        "type": "string"
-      },
-      "expected_mutation_gene": {
-        "description": "The gene in which the mutation is expected to occur.",
-        "type": "string"
-      },
-      "expected_mutation_position": {
-        "description": "The amino acid or base position of the expected mutation.",
-        "type": "string"
-      },
-      "expected_mutation_reference": {
-        "description": "Identifier for the bases/amino acids in the reference genome.",
-        "type": "string"
-      },
-      "expected_mutation_type": {
-        "description": "The type of mutation expected in the sample. (e.g. missense, indel, etc)",
-        "type": "string"
-      },
-      "id": {
-        "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
-        "systemAlias": "node_id",
-        "term": {
-          "description": "A 128-bit identifier. Depending on the mechanism used to generate it, it is either guaranteed to be different from all other UUIDs/GUIDs generated until 3400 AD or extremely likely to be different. Its relatively small size lends itself well to sorting, ordering, and hashing of all sorts, storing in databases, simple allocation, and ease of programming in general.\n",
-          "termDef": {
-            "cde_id": "C54100",
-            "cde_version": null,
-            "source": "NCIt",
-            "term": "Universally Unique Identifier",
-            "term_url": "https://ncit.nci.nih.gov/ncitbrowser/ConceptReport.jsp?dictionary=NCI_Thesaurus&version=16.02d&ns=NCI_Thesaurus&code=C54100"
-          }
-        },
-        "type": "string"
-      },
-      "project_id": {
-        "term": {
-          "description": "Unique ID for any specific defined piece of work that is undertaken or attempted to meet a single requirement.\n"
-        },
-        "type": "string"
-      },
-      "state": {
-        "default": "validated",
-        "downloadable": [
-          "uploaded",
-          "md5summed",
-          "validating",
-          "validated",
-          "error",
-          "invalid",
-          "released"
-        ],
-        "oneOf": [
-          {
-            "enum": [
-              "uploading",
-              "uploaded",
-              "md5summing",
-              "md5summed",
-              "validating",
-              "error",
-              "invalid",
-              "suppressed",
-              "redacted",
-              "live"
-            ]
-          },
-          {
-            "enum": [
-              "validated",
-              "submitted",
-              "released"
-            ]
-          }
-        ],
-        "public": [
-          "live"
-        ],
-        "term": {
-          "description": "The current state of the object.\n"
-        }
-      },
-      "submitter_id": {
-        "description": "A project-specific identifier for a node. This property is the calling card/nickname/alias for a unit of submission. It can be used in place of the UUID for identifying or recalling a node.\n",
-        "type": [
-          "string"
-        ]
-      },
-      "type": {
-        "type": "string"
-      },
-      "updated_datetime": {
-        "oneOf": [
-          {
-            "format": "date-time",
-            "type": "string"
-          },
-          {
-            "type": "null"
-          }
-        ],
-        "term": {
-          "description": "A combination of date and time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]\n"
-        }
-      }
-    },
-    "required": [
-      "submitter_id",
-      "type",
-      "aliquots"
+      "biomarker_name",
+      "biomarker_result",
+      "biomarker_test_method",
+      "cases"
     ],
     "submittable": true,
     "systemProperties": [
       "id",
       "project_id",
-      "state",
       "created_datetime",
-      "updated_datetime"
+      "updated_datetime",
+      "state"
     ],
-    "title": "Contrived Expectation",
+    "title": "Clinical Test",
     "type": "object",
     "uniqueKeys": [
       [
@@ -6128,7 +4034,7 @@
     "$schema": "http://json-schema.org/draft-04/schema#",
     "additionalProperties": false,
     "category": "administrative",
-    "description": "Structured description of a collection of several datasets\n",
+    "description": "Structured description of a collection of several dataset\n",
     "id": "core_metadata_collection",
     "links": [
       {
@@ -6140,7 +4046,7 @@
         "target_type": "project"
       }
     ],
-    "namespace": "https://data.bloodpac.org",
+    "namespace": "https://dcp.bionimbus.org/",
     "program": "*",
     "project": "*",
     "properties": {
@@ -6193,7 +4099,7 @@
         "type": "string"
       },
       "format": {
-        "description": "The file format, physical medium, or dimensions of the resource. Examples of dimensions include size and duration. Recommended best practice is to use a controlled vocabulary such as the list of Internet Media Types [MIME] (http://www.iana.org/assignments/media-types/).\n",
+        "description": "The file format, physical medium, or dimensions of the resource. Examples of dimensions include size and duration. Recommended best practice is to use a controlled vocabulary such as the list of Internet Media Types [MIME] (http://www.iana.org/assignments/media-types/). \n",
         "type": "string"
       },
       "id": {
@@ -6229,9 +4135,6 @@
               "maxItems": 1,
               "minItems": 1,
               "properties": {
-                "code": {
-                  "type": "string"
-                },
                 "id": {
                   "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
                   "term": {
@@ -6245,6 +4148,9 @@
                     }
                   },
                   "type": "string"
+                },
+                "submitter_id": {
+                  "type": "string"
                 }
               },
               "type": "object"
@@ -6254,9 +4160,6 @@
           {
             "additionalProperties": true,
             "properties": {
-              "code": {
-                "type": "string"
-              },
               "id": {
                 "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
                 "term": {
@@ -6270,6 +4173,9 @@
                   }
                 },
                 "type": "string"
+              },
+              "submitter_id": {
+                "type": "string"
               }
             },
             "type": "object"
@@ -6281,7 +4187,7 @@
         "type": "string"
       },
       "relation": {
-        "description": "A related resource. Recommended best practice is to identify the related resource by means of a string conforming to a formal identification system. \n",
+        "description": "A related resource. Recommended best practice is to identify the related resource by means of a string conforming to a formal identification system. \n",
         "type": "string"
       },
       "rights": {
@@ -6408,8 +4314,6 @@
       }
     ],
     "namespace": "http://gdc.nci.nih.gov",
-    "program": "*",
-    "project": "*",
     "properties": {
       "created_datetime": {
         "oneOf": [
@@ -6447,10 +4351,6 @@
       "minor_version": {
         "description": "The number identifying the minor version.\n",
         "type": "integer"
-      },
-      "name": {
-        "description": "String representing release name.\n",
-        "type": "string"
       },
       "release_date": {
         "oneOf": [
@@ -6547,7 +4447,6 @@
       }
     },
     "required": [
-      "name",
       "major_version",
       "minor_version"
     ],
@@ -6582,7 +4481,10 @@
         "target_type": "case"
       }
     ],
-    "namespace": "https://www.bloodpac.org",
+    "namespace": "http://gdc.nci.nih.gov",
+    "preferred": [
+      "year_of_death"
+    ],
     "program": "*",
     "project": "*",
     "properties": {
@@ -6641,14 +4543,6 @@
           }
         ]
       },
-      "cause_of_death": {
-        "description": "Text term to identify the cause of patient death with respect to cancer.\n",
-        "enum": [
-          "Cancer Related",
-          "Not Cancer Related",
-          "Unknown"
-        ]
-      },
       "created_datetime": {
         "oneOf": [
           {
@@ -6663,28 +4557,13 @@
           "description": "A combination of date and time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]\n"
         }
       },
-      "days_to_birth": {
-        "description": "The number of days between the index date and the date of patient birth. If the number of days is greater than 32872 (89 years), then please use 'days_to_birth_gt89'.\n",
-        "maximum": 32872,
-        "minimum": 0,
-        "type": "integer"
-      },
-      "days_to_birth_gt89": {
-        "description": "Indicate if the number of days between the index date and the date of patient birth is greater than 32872 (89 years).\n",
-        "enum": [
-          "Yes",
-          "No"
-        ]
-      },
-      "days_to_death": {
-        "description": "The number of days between the index date and the date of patient death.\n",
-        "type": "integer"
-      },
       "ethnicity": {
         "enum": [
-          "Hispanic or Latino",
-          "Not Hispanic or Latino",
-          "Unknown"
+          "hispanic or latino",
+          "not hispanic or latino",
+          "Unknown",
+          "not reported",
+          "not allowed to collect"
         ],
         "term": {
           "description": "An individual's self-described social and cultural grouping, specifically whether an individual describes themselves as Hispanic or Latino. The provided values are based on the categories defined by the U.S. Office of Management and Business and used by the U.S. Census Bureau.\n",
@@ -6699,10 +4578,11 @@
       },
       "gender": {
         "enum": [
-          "Female",
-          "Male",
-          "Unknown",
-          "Unspecified"
+          "female",
+          "male",
+          "unknown",
+          "unspecified",
+          "not reported"
         ],
         "term": {
           "description": "Text designations that identify gender. Gender is described as the assemblage of properties that distinguish people on the basis of their societal roles. [Explanatory Comment 1: Identification of gender is based upon self-report and may come from a form, questionnaire, interview, etc.]\n",
@@ -6738,13 +4618,15 @@
       },
       "race": {
         "enum": [
-          "White",
-          "American Indian or Alaska Native",
-          "Black or African American",
-          "Asian",
-          "Native Hawaiian or Other Pacific Islander",
-          "Other",
-          "Unknown"
+          "white",
+          "american indian or alaska native",
+          "black or african american",
+          "asian",
+          "native hawaiian or other pacific islander",
+          "other",
+          "Unknown",
+          "not reported",
+          "not allowed to collect"
         ],
         "term": {
           "description": "An arbitrary classification of a taxonomic group that is a division of a species. It usually arises as a consequence of geographical isolation within a species and is characterized by shared heredity, physical attributes and behavior, and in the case of humans, by common history, nationality, or geographic distribution. The provided values are based on the categories defined by the U.S. Office of Management and Business and used by the U.S. Census Bureau.\n",
@@ -6799,9 +4681,9 @@
         }
       },
       "submitter_id": {
-        "description": "A project-specific identifier for a node. This property is the calling card/nickname/alias for a unit of submission. It can be used in place of the UUID for identifying or recalling a node.\n",
         "type": [
-          "string"
+          "string",
+          "null"
         ]
       },
       "type": {
@@ -6821,28 +4703,38 @@
           "description": "A combination of date and time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]\n"
         }
       },
-      "vital_status": {
-        "enum": [
-          "Alive",
-          "Dead",
-          "Lost to Follow-up",
-          "Unknown"
-        ],
+      "year_of_birth": {
         "term": {
-          "description": "The survival state of the person registered on the protocol.\n",
+          "description": "Numeric value to represent the calendar year in which an individual was born.\n",
           "termDef": {
-            "cde_id": 5,
-            "cde_version": 5,
+            "cde_id": 2896954,
+            "cde_version": 1,
             "source": "caDSR",
-            "term": "Patient Vital Status",
-            "term_url": "https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=5&version=5.0"
+            "term": "Year Birth Date Number",
+            "term_url": "https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=2896954&version=1.0"
           }
-        }
+        },
+        "type": [
+          "number",
+          "null"
+        ]
+      },
+      "year_of_death": {
+        "term": {
+          "description": "Numeric value to represent the year of the death of an individual.\n",
+          "termDef": {
+            "cde_id": 2897030,
+            "cde_version": 1,
+            "source": "caDSR",
+            "term": "Year Death Number",
+            "term_url": "https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=2897030&version=1.0"
+          }
+        },
+        "type": "number"
       }
     },
     "required": [
       "submitter_id",
-      "type",
       "cases"
     ],
     "submittable": true,
@@ -6882,7 +4774,11 @@
         "target_type": "case"
       }
     ],
-    "namespace": "https://www.bloodpac.org",
+    "namespace": "http://gdc.nci.nih.gov",
+    "preferred": [
+      "days_to_birth",
+      "site_of_resection_or_biopsy"
+    ],
     "program": "*",
     "project": "*",
     "properties": {
@@ -6890,7 +4786,7 @@
         "maximum": 32872,
         "minimum": 0,
         "term": {
-          "description": "Age at the time of diagnosis expressed in number of days since birth. If the age at diagnosis is greater than 32872 days (89 years), then see 'age_at_diagnosis_gt89'.\n",
+          "description": "Age at the time of diagnosis expressed in number of days since birth.\n",
           "termDef": {
             "cde_id": 3225640,
             "cde_version": 2,
@@ -6899,23 +4795,10 @@
             "term_url": "https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=3225640&version=2.0"
           }
         },
-        "type": "integer"
-      },
-      "age_at_diagnosis_gt89": {
-        "enum": [
-          "Yes",
-          "No"
-        ],
-        "term": {
-          "description": "Indicate if the age at the time of diagnosis expressed in number of days since birth is greater than 32872 days (89 years).\n",
-          "termDef": {
-            "cde_id": 3225640,
-            "cde_version": 2,
-            "source": "caDSR",
-            "term": "Patient Diagnosis Age Day Value",
-            "term_url": "https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=3225640&version=2.0"
-          }
-        }
+        "type": [
+          "number",
+          "null"
+        ]
       },
       "ajcc_clinical_m": {
         "enum": [
@@ -6926,7 +4809,9 @@
           "M1c",
           "MX",
           "cM0 (i+)",
-          "Unknown"
+          "Unknown",
+          "Not Reported",
+          "Not Allowed To Collect"
         ],
         "term": {
           "description": "Extent of the distant metastasis for the cancer based on evidence obtained from clinical assessment parameters determined prior to treatment.\n",
@@ -6965,7 +4850,9 @@
           "N3c",
           "N4",
           "NX",
-          "Unknown"
+          "Unknown",
+          "Not Reported",
+          "Not Allowed To Collect"
         ],
         "term": {
           "description": "Extent of the regional lymph node involvement for the cancer based on evidence obtained from clinical assessment parameters determined prior to treatment.\n",
@@ -7008,7 +4895,9 @@
           "Stage IVC",
           "Stage Tis",
           "Stage X",
-          "Unknown"
+          "Unknown",
+          "Not Reported",
+          "Not Allowed To Collect"
         ],
         "term": {
           "description": "Stage group determined from clinical information on the tumor (T), regional node (N) and metastases (M) and by grouping cases with similar prognosis for cancer.\n",
@@ -7057,7 +4946,9 @@
           "Tis (DCIS)",
           "Tis (LCIS)",
           "Tis (Paget's)",
-          "Unknown"
+          "Unknown",
+          "Not Reported",
+          "Not Allowed To Collect"
         ],
         "term": {
           "description": "Extent of the primary cancer based on evidence obtained from clinical assessment parameters determined prior to treatment.\n",
@@ -7080,7 +4971,9 @@
           "M2",
           "MX",
           "cM0 (i+)",
-          "Unknown"
+          "Unknown",
+          "Not Reported",
+          "Not Allowed To Collect"
         ],
         "term": {
           "description": "Code to represent the defined absence or presence of distant spread or metastases (M) to locations via vascular channels or lymphatics beyond the regional lymph nodes, using criteria established by the American Joint Committee on Cancer (AJCC).\n",
@@ -7119,7 +5012,9 @@
           "N3c",
           "N4",
           "NX",
-          "Unknown"
+          "Unknown",
+          "Not Reported",
+          "Not Allowed To Collect"
         ],
         "term": {
           "description": "The codes that represent the stage of cancer based on the nodes present (N stage) according to criteria based on multiple editions of the AJCC's Cancer Staging Manual.\n",
@@ -7209,7 +5104,9 @@
           "Tis (DCIS)",
           "Tis (LCIS)",
           "Tis (Paget's)",
-          "Unknown"
+          "Unknown",
+          "Not Reported",
+          "Not Allowed To Collect"
         ],
         "term": {
           "description": "Code of pathological T (primary tumor) to define the size or contiguous extension of the primary tumor (T), using staging criteria from the American Joint Committee on Cancer (AJCC).\n",
@@ -7222,36 +5119,101 @@
           }
         }
       },
-      "best_overall_response": {
-        "description": "The best improvement achieved throughout the entire course of protocol treatment.",
+      "ann_arbor_b_symptoms": {
         "enum": [
-          "AJ-Adjuvant Therapy",
-          "CPD-Clinical Progression",
-          "CR-Complete Response",
-          "CRU-Complete Response Unconfirmed",
-          "DU-Disease Unchanged",
-          "IMR-Immunoresponse",
-          "IPD-Immunoprogression",
-          "MR-Minimal/Marginal response",
-          "MX-Mixed response",
-          "Non-CR/Non-PD-Non-CR/Non-PD",
-          "NPB-No Palliative Benefit",
-          "NR-NO RESPONSE",
-          "PA-Palliative Therapy",
-          "PB-Palliative Benefit",
-          "PD-Progressive Disease",
-          "PPD-Pseudoprogression",
-          "PR-Partial Response",
-          "PSR-Pseudoresponse",
-          "RD-Responsive Disease",
-          "RP-Response",
-          "RPD-Radiographic Progressive Disease",
-          "sCR-Stringent Complete Response",
-          "SD-Stable Disease",
-          "SPD-Surgical progression",
-          "TE-Too early",
-          "VGPR-Very Good Partial Response"
-        ]
+          "Yes",
+          "No",
+          "Unknown",
+          "Not Reported",
+          "Not Allowed To Collect"
+        ],
+        "term": {
+          "description": "Text term to signify whether lymphoma B-symptoms are present as noted in the patient's medical record.\n",
+          "termDef": {
+            "cde_id": 2902402,
+            "cde_version": 1,
+            "source": "caDSR",
+            "term": "Lymphoma B-Symptoms Medical Record Documented Indicator",
+            "term_url": "https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=2902402&version=1.0"
+          }
+        }
+      },
+      "ann_arbor_clinical_stage": {
+        "enum": [
+          "Stage I",
+          "Stage II",
+          "Stage III",
+          "Stage IV"
+        ],
+        "term": {
+          "description": "The classification of the clinically confirmed anatomic disease extent of lymphoma (Hodgkin's and Non-Hodgkins) based on the Ann Arbor Staging System.\n",
+          "termDef": {
+            "cde_id": null,
+            "cde_version": null,
+            "source": null,
+            "term": "Ann Arbor Clinical Stage",
+            "term_url": null
+          }
+        }
+      },
+      "ann_arbor_extranodal_involvement": {
+        "enum": [
+          "Yes",
+          "No",
+          "Unknown",
+          "Not Reported",
+          "Not Allowed To Collect"
+        ],
+        "term": {
+          "description": "Indicator that identifies whether a patient with malignant lymphoma has lymphomatous involvement of an extranodal site.\n",
+          "termDef": {
+            "cde_id": 3364582,
+            "cde_version": 1,
+            "source": "caDSR",
+            "term": "Lymphomatous Extranodal Site Involvement Indicator",
+            "term_url": "https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=3364582&version=1.0"
+          }
+        }
+      },
+      "ann_arbor_pathologic_stage": {
+        "enum": [
+          "Stage I",
+          "Stage II",
+          "Stage III",
+          "Stage IV"
+        ],
+        "term": {
+          "description": "The classification of the pathologically confirmed anatomic disease extent of lymphoma (Hodgkin's and Non-Hodgkins) based on the Ann Arbor Staging System.\n",
+          "termDef": {
+            "cde_id": null,
+            "cde_version": null,
+            "source": null,
+            "term": "Ann Arbor Pathologic Stage",
+            "term_url": null
+          }
+        }
+      },
+      "burkitt_lymphoma_clinical_variant": {
+        "enum": [
+          "Endemic",
+          "Immunodeficiency-associated, adult",
+          "Immunodeficiency-associated, pediatric",
+          "Sporadic, adult",
+          "Sporadic, pediatric",
+          "Unknown",
+          "Not Reported",
+          "Not Allowed To Collect"
+        ],
+        "term": {
+          "description": "Burkitt's lymphoma categorization based on clinical features that differ from other forms of the same disease.\n",
+          "termDef": {
+            "cde_id": 3770421,
+            "cde_version": 1,
+            "source": "caDSR",
+            "term": "Burkitt Lymphoma Clinical Variant Type",
+            "term_url": "https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=3770421&version=1.0"
+          }
+        }
       },
       "cases": {
         "anyOf": [
@@ -7308,13 +5270,45 @@
           }
         ]
       },
+      "cause_of_death": {
+        "enum": [
+          "Cancer Related",
+          "Not Cancer Related",
+          "Unknown"
+        ],
+        "term": {
+          "description": "Text term to identify the cause of death for a patient.\n",
+          "termDef": {
+            "cde_id": 2554674,
+            "cde_version": 3,
+            "source": "caDSR",
+            "term": "Patient Death Reason",
+            "term_url": "https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=2554674&version=3.0"
+          }
+        }
+      },
+      "circumferential_resection_margin": {
+        "term": {
+          "description": "A value in millimeters indicating the measured length between a malignant lesion of the colon or rectum and the nearest radial (or circumferential) border of tissue removed during cancer surgery.\n",
+          "termDef": {
+            "cde_id": 64202,
+            "cde_version": 3,
+            "source": "caDSR",
+            "term": "Colorectal Surgical Margin Circumferential Distance Measurement",
+            "term_url": "https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=64202&version=3.0"
+          }
+        },
+        "type": "number"
+      },
       "classification_of_tumor": {
         "enum": [
-          "Primary",
-          "Metastasis",
-          "Recurrence",
-          "Other",
-          "Unknown"
+          "primary",
+          "metastasis",
+          "recurrence",
+          "other",
+          "Unknown",
+          "not reported",
+          "Not Allowed To Collect"
         ],
         "term": {
           "description": "Text that describes the kind of disease present in the tumor specimen as related to a specific timepoint.\n",
@@ -7324,6 +5318,25 @@
             "source": "caDSR",
             "term": "Tumor Tissue Disease Description Type",
             "term_url": "https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=3288124&version=1.0"
+          }
+        }
+      },
+      "colon_polyps_history": {
+        "enum": [
+          "Yes",
+          "No",
+          "Unknown",
+          "Not Reported",
+          "Not Allowed To Collect"
+        ],
+        "term": {
+          "description": "Yes/No indicator to describe if the subject had a previous history of colon polyps as noted in the history/physical or previous endoscopic report (s).\n",
+          "termDef": {
+            "cde_id": 3107197,
+            "cde_version": 1,
+            "source": "caDSR",
+            "term": "Colon Carcinoma Polyp Occurrence Indicator",
+            "term_url": "https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=3107197&version=1.0"
           }
         }
       },
@@ -7341,13 +5354,210 @@
           "description": "A combination of date and time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]\n"
         }
       },
-      "days_to_best_overall_response": {
-        "description": "Number of days between the date used for index and the date of the patient's best overall response.",
-        "type": "integer"
+      "days_to_birth": {
+        "maximum": 0,
+        "minimum": -32872,
+        "term": {
+          "description": "Time interval from a person's date of birth to the date of initial pathologic diagnosis, represented as a calculated negative number of days.\n",
+          "termDef": {
+            "cde_id": 3008233,
+            "cde_version": 1,
+            "source": "caDSR",
+            "term": "Person Birth Date Less Initial Pathologic Diagnosis Date Calculated Day Value",
+            "term_url": "https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=3008233&version=1.0"
+          }
+        },
+        "type": [
+          "number",
+          "null"
+        ]
       },
-      "days_to_diagnosis": {
-        "description": "Number of days between the date used for index and the date of the patient's diagnosis.",
-        "type": "integer"
+      "days_to_death": {
+        "maximum": 32872,
+        "minimum": 0,
+        "term": {
+          "description": "Time interval from a person's date of death to the date of initial pathologic diagnosis, represented as a calculated number of days.\n",
+          "termDef": {
+            "cde_id": 3165475,
+            "cde_version": 1,
+            "source": "caDSR",
+            "term": "Death Less Initial Pathologic Diagnosis Date Calculated Day Value",
+            "term_url": "https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=3165475&version=1.0"
+          }
+        },
+        "type": "number"
+      },
+      "days_to_hiv_diagnosis": {
+        "term": {
+          "description": "Time interval from the date of the initial pathologic diagnosis to the date of human immunodeficiency diagnosis, represented as a calculated number of days.\n",
+          "termDef": {
+            "cde_id": 4618491,
+            "cde_version": 1,
+            "source": "caDSR",
+            "term": "Human Immunodeficiency Virus Diagnosis Subtract Initial Pathologic Diagnosis Time Duration Day Calculation Value",
+            "term_url": "https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=4618491&version=1.0"
+          }
+        },
+        "type": [
+          "number",
+          "null"
+        ]
+      },
+      "days_to_last_follow_up": {
+        "term": {
+          "description": "Time interval from the date of last follow up to the date of initial pathologic diagnosis, represented as a calculated number of days.\n",
+          "termDef": {
+            "cde_id": 3008273,
+            "cde_version": 1,
+            "source": "caDSR",
+            "term": "Last Communication Contact Less Initial Pathologic Diagnosis Date Calculated Day Value",
+            "term_url": "https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=3008273&version=1.0"
+          }
+        },
+        "type": [
+          "number",
+          "null"
+        ]
+      },
+      "days_to_last_known_disease_status": {
+        "term": {
+          "description": "Time interval from the date of last follow up to the date of initial pathologic diagnosis, represented as a calculated number of days.\n",
+          "termDef": {
+            "cde_id": 3008273,
+            "cde_version": 1,
+            "source": "caDSR",
+            "term": "Last Communication Contact Less Initial Pathologic Diagnosis Date Calculated Day Value",
+            "term_url": "https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=3008273&version=1.0"
+          }
+        },
+        "type": [
+          "number",
+          "null"
+        ]
+      },
+      "days_to_new_event": {
+        "term": {
+          "description": "Time interval from the date of new tumor event including progression, recurrence and new primary malignacies to the date of initial pathologic diagnosis, represented as a calculated number of days.\n",
+          "termDef": {
+            "cde_id": 3392464,
+            "cde_version": 1,
+            "source": "caDSR",
+            "term": "New Tumor Event Less Initial Pathologic Diagnosis Date Calculated Day Value",
+            "term_url": "https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=3392464&version=1.0"
+          }
+        },
+        "type": [
+          "number",
+          "null"
+        ]
+      },
+      "days_to_recurrence": {
+        "term": {
+          "description": "Time interval from the date of new tumor event including progression, recurrence and new primary malignancies to the date of initial pathologic diagnosis, represented as a calculated number of days.\n",
+          "termDef": {
+            "cde_id": 3392464,
+            "cde_version": 1,
+            "source": "caDSR",
+            "term": "New Tumor Event Less Initial Pathologic Diagnosis Date Calculated Day Value",
+            "term_url": "https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=3392464&version=1.0"
+          }
+        },
+        "type": [
+          "number",
+          "null"
+        ]
+      },
+      "figo_stage": {
+        "enum": [
+          "Stage 0",
+          "Stage I",
+          "Stage IA",
+          "Stage IA1",
+          "Stage IA2",
+          "Stage IB",
+          "Stage IB1",
+          "Stage IB2",
+          "Stage IC",
+          "Stage II",
+          "Stage IIA",
+          "Stage IIA1",
+          "Stage IIA2",
+          "Stage IIB",
+          "Stage III",
+          "Stage IIIA",
+          "Stage IIIB",
+          "Stage IIIC",
+          "Stage IIIC1",
+          "Stage IIIC2",
+          "Stage IV",
+          "Stage IVA",
+          "Stage IVB",
+          "Unknown",
+          "Not Reported",
+          "Not Allowed To Collect"
+        ],
+        "term": {
+          "description": "The extent of a cervical or endometrial cancer within the body, especially whether the disease has spread from the original site to other parts of the body, as described by the International Federation of Gynecology and Obstetrics (FIGO) stages.\n",
+          "termDef": {
+            "cde_id": 3225684,
+            "cde_version": 1,
+            "source": "caDSR",
+            "term": "Gynecologic Tumor Grouping Cervical Endometrial FIGO 2009 Stage",
+            "term_url": "https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=3225684&version=1.0"
+          }
+        }
+      },
+      "hiv_positive": {
+        "enum": [
+          "Yes",
+          "No",
+          "Unknown"
+        ],
+        "term": {
+          "description": "Text term to signify whether a physician has diagnosed HIV infection in a patient.\n",
+          "termDef": {
+            "cde_id": 4030799,
+            "cde_version": 1,
+            "source": "caDSR",
+            "term": "Physician Diagnosed HIV Infection Personal Medical History Yes No Not Applicable Indicator",
+            "term_url": "https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=4030799&version=1.0"
+          }
+        }
+      },
+      "hpv_positive_type": {
+        "enum": [
+          "HPV 16",
+          "HPV 18",
+          "Other HPV type(s)",
+          "Unknown"
+        ],
+        "term": {
+          "description": "Text classification to represent the strain or type of human papillomavirus identified in an individual.\n",
+          "termDef": {
+            "cde_id": 2922649,
+            "cde_version": 1,
+            "source": "caDSR",
+            "term": "Human Papillomavirus Type",
+            "term_url": "https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=2922649&version=1.0"
+          }
+        }
+      },
+      "hpv_status": {
+        "enum": [
+          "Negative",
+          "Positive",
+          "Unknown"
+        ],
+        "term": {
+          "description": "The findings of the oncogenic HPV.\n",
+          "termDef": {
+            "cde_id": 2230033,
+            "cde_version": 1,
+            "source": "caDSR",
+            "term": "Oncogenic Human Papillomavirus Result Type",
+            "term_url": "https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=2230033&version=1.0"
+          }
+        }
       },
       "id": {
         "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
@@ -7363,6 +5573,108 @@
           }
         },
         "type": "string"
+      },
+      "last_known_disease_status": {
+        "enum": [
+          "Distant met recurrence/progression",
+          "Loco-regional recurrence/progression",
+          "Biochemical evidence of disease without structural correlate",
+          "Tumor free",
+          "Unknown tumor status",
+          "With tumor",
+          "not reported",
+          "Not Allowed To Collect"
+        ],
+        "term": {
+          "description": "Text term that describes the last known state or condition of an individual's neoplasm.\n",
+          "termDef": {
+            "cde_id": 5424231,
+            "cde_version": 1,
+            "source": "caDSR",
+            "term": "Person Last Known Neoplasm Status",
+            "term_url": "https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=2759550&version=1.0"
+          }
+        }
+      },
+      "laterality": {
+        "enum": [
+          "Bilateral",
+          "Left",
+          "Right",
+          "Unknown"
+        ],
+        "term": {
+          "description": "For tumors in paired organs, designates the side on which the cancer originates.\n",
+          "termDef": {
+            "cde_id": 827,
+            "cde_version": 3,
+            "source": "caDSR",
+            "term": "Primary Tumor Laterality",
+            "term_url": "https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=827&version=3.0"
+          }
+        }
+      },
+      "ldh_level_at_diagnosis": {
+        "term": {
+          "description": "The 2 decimal place numeric laboratory value measured, assigned or computed related to the assessment of lactate dehydrogenase in a specimen.\n",
+          "termDef": {
+            "cde_id": 2798766,
+            "cde_version": 1,
+            "source": "caDSR",
+            "term": "Laboratory Procedure Lactate Dehydrogenase Result Integer::2 Decimal Place Value",
+            "term_url": "https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=2798766&version=1.0"
+          }
+        },
+        "type": [
+          "number",
+          "null"
+        ]
+      },
+      "ldh_normal_range_upper": {
+        "term": {
+          "description": "The top value of the range of statistical characteristics that are supposed to represent accepted standard, non-pathological pattern for lactate dehydrogenase (units not specified).\n",
+          "termDef": {
+            "cde_id": 2597015,
+            "cde_version": 1,
+            "source": "caDSR",
+            "term": "Laboratory Procedure Lactate Dehydrogenase Result Upper Limit of Normal Value",
+            "term_url": "https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=2597015&version=1.0"
+          }
+        },
+        "type": [
+          "number",
+          "null"
+        ]
+      },
+      "lymph_nodes_positive": {
+        "term": {
+          "description": "The number of lymph nodes involved with disease as determined by pathologic examination.\n",
+          "termDef": {
+            "cde_id": 89,
+            "cde_version": 3,
+            "source": "caDSR",
+            "term": "Lymph Node(s) Positive Number",
+            "term_url": "https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=89&version=3.0"
+          }
+        },
+        "type": "integer"
+      },
+      "lymphatic_invasion_present": {
+        "enum": [
+          "Yes",
+          "No",
+          "Unknown"
+        ],
+        "term": {
+          "description": "A yes/no indicator to ask if small or thin-walled vessel invasion is present, indicating lymphatic involvement\n",
+          "termDef": {
+            "cde_id": 64171,
+            "cde_version": 3,
+            "source": "caDSR",
+            "term": "Lymphatic/Small vessel Invasion Ind",
+            "term_url": "https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=64171&version=3.0"
+          }
+        }
       },
       "method_of_diagnosis": {
         "enum": [
@@ -7382,7 +5694,9 @@
           "Other",
           "Surgical Resection",
           "Ultrasound Guided Biopsy",
-          "Unknown"
+          "Unknown",
+          "Not Reported",
+          "Not Allowed To Collect"
         ],
         "term": {
           "description": "The method used to initially the patient's diagnosis.\n",
@@ -7396,1090 +5710,6 @@
         }
       },
       "morphology": {
-        "enum": [
-          "8000/0",
-          "8000/1",
-          "8000/3",
-          "8000/6",
-          "8000/9",
-          "8001/0",
-          "8001/1",
-          "8001/3",
-          "8002/3",
-          "8003/3",
-          "8004/3",
-          "8005/0",
-          "8005/3",
-          "8010/0",
-          "8010/2",
-          "8010/3",
-          "8010/6",
-          "8010/9",
-          "8011/0",
-          "8011/3",
-          "8012/3",
-          "8013/3",
-          "8014/3",
-          "8015/3",
-          "8020/3",
-          "8021/3",
-          "8022/3",
-          "8030/3",
-          "8031/3",
-          "8032/3",
-          "8033/3",
-          "8034/3",
-          "8035/3",
-          "8040/0",
-          "8040/1",
-          "8041/3",
-          "8042/3",
-          "8043/3",
-          "8044/3",
-          "8045/3",
-          "8046/3",
-          "8050/0",
-          "8050/2",
-          "8050/3",
-          "8051/0",
-          "8051/3",
-          "8052/0",
-          "8052/2",
-          "8052/3",
-          "8053/0",
-          "8060/0",
-          "8070/2",
-          "8070/3",
-          "8070/6",
-          "8071/3",
-          "8072/3",
-          "8073/3",
-          "8074/3",
-          "8075/3",
-          "8076/2",
-          "8076/3",
-          "8077/0",
-          "8077/2",
-          "8078/3",
-          "8080/2",
-          "8081/2",
-          "8082/3",
-          "8083/3",
-          "8084/3",
-          "8090/1",
-          "8090/3",
-          "8091/3",
-          "8092/3",
-          "8093/3",
-          "8094/3",
-          "8095/3",
-          "8096/0",
-          "8097/3",
-          "8098/3",
-          "8100/0",
-          "8101/0",
-          "8102/0",
-          "8102/3",
-          "8103/0",
-          "8110/0",
-          "8110/3",
-          "8120/0",
-          "8120/1",
-          "8120/2",
-          "8120/3",
-          "8121/0",
-          "8121/1",
-          "8121/3",
-          "8122/3",
-          "8123/3",
-          "8124/3",
-          "8130/1",
-          "8130/2",
-          "8130/3",
-          "8131/3",
-          "8140/0",
-          "8140/1",
-          "8140/2",
-          "8140/3",
-          "8140/6",
-          "8141/3",
-          "8142/3",
-          "8143/3",
-          "8144/3",
-          "8145/3",
-          "8146/0",
-          "8147/0",
-          "8147/3",
-          "8148/0",
-          "8148/2",
-          "8149/0",
-          "8150/0",
-          "8150/1",
-          "8150/3",
-          "8151/0",
-          "8151/3",
-          "8152/1",
-          "8152/3",
-          "8153/1",
-          "8153/3",
-          "8154/3",
-          "8155/1",
-          "8155/3",
-          "8156/1",
-          "8156/3",
-          "8158/1",
-          "8160/0",
-          "8160/3",
-          "8161/0",
-          "8161/3",
-          "8162/3",
-          "8163/0",
-          "8163/2",
-          "8163/3",
-          "8170/0",
-          "8170/3",
-          "8171/3",
-          "8172/3",
-          "8173/3",
-          "8174/3",
-          "8175/3",
-          "8180/3",
-          "8190/0",
-          "8190/3",
-          "8191/0",
-          "8200/0",
-          "8200/3",
-          "8201/2",
-          "8201/3",
-          "8202/0",
-          "8204/0",
-          "8210/0",
-          "8210/2",
-          "8210/3",
-          "8211/0",
-          "8211/3",
-          "8212/0",
-          "8213/0",
-          "8213/3",
-          "8214/3",
-          "8215/3",
-          "8220/0",
-          "8220/3",
-          "8221/0",
-          "8221/3",
-          "8230/2",
-          "8230/3",
-          "8231/3",
-          "8240/1",
-          "8240/3",
-          "8241/3",
-          "8242/1",
-          "8242/3",
-          "8243/3",
-          "8244/3",
-          "8245/1",
-          "8245/3",
-          "8246/3",
-          "8247/3",
-          "8248/1",
-          "8249/3",
-          "8250/1",
-          "8250/3",
-          "8251/0",
-          "8251/3",
-          "8252/3",
-          "8253/3",
-          "8254/3",
-          "8255/3",
-          "8260/0",
-          "8260/3",
-          "8261/0",
-          "8261/2",
-          "8261/3",
-          "8262/3",
-          "8263/0",
-          "8263/2",
-          "8263/3",
-          "8264/0",
-          "8265/3",
-          "8270/0",
-          "8270/3",
-          "8271/0",
-          "8272/0",
-          "8272/3",
-          "8280/0",
-          "8280/3",
-          "8281/0",
-          "8281/3",
-          "8290/0",
-          "8290/3",
-          "8300/0",
-          "8300/3",
-          "8310/0",
-          "8310/3",
-          "8311/1",
-          "8312/3",
-          "8313/0",
-          "8313/1",
-          "8313/3",
-          "8314/3",
-          "8315/3",
-          "8316/3",
-          "8317/3",
-          "8318/3",
-          "8319/3",
-          "8320/3",
-          "8321/0",
-          "8322/0",
-          "8322/3",
-          "8323/0",
-          "8323/3",
-          "8324/0",
-          "8325/0",
-          "8330/0",
-          "8330/1",
-          "8330/3",
-          "8331/3",
-          "8332/3",
-          "8333/0",
-          "8333/3",
-          "8334/0",
-          "8335/3",
-          "8336/0",
-          "8337/3",
-          "8340/3",
-          "8341/3",
-          "8342/3",
-          "8343/3",
-          "8344/3",
-          "8345/3",
-          "8346/3",
-          "8347/3",
-          "8350/3",
-          "8360/1",
-          "8361/0",
-          "8370/0",
-          "8370/3",
-          "8371/0",
-          "8372/0",
-          "8373/0",
-          "8374/0",
-          "8375/0",
-          "8380/0",
-          "8380/1",
-          "8380/3",
-          "8381/0",
-          "8381/1",
-          "8381/3",
-          "8382/3",
-          "8383/3",
-          "8384/3",
-          "8390/0",
-          "8390/3",
-          "8391/0",
-          "8392/0",
-          "8400/0",
-          "8400/1",
-          "8400/3",
-          "8401/0",
-          "8401/3",
-          "8402/0",
-          "8402/3",
-          "8403/0",
-          "8403/3",
-          "8404/0",
-          "8405/0",
-          "8406/0",
-          "8407/0",
-          "8407/3",
-          "8408/0",
-          "8408/1",
-          "8408/3",
-          "8409/0",
-          "8409/3",
-          "8410/0",
-          "8410/3",
-          "8413/3",
-          "8420/0",
-          "8420/3",
-          "8430/1",
-          "8430/3",
-          "8440/0",
-          "8440/3",
-          "8441/0",
-          "8441/3",
-          "8442/1",
-          "8443/0",
-          "8444/1",
-          "8450/0",
-          "8450/3",
-          "8451/1",
-          "8452/1",
-          "8452/3",
-          "8453/0",
-          "8453/2",
-          "8453/3",
-          "8454/0",
-          "8460/0",
-          "8460/3",
-          "8461/0",
-          "8461/3",
-          "8462/1",
-          "8463/1",
-          "8470/0",
-          "8470/2",
-          "8470/3",
-          "8471/0",
-          "8471/3",
-          "8472/1",
-          "8473/1",
-          "8480/0",
-          "8480/1",
-          "8480/3",
-          "8480/6",
-          "8481/3",
-          "8482/3",
-          "8490/3",
-          "8490/6",
-          "8500/2",
-          "8500/3",
-          "8501/2",
-          "8501/3",
-          "8502/3",
-          "8503/0",
-          "8503/2",
-          "8503/3",
-          "8504/0",
-          "8504/2",
-          "8504/3",
-          "8505/0",
-          "8506/0",
-          "8507/2",
-          "8508/3",
-          "8510/3",
-          "8512/3",
-          "8513/3",
-          "8514/3",
-          "8520/2",
-          "8520/3",
-          "8521/3",
-          "8522/2",
-          "8522/3",
-          "8523/3",
-          "8524/3",
-          "8525/3",
-          "8530/3",
-          "8540/3",
-          "8541/3",
-          "8542/3",
-          "8543/3",
-          "8550/0",
-          "8550/1",
-          "8550/3",
-          "8551/3",
-          "8552/3",
-          "8560/0",
-          "8560/3",
-          "8561/0",
-          "8562/3",
-          "8570/3",
-          "8571/3",
-          "8572/3",
-          "8573/3",
-          "8574/3",
-          "8575/3",
-          "8576/3",
-          "8580/0",
-          "8580/1",
-          "8580/3",
-          "8581/1",
-          "8581/3",
-          "8582/1",
-          "8582/3",
-          "8583/1",
-          "8583/3",
-          "8584/1",
-          "8584/3",
-          "8585/1",
-          "8585/3",
-          "8586/3",
-          "8587/0",
-          "8588/3",
-          "8589/3",
-          "8590/1",
-          "8591/1",
-          "8592/1",
-          "8593/1",
-          "8600/0",
-          "8600/3",
-          "8601/0",
-          "8602/0",
-          "8610/0",
-          "8620/1",
-          "8620/3",
-          "8621/1",
-          "8622/1",
-          "8623/1",
-          "8630/0",
-          "8630/1",
-          "8630/3",
-          "8631/0",
-          "8631/1",
-          "8631/3",
-          "8632/1",
-          "8633/1",
-          "8634/1",
-          "8634/3",
-          "8640/1",
-          "8640/3",
-          "8641/0",
-          "8642/1",
-          "8650/0",
-          "8650/1",
-          "8650/3",
-          "8660/0",
-          "8670/0",
-          "8670/3",
-          "8671/0",
-          "8680/0",
-          "8680/1",
-          "8680/3",
-          "8681/1",
-          "8682/1",
-          "8683/0",
-          "8690/1",
-          "8691/1",
-          "8692/1",
-          "8693/1",
-          "8693/3",
-          "8700/0",
-          "8700/3",
-          "8710/3",
-          "8711/0",
-          "8711/3",
-          "8712/0",
-          "8713/0",
-          "8720/0",
-          "8720/2",
-          "8720/3",
-          "8721/3",
-          "8722/0",
-          "8722/3",
-          "8723/0",
-          "8723/3",
-          "8725/0",
-          "8726/0",
-          "8727/0",
-          "8728/0",
-          "8728/1",
-          "8728/3",
-          "8730/0",
-          "8730/3",
-          "8740/0",
-          "8740/3",
-          "8741/2",
-          "8741/3",
-          "8742/2",
-          "8742/3",
-          "8743/3",
-          "8744/3",
-          "8745/3",
-          "8746/3",
-          "8750/0",
-          "8760/0",
-          "8761/0",
-          "8761/1",
-          "8761/3",
-          "8762/1",
-          "8770/0",
-          "8770/3",
-          "8771/0",
-          "8771/3",
-          "8772/0",
-          "8772/3",
-          "8773/3",
-          "8774/3",
-          "8780/0",
-          "8780/3",
-          "8790/0",
-          "8800/0",
-          "8800/3",
-          "8800/9",
-          "8801/3",
-          "8802/3",
-          "8803/3",
-          "8804/3",
-          "8805/3",
-          "8806/3",
-          "8810/0",
-          "8810/1",
-          "8810/3",
-          "8811/0",
-          "8811/3",
-          "8812/0",
-          "8812/3",
-          "8813/0",
-          "8813/3",
-          "8814/3",
-          "8815/0",
-          "8815/3",
-          "8820/0",
-          "8821/1",
-          "8822/1",
-          "8823/0",
-          "8824/0",
-          "8824/1",
-          "8825/0",
-          "8825/1",
-          "8826/0",
-          "8827/1",
-          "8830/0",
-          "8830/1",
-          "8830/3",
-          "8831/0",
-          "8832/0",
-          "8832/3",
-          "8833/3",
-          "8834/1",
-          "8835/1",
-          "8836/1",
-          "8840/0",
-          "8840/3",
-          "8841/1",
-          "8842/0",
-          "8850/0",
-          "8850/1",
-          "8850/3",
-          "8851/0",
-          "8851/3",
-          "8852/0",
-          "8852/3",
-          "8853/3",
-          "8854/0",
-          "8854/3",
-          "8855/3",
-          "8856/0",
-          "8857/0",
-          "8857/3",
-          "8858/3",
-          "8860/0",
-          "8861/0",
-          "8862/0",
-          "8870/0",
-          "8880/0",
-          "8881/0",
-          "8890/0",
-          "8890/1",
-          "8890/3",
-          "8891/0",
-          "8891/3",
-          "8892/0",
-          "8893/0",
-          "8894/0",
-          "8894/3",
-          "8895/0",
-          "8895/3",
-          "8896/3",
-          "8897/1",
-          "8898/1",
-          "8900/0",
-          "8900/3",
-          "8901/3",
-          "8902/3",
-          "8903/0",
-          "8904/0",
-          "8905/0",
-          "8910/3",
-          "8912/3",
-          "8920/3",
-          "8921/3",
-          "8930/0",
-          "8930/3",
-          "8931/3",
-          "8932/0",
-          "8933/3",
-          "8934/3",
-          "8935/0",
-          "8935/1",
-          "8935/3",
-          "8936/0",
-          "8936/1",
-          "8936/3",
-          "8940/0",
-          "8940/3",
-          "8941/3",
-          "8950/3",
-          "8951/3",
-          "8959/0",
-          "8959/1",
-          "8959/3",
-          "8960/1",
-          "8960/3",
-          "8963/3",
-          "8964/3",
-          "8965/0",
-          "8966/0",
-          "8967/0",
-          "8970/3",
-          "8971/3",
-          "8972/3",
-          "8973/3",
-          "8974/1",
-          "8975/1",
-          "8980/3",
-          "8981/3",
-          "8982/0",
-          "8982/3",
-          "8983/0",
-          "8990/0",
-          "8990/1",
-          "8990/3",
-          "8991/3",
-          "9000/0",
-          "9000/1",
-          "9000/3",
-          "9010/0",
-          "9011/0",
-          "9012/0",
-          "9013/0",
-          "9014/0",
-          "9014/1",
-          "9014/3",
-          "9015/0",
-          "9015/1",
-          "9015/3",
-          "9016/0",
-          "9020/0",
-          "9020/1",
-          "9020/3",
-          "9030/0",
-          "9040/0",
-          "9040/3",
-          "9041/3",
-          "9042/3",
-          "9043/3",
-          "9044/3",
-          "9050/0",
-          "9050/3",
-          "9051/0",
-          "9051/3",
-          "9052/0",
-          "9052/3",
-          "9053/3",
-          "9054/0",
-          "9055/0",
-          "9055/1",
-          "9060/3",
-          "9061/3",
-          "9062/3",
-          "9063/3",
-          "9064/2",
-          "9064/3",
-          "9065/3",
-          "9070/3",
-          "9071/3",
-          "9072/3",
-          "9073/1",
-          "9080/0",
-          "9080/1",
-          "9080/3",
-          "9081/3",
-          "9082/3",
-          "9083/3",
-          "9084/0",
-          "9084/3",
-          "9085/3",
-          "9090/0",
-          "9090/3",
-          "9091/1",
-          "9100/0",
-          "9100/1",
-          "9100/3",
-          "9101/3",
-          "9102/3",
-          "9103/0",
-          "9104/1",
-          "9105/3",
-          "9110/0",
-          "9110/1",
-          "9110/3",
-          "9120/0",
-          "9120/3",
-          "9121/0",
-          "9122/0",
-          "9123/0",
-          "9124/3",
-          "9125/0",
-          "9130/0",
-          "9130/1",
-          "9130/3",
-          "9131/0",
-          "9132/0",
-          "9133/1",
-          "9133/3",
-          "9135/1",
-          "9136/1",
-          "9140/3",
-          "9141/0",
-          "9142/0",
-          "9150/0",
-          "9150/1",
-          "9150/3",
-          "9160/0",
-          "9161/0",
-          "9161/1",
-          "9170/0",
-          "9170/3",
-          "9171/0",
-          "9172/0",
-          "9173/0",
-          "9174/0",
-          "9174/1",
-          "9175/0",
-          "9180/0",
-          "9180/3",
-          "9181/3",
-          "9182/3",
-          "9183/3",
-          "9184/3",
-          "9185/3",
-          "9186/3",
-          "9187/3",
-          "9191/0",
-          "9192/3",
-          "9193/3",
-          "9194/3",
-          "9195/3",
-          "9200/0",
-          "9200/1",
-          "9210/0",
-          "9210/1",
-          "9220/0",
-          "9220/1",
-          "9220/3",
-          "9221/0",
-          "9221/3",
-          "9230/0",
-          "9230/3",
-          "9231/3",
-          "9240/3",
-          "9241/0",
-          "9242/3",
-          "9243/3",
-          "9250/1",
-          "9250/3",
-          "9251/1",
-          "9251/3",
-          "9252/0",
-          "9252/3",
-          "9260/3",
-          "9261/3",
-          "9262/0",
-          "9270/0",
-          "9270/1",
-          "9270/3",
-          "9271/0",
-          "9272/0",
-          "9273/0",
-          "9274/0",
-          "9275/0",
-          "9280/0",
-          "9281/0",
-          "9282/0",
-          "9290/0",
-          "9290/3",
-          "9300/0",
-          "9301/0",
-          "9302/0",
-          "9310/0",
-          "9310/3",
-          "9311/0",
-          "9312/0",
-          "9320/0",
-          "9321/0",
-          "9322/0",
-          "9330/0",
-          "9330/3",
-          "9340/0",
-          "9341/1",
-          "9342/3",
-          "9350/1",
-          "9351/1",
-          "9352/1",
-          "9360/1",
-          "9361/1",
-          "9362/3",
-          "9363/0",
-          "9364/3",
-          "9365/3",
-          "9370/3",
-          "9371/3",
-          "9372/3",
-          "9373/0",
-          "9380/3",
-          "9381/3",
-          "9382/3",
-          "9383/1",
-          "9384/1",
-          "9390/0",
-          "9390/1",
-          "9390/3",
-          "9391/3",
-          "9392/3",
-          "9393/3",
-          "9394/1",
-          "9395/3",
-          "9400/3",
-          "9401/3",
-          "9410/3",
-          "9411/3",
-          "9412/1",
-          "9413/0",
-          "9420/3",
-          "9421/1",
-          "9423/3",
-          "9424/3",
-          "9425/3",
-          "9430/3",
-          "9431/1",
-          "9432/1",
-          "9440/3",
-          "9441/3",
-          "9442/1",
-          "9442/3",
-          "9444/1",
-          "9450/3",
-          "9451/3",
-          "9460/3",
-          "9470/3",
-          "9471/3",
-          "9472/3",
-          "9473/3",
-          "9474/3",
-          "9480/3",
-          "9490/0",
-          "9490/3",
-          "9491/0",
-          "9492/0",
-          "9493/0",
-          "9500/3",
-          "9501/0",
-          "9501/3",
-          "9502/0",
-          "9502/3",
-          "9503/3",
-          "9504/3",
-          "9505/1",
-          "9505/3",
-          "9506/1",
-          "9507/0",
-          "9508/3",
-          "9509/1",
-          "9510/0",
-          "9510/3",
-          "9511/3",
-          "9512/3",
-          "9513/3",
-          "9514/1",
-          "9520/3",
-          "9521/3",
-          "9522/3",
-          "9523/3",
-          "9530/0",
-          "9530/1",
-          "9530/3",
-          "9531/0",
-          "9532/0",
-          "9533/0",
-          "9534/0",
-          "9535/0",
-          "9537/0",
-          "9538/1",
-          "9538/3",
-          "9539/1",
-          "9539/3",
-          "9540/0",
-          "9540/1",
-          "9540/3",
-          "9541/0",
-          "9550/0",
-          "9560/0",
-          "9560/1",
-          "9560/3",
-          "9561/3",
-          "9562/0",
-          "9570/0",
-          "9571/0",
-          "9571/3",
-          "9580/0",
-          "9580/3",
-          "9581/3",
-          "9582/0",
-          "9590/3",
-          "9591/3",
-          "9596/3",
-          "9597/3",
-          "9650/3",
-          "9651/3",
-          "9652/3",
-          "9653/3",
-          "9654/3",
-          "9655/3",
-          "9659/3",
-          "9661/3",
-          "9662/3",
-          "9663/3",
-          "9664/3",
-          "9665/3",
-          "9667/3",
-          "9670/3",
-          "9671/3",
-          "9673/3",
-          "9675/3",
-          "9678/3",
-          "9679/3",
-          "9680/3",
-          "9684/3",
-          "9687/3",
-          "9688/3",
-          "9689/3",
-          "9690/3",
-          "9691/3",
-          "9695/3",
-          "9698/3",
-          "9699/3",
-          "9700/3",
-          "9701/3",
-          "9702/3",
-          "9705/3",
-          "9708/3",
-          "9709/3",
-          "9712/3",
-          "9714/3",
-          "9716/3",
-          "9717/3",
-          "9718/3",
-          "9719/3",
-          "9724/3",
-          "9725/3",
-          "9726/3",
-          "9727/3",
-          "9728/3",
-          "9729/3",
-          "9731/3",
-          "9732/3",
-          "9733/3",
-          "9734/3",
-          "9735/3",
-          "9737/3",
-          "9738/3",
-          "9740/1",
-          "9740/3",
-          "9741/1",
-          "9741/3",
-          "9742/3",
-          "9750/3",
-          "9751/1",
-          "9751/3",
-          "9752/1",
-          "9753/1",
-          "9754/3",
-          "9755/3",
-          "9756/3",
-          "9757/3",
-          "9758/3",
-          "9759/3",
-          "9760/3",
-          "9761/3",
-          "9762/3",
-          "9764/3",
-          "9765/1",
-          "9766/1",
-          "9767/1",
-          "9768/1",
-          "9769/1",
-          "9800/3",
-          "9801/3",
-          "9805/3",
-          "9806/3",
-          "9807/3",
-          "9808/3",
-          "9809/3",
-          "9811/3",
-          "9812/3",
-          "9813/3",
-          "9814/3",
-          "9815/3",
-          "9816/3",
-          "9817/3",
-          "9818/3",
-          "9820/3",
-          "9823/3",
-          "9826/3",
-          "9827/3",
-          "9831/3",
-          "9832/3",
-          "9833/3",
-          "9834/3",
-          "9835/3",
-          "9836/3",
-          "9837/3",
-          "9840/3",
-          "9860/3",
-          "9861/3",
-          "9863/3",
-          "9865/3",
-          "9866/3",
-          "9867/3",
-          "9869/3",
-          "9870/3",
-          "9871/3",
-          "9872/3",
-          "9873/3",
-          "9874/3",
-          "9875/3",
-          "9876/3",
-          "9891/3",
-          "9895/3",
-          "9896/3",
-          "9897/3",
-          "9898/1",
-          "9898/3",
-          "9910/3",
-          "9911/3",
-          "9920/3",
-          "9930/3",
-          "9931/3",
-          "9940/3",
-          "9945/3",
-          "9946/3",
-          "9948/3",
-          "9950/3",
-          "9960/3",
-          "9961/3",
-          "9962/3",
-          "9963/3",
-          "9964/3",
-          "9965/3",
-          "9966/3",
-          "9967/3",
-          "9970/1",
-          "9971/1",
-          "9971/3",
-          "9975/3",
-          "9980/3",
-          "9982/3",
-          "9983/3",
-          "9984/3",
-          "9985/3",
-          "9986/3",
-          "9987/3",
-          "9989/3",
-          "9991/3",
-          "9992/3",
-          "Unknown",
-          "Not Applicable"
-        ],
         "term": {
           "description": "The third edition of the International Classification of Diseases for Oncology, published in 2000 used principally in tumor and cancer registries for coding the site (topography) and the histology (morphology) of neoplasms. The study of the structure of the cells and their arrangement to constitute tissues and, finally, the association among these to form organs. In pathology, the microscopic process of identifying normal and abnormal morphologic characteristics in tissues, by employing various cytochemical and immunocytochemical stains. A system of numbered categories for representation of data.\n",
           "termDef": {
@@ -8489,2475 +5719,178 @@
             "term": "International Classification of Diseases for Oncology, Third Edition ICD-O-3 Histology Code",
             "term_url": "https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=3226275&version=1.0"
           }
+        },
+        "type": "string"
+      },
+      "new_event_anatomic_site": {
+        "enum": [
+          "Abdomen",
+          "Adrenal",
+          "Anus",
+          "Appendix",
+          "Ascites/Peritoneum",
+          "Axillary lymph nodes",
+          "Bladder",
+          "Bone",
+          "Bone Marrow",
+          "Brain",
+          "Breast",
+          "Cervical lymph nodes",
+          "Cervix",
+          "Colon",
+          "Conjunctiva",
+          "Contralateral Pleura",
+          "Distant Metastasis",
+          "Epididymis",
+          "Epidural",
+          "Epitrochlear lymph nodes",
+          "Esophagus",
+          "Extremities",
+          "Femoral lymph nodes",
+          "Gallbladder",
+          "Gastrointestinal/Abdominal",
+          "Head & Neck",
+          "Heart",
+          "Hilar lymph nodes",
+          "Hypopharynx",
+          "Iliac Lymph Node",
+          "Iliac-common lymph nodes",
+          "Iliac-external lymph nodes",
+          "Inguinal lymph nodes",
+          "Intraocular",
+          "Ipsilateral Chest Cavity",
+          "Ipsilateral Chest Wall",
+          "Ipsilateral Lymph Nodes",
+          "Ipsilateral Pleura",
+          "Kidney",
+          "Large Intestine",
+          "Larynx",
+          "Leptomeninges",
+          "Liver",
+          "Lung",
+          "Lymph Node Only",
+          "Lymph Node(s)",
+          "Mandible",
+          "Maxilla",
+          "Mediastinal Soft Tissue",
+          "Mediastinal lymph nodes",
+          "Mediastinal/Intra-thoracic",
+          "Mesenteric lymph nodes",
+          "Nasal Soft Tissue",
+          "Nasopharynx",
+          "No Known Extranodal Involvement",
+          "Non-regional / Distant Lymph Nodes",
+          "Not Applicable",
+          "Occipital lymph nodes",
+          "Oral Cavity",
+          "Oropharynx",
+          "Other",
+          "Other Extranodal Site",
+          "Other, specify",
+          "Ovary",
+          "Pancreas",
+          "Paraaortic lymph nodes",
+          "Parotid Gland",
+          "Parotid lymph nodes",
+          "Pelvis",
+          "Peri-orbital Soft Tissue",
+          "Pericardium",
+          "Perihilar Lymph Node",
+          "Peripheral Blood",
+          "Peritoneal Surfaces",
+          "Pleura/Pleural Effusion",
+          "Popliteal lymph nodes",
+          "Prostate",
+          "Pulmonary",
+          "Rectum",
+          "Renal Pelvis",
+          "Retroperitoneal lymph nodes",
+          "Retroperitoneum",
+          "Salivary Gland",
+          "Sinus",
+          "Skin",
+          "Small Intestine",
+          "Soft Tissue",
+          "Splenic lymph nodes",
+          "Stomach",
+          "Submandibular lymph nodes",
+          "Supraclavicular lymph nodes",
+          "Testes",
+          "Thyroid",
+          "Trunk",
+          "Tumor Bed",
+          "Ureter",
+          "Urethra",
+          "Uterus",
+          "Vulva",
+          "Unknown",
+          "Not Reported",
+          "Not Allowed To Collect"
+        ],
+        "term": {
+          "description": "Text term to specify the anatomic location of the return of tumor after treatment.\n",
+          "termDef": {
+            "cde_id": 3108271,
+            "cde_version": 2,
+            "source": "caDSR",
+            "term": "New Neoplasm Event Occurrence Anatomic Site",
+            "term_url": "https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=3108271&version=2.0"
+          }
         }
       },
-      "overall_survival": {
-        "description": "Number of days between the date used for index and the patient's date of death or the date the patient was last known to be alive.",
-        "type": "integer"
+      "new_event_type": {
+        "enum": [
+          "Biochemical Evidence of Disease",
+          "Both Locoregional and Distant Metastasis",
+          "Distant Metastasis",
+          "Extrahepatic Recurrence",
+          "Intrahepatic Recurrence",
+          "Intrapleural Progression",
+          "Locoregional (Urothelial tumor event)",
+          "Locoregional Disease",
+          "Locoregional Recurrence",
+          "Metachronous Testicular Tumor",
+          "Metastatic",
+          "New Primary Tumor",
+          "New primary Melanoma",
+          "No New Tumor Event",
+          "Not Applicable",
+          "Progression of Disease",
+          "Recurrence",
+          "Regional Lymph Node",
+          "Unknown",
+          "Not Reported",
+          "Not Allowed To Collect"
+        ],
+        "term": {
+          "description": "Text term to identify a new tumor event.\n",
+          "termDef": {
+            "cde_id": 3119721,
+            "cde_version": 1,
+            "source": "caDSR",
+            "term": "New Neoplasm Event Type",
+            "term_url": "https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=3119721&version=1.0"
+          }
+        }
+      },
+      "perineural_invasion_present": {
+        "enum": [
+          "Yes",
+          "No",
+          "Unknown"
+        ],
+        "term": {
+          "description": "a yes/no indicator to ask if perineural invasion or infiltration of tumor or cancer is present.\n",
+          "termDef": {
+            "cde_id": 64181,
+            "cde_version": 3,
+            "source": "caDSR",
+            "term": "Tumor Perineural Invasion Ind",
+            "term_url": "https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=64181&version=3.0"
+          }
+        }
       },
       "primary_diagnosis": {
-        "enum": [
-          "Abdominal desmoid",
-          "Abdominal fibromatosis",
-          "Achromic nevus",
-          "Acidophil adenocarcinoma",
-          "Acidophil adenoma",
-          "Acidophil carcinoma",
-          "Acinar adenocarcinoma",
-          "Acinar adenoma",
-          "Acinar carcinoma",
-          "Acinar cell adenoma",
-          "Acinar cell carcinoma",
-          "Acinar cell cystadenocarcinoma",
-          "Acinar cell tumour [obs]",
-          "Acinic cell adenocarcinoma",
-          "Acinic cell adenoma",
-          "Acinic cell tumor [obs]",
-          "Acoustic neuroma",
-          "Acquired tufted hemangioma",
-          "Acral lentiginous melanoma, malignant",
-          "ACTH-producing tumor",
-          "Acute basophilic leukaemia",
-          "Acute bilineal leukemia",
-          "Acute biphenotypic leukemia",
-          "Acute erythremia [obs]",
-          "Acute erythremic myelosis [obs]",
-          "Acute erythroid leukaemia",
-          "Acute granulocytic leukemia",
-          "Acute leukemia, Burkitt type [obs]",
-          "Acute leukemia, NOS",
-          "Acute lymphatic leukemia",
-          "Acute lymphoblastic leukemia-lymphoma, NOS",
-          "Acute lymphoblastic leukemia, L2 type, NOS",
-          "Acute lymphoblastic leukemia, mature B-cell type",
-          "Acute lymphoblastic leukemia, NOS",
-          "Acute lymphoblastic leukemia, precursorcell type",
-          "Acute lymphocytic leukemia",
-          "Acute lymphoid leukemia",
-          "Acute megakaryoblastic leukaemia",
-          "Acute mixed lineage leukemia",
-          "Acute monoblastic and monocytic leukemia",
-          "Acute monoblastic leukemia",
-          "Acute monocytic leukemia",
-          "Acute myeloblastic leukemia",
-          "Acute myelocytic leukemia",
-          "Acute myelofibrosis",
-          "Acute myelogenous leukemia",
-          "Acute myeloid leukaemia, inv(16) (p13;q22)",
-          "Acute myeloid leukaemia, t(8;21)(q22;q22)",
-          "Acute myeloid leukemia (megakaryoblastic) with t(1;22)(p13;q13); RBM15-MKL1",
-          "Acute myeloid leukemia with abnormal marrow eosinophils (includes all variants)",
-          "Acute myeloid leukemia with inv(3) (q21q26.2) or t(3;3) (q21;q26.2); RPN1-EVI1",
-          "Acute myeloid leukemia with maturation",
-          "Acute myeloid leukemia with multilineage dysplasia",
-          "Acute myeloid leukemia with mutated CEBPA",
-          "Acute myeloid leukemia with mutated NPM1",
-          "Acute myeloid leukemia with myelodysplasia-related changes",
-          "Acute myeloid leukemia with prior myelodysplastic syndrome",
-          "Acute myeloid leukemia with t(6;9) (p23;q34); DEK-NUP214",
-          "Acute myeloid leukemia with t(8;21)(q22;q22); RUNX1-RUNX1T1",
-          "Acute myeloid leukemia with t(9;11)(p22;q23); MLLT3-MLL",
-          "Acute myeloid leukemia without maturation",
-          "Acute myeloid leukemia without prior myelodysplastic syndrome",
-          "Acute myeloid leukemia, AML1 (CBF-alpha)/ETO",
-          "Acute myeloid leukemia, CBF-beta/MYH11",
-          "Acute myeloid leukemia, M6 type",
-          "Acute myeloid leukemia, minimal differentiation",
-          "Acute myeloid leukemia, NOS (FAB or WHO type not specified)",
-          "Acute myeloid leukemia, PML/RAR-alpha",
-          "Acute myeloid leukemia, t(15;17) (q22;q11-12)",
-          "Acute myeloid leukemia, t(16;16)(p 13;q 11)",
-          "Acute myelomonocytic leukemia",
-          "Acute myelomonocytic leukemia with abnormal eosinophils",
-          "Acute myelosclerosis, NOS",
-          "Acute myloid leukemia, 11q23 abnormalities",
-          "Acute myloid leukemia, MLL",
-          "Acute non-lymphocytic leukemia",
-          "Acute panmyelosis with myelofibrosis",
-          "Acute panmyelosis, NOS",
-          "Acute progressive histiocytosis X",
-          "Acute promyelocytic leukaemia, PML-RAR-alpha",
-          "Acute promyelocytic leukaemia, t(15;17) (q22;q11-12)",
-          "Acute promyelocytic leukemia, NOS",
-          "Adamantinoma of long bones",
-          "Adamantinoma, malignant (except of long bones)",
-          "Adamantinoma, NOS (except of long bones)",
-          "Adenoacanthoma",
-          "Adenoameloblastoma",
-          "Adenocarcinoid tumor",
-          "Adenocarcinoma combined with other types of carcinoma",
-          "Adenocarcinoma in a polyp, NOS",
-          "Adenocarcinoma in adenomatous polyp",
-          "Adenocarcinoma in adenomatous polyposis coli",
-          "Adenocarcinoma in multiple adenomatous polyps",
-          "Adenocarcinoma in polypoid adenoma",
-          "Adenocarcinoma in situ in a polyp, NOS",
-          "Adenocarcinoma in situ in adenomatous polyp",
-          "Adenocarcinoma in situ in polypoid adenoma",
-          "Adenocarcinoma in situ in tubular adenoma",
-          "Adenocarcinoma in situ in tubulovillous adenoma",
-          "Adenocarcinoma in situ in villous adenoma",
-          "Adenocarcinoma in situ, NOS",
-          "Adenocarcinoma in tubolovillous adenoma",
-          "Adenocarcinoma in tubular adenoma",
-          "Adenocarcinoma in villous adenoma",
-          "Adenocarcinoma of anal ducts",
-          "Adenocarcinoma of anal glands",
-          "Adenocarcinoma with apocrine metaplasia",
-          "Adenocarcinoma with cartilaginous and osseous metaplasia",
-          "Adenocarcinoma with cartilaginous metaplasia",
-          "Adenocarcinoma with mixed subtypes",
-          "Adenocarcinoma with neuroendocrine differentiation",
-          "Adenocarcinoma with osseous metaplasia",
-          "Adenocarcinoma with spindle cell metaplasia",
-          "Adenocarcinoma with squamous metaplasia",
-          "Adenocarcinoma, cribriform comedo-type",
-          "Adenocarcinoma, cylindroid",
-          "Adenocarcinoma, diffuse type",
-          "Adenocarcinoma, endocervical type",
-          "Adenocarcinoma, intestinal type",
-          "Adenocarcinoma, metastatic, NOS",
-          "Adenocarcinoma, NOS",
-          "Adenocarcinoma, pancreatobiliary type",
-          "Adenocystic carcinoma",
-          "Adenofibroma, NOS",
-          "Adenoid basal carcinoma",
-          "Adenoid cystic carcinoma",
-          "Adenolipoma",
-          "Adenolymphoma",
-          "Adenoma of nipple",
-          "Adenoma, NOS",
-          "Adenomatoid odontogenic tumor",
-          "Adenomatoid tumor, NOS",
-          "Adenomatosis, NOS",
-          "Adenomatous polyp, NOS",
-          "Adenomatous polyposis coli",
-          "Adenomyoepithelioma",
-          "Adenomyoma",
-          "Adenosarcoma",
-          "Adenosquamous carcinoma",
-          "Adnexal carcinoma",
-          "Adnexal tumor, benign",
-          "Adrenal cortical adenocarcinoma",
-          "Adrenal cortical adenoma, clear cell",
-          "Adrenal cortical adenoma, compact cell",
-          "Adrenal cortical adenoma, glomerulosa cell",
-          "Adrenal cortical adenoma, mixed cell",
-          "Adrenal cortical adenoma, NOS",
-          "Adrenal cortical adenoma, pigmented",
-          "Adrenal cortical carcinoma",
-          "Adrenal cortical tumor, benign",
-          "Adrenal cortical tumor, malignant",
-          "Adrenal cortical tumor, NOS",
-          "Adrenal medullary paraganglioma",
-          "Adrenal medullary paraganglioma, malignant",
-          "Adrenal rest tumor",
-          "Adult cystic teratoma",
-          "Adult rhabdomyoma",
-          "Adult T-cell leukemia",
-          "Adult T-cell leukemia/lymphoma (HTLV-1 positive) (includes all variants)",
-          "Adult T-cell lymphoma",
-          "Adult T-cell lymphoma/leukemia",
-          "Adult teratoma, NOS",
-          "Aggressive angiomyxoma",
-          "Aggressive digital papillary adenoma",
-          "Aggressive fibromatosis",
-          "Aggressive NK-cell leukaemia",
-          "Aggressive osteoblastoma",
-          "Aggressive systemic mastocytosis",
-          "Agnogenic myeloid metaplasia",
-          "AIN III",
-          "Aleukemic granulocytic leukemia [obs]",
-          "Aleukemic leukemia, NOS [obs]",
-          "Aleukemic lymphatic leukemia [obs]",
-          "Aleukemic lymphocytic leukemia [obs]",
-          "Aleukemic lymphoid leukemia [obs]",
-          "Aleukemic monocytic leukemia [obs]",
-          "Aleukemic myelogenous leukemia [obs]",
-          "Aleukemic myeloid leukemia [obs]",
-          "ALK positive large B-cell lymphoma",
-          "Alpha cell tumor, malignant",
-          "Alpha cell tumor, NOS",
-          "Alpha heavy chain disease",
-          "Alveolar adenocarcinoma",
-          "Alveolar adenoma",
-          "Alveolar carcinoma",
-          "Alveolar cell carcinoma",
-          "Alveolar rhabdomyosarcoma",
-          "Alveolar soft part sarcoma",
-          "Amelanotic melanoma",
-          "Ameloblastic carcinoma",
-          "Ameloblastic fibro-odontoma",
-          "Ameloblastic fibro-odontosarcoma",
-          "Ameloblastic fibrodentinoma",
-          "Ameloblastic fibrodentinosarcoma",
-          "Ameloblastic fibroma",
-          "Ameloblastic fibrosarcoma",
-          "Ameloblastic odontosarcoma",
-          "Ameloblastic sarcoma",
-          "Ameloblastoma, malignant",
-          "Ameloblastoma, NOS",
-          "AML M6",
-          "Anal intraepithelial neoplasia, grade III",
-          "Anal intraepithelial neoplasia, low grade",
-          "Anaplastic large B-cell lymphoma",
-          "Anaplastic large cell lymphoma, ALK negative",
-          "Anaplastic large cell lymphoma, ALK positive",
-          "Anaplastic large cell lymphoma, CD30+",
-          "Anaplastic large cell lymphoma, NOS",
-          "Anaplastic large cell lymphoma, T cell and Null cell type",
-          "Anaplastic medulloblastoma",
-          "Anaplastic oligoastrocytoma",
-          "Ancient schwannoma",
-          "Androblastoma, benign",
-          "Androblastoma, malignant",
-          "Androblastoma, NOS",
-          "Angioblastic meningioma [obs]",
-          "Angioblastoma",
-          "Angiocentric glioma",
-          "Angiocentric immunoproliferative lesion",
-          "Angiocentric T-cell lymphoma [obs]",
-          "Angioendothelioma",
-          "Angioendotheliomatosis",
-          "Angiofibroma, NOS",
-          "Angioimmunoblastic lymphadenopathy",
-          "Angioimmunoblastic lymphoma [obs]",
-          "Angioimmunoblastic T-cell lymphoma",
-          "Angiokeratoma",
-          "Angioleiomyoma",
-          "Angiolipoma, NOS",
-          "Angioma, NOS",
-          "Angiomatoid fibrous histiocytoma",
-          "Angiomatous meningioma",
-          "Angiomyofibroblastoma",
-          "Angiomyolipoma",
-          "Angiomyoma",
-          "Angiomyosarcoma",
-          "Angiomyxoma",
-          "Angiosarcoma",
-          "Angiotropic lymphoma",
-          "Aortic body paraganglioma",
-          "Aortic body tumor",
-          "Aorticopulmonary paraganglioma",
-          "Apocrine adenocarcinoma",
-          "Apocrine adenoma",
-          "Apocrine cystadenoma",
-          "Apudoma",
-          "Argentaffinoma, malignant",
-          "Argentaffinoma, NOS [obs]",
-          "Arrhenoblastoma, benign",
-          "Arrhenoblastoma, malignant",
-          "Arrhenoblastoma, NOS",
-          "Arteriovenous hemangioma",
-          "Askin tumor",
-          "Astroblastoma",
-          "Astrocytic glioma",
-          "Astrocytoma, anaplastic",
-          "Astrocytoma, low grade",
-          "Astrocytoma, NOS",
-          "Astroglioma",
-          "Atypical adenoma",
-          "Atypical carcinoid tumor",
-          "Atypical choroid plexus papilloma",
-          "Atypical chronic myeloid leukemia, BCR/ABL negative",
-          "Atypical chronic myeloid leukemia, Philadelphia chromosome (Ph1) negative",
-          "Atypical fibrous histiocytoma",
-          "Atypical fibroxanthoma",
-          "Atypical follicular adenoma",
-          "Atypical leiomyoma",
-          "Atypical lipoma",
-          "Atypical medullary carcinoma",
-          "Atypical meningioma",
-          "Atypical polypoid adenomyoma",
-          "Atypical proliferating clear cell tumor",
-          "Atypical proliferating serous tumor",
-          "Atypical proliferative endometrioid tumor",
-          "Atypical proliferative mucinous tumor",
-          "Atypical proliferative papillary serous tumor",
-          "Atypical teratoid/rhabdoid tumor",
-          "B cell lymphoma, NOS",
-          "B lymphoblastic leukemia/lymphoma with hyperdiploidy",
-          "B lymphoblastic leukemia/lymphoma with hypodiploidy (Hypodiploid ALL)",
-          "B lymphoblastic leukemia/lymphoma with t(1;19) (q23;p13.3); E2A-PBX1 (TCF3-PBX1)",
-          "B lymphoblastic leukemia/lymphoma with t(12;21) (p13;q22); TEL-AML1 (ETV6-RUNX1)",
-          "B lymphoblastic leukemia/lymphoma with t(5;14) (q31;q32); IL3-IGH",
-          "B lymphoblastic leukemia/lymphoma with t(9;22) (q34;q11.2); BCR-ABL1",
-          "B lymphoblastic leukemia/lymphoma with t(v;11q23); MLL rearranged",
-          "B lymphoblastic leukemia/lymphoma, NOS",
-          "B-ALL [obs]",
-          "B-cell lymphocytic leukemia/small lymphocytic lymphoma",
-          "B-cell lymphoma, unclassifiable, with features intermediate between diffuse large B-cell lymphoma and Burkitt lymphoma",
-          "B-cell lymphoma, unclassifiable, with features intermediate between diffuse large B-cell lymphoma and classical Hodgkin lymphoma",
-          "Balloon cell melanoma",
-          "Balloon cell nevus",
-          "BALT lymphoma",
-          "Basal cell adenocarcinoma",
-          "Basal cell adenoma",
-          "Basal cell carcinoma, desmoplastic type",
-          "Basal cell carcinoma, fibroepithelial",
-          "Basal cell carcinoma, micronodular",
-          "Basal cell carcinoma, morpheic",
-          "Basal cell carcinoma, nodular",
-          "Basal cell carcinoma, NOS",
-          "Basal cell epithelioma",
-          "Basal cell tumor",
-          "Basaloid carcinoma",
-          "Basaloid squamous cell carcinoma",
-          "Basophil adenocarcinoma",
-          "Basophil adenoma",
-          "Basophil carcinoma",
-          "Basosquamous carcinoma",
-          "Bednar tumor",
-          "Bellini duct carcinoma",
-          "Benign cystic nephroma",
-          "Benign fibrous histiocytoma",
-          "Beta cell adenoma",
-          "Beta cell tumor, malignant",
-          "Bile duct adenocarcinoma",
-          "Bile duct adenoma",
-          "Bile duct carcinoma",
-          "Bile duct cystadenocarcinoma",
-          "Bile duct cystadenoma",
-          "Biliary intraepithelial neoplasia, grade 3 (BilIN-3)",
-          "Biliary intraepithelial neoplasia, high grade",
-          "Biliary intraepithelial neoplasia, low grade",
-          "Biliary papillomatosis",
-          "Bizarre leiomyoma",
-          "Black adenoma",
-          "Blast cell leukemia",
-          "Blastic NK cell lymphoma [obs]",
-          "Blastic plasmacytoid dendritic cell neoplasm",
-          "Blastoma, NOS",
-          "Blue nevus, malignant",
-          "Blue nevus, NOS",
-          "Botryoid sarcoma",
-          "Bowen disease",
-          "Brenner tumor, borderline malignancy",
-          "Brenner tumor, malignant",
-          "Brenner tumor, NOS",
-          "Brenner tumor, proliferating",
-          "Bronchial adenoma, carcinoid",
-          "Bronchial adenoma, cylindroid",
-          "Bronchial adenoma, NOS",
-          "Bronchial-associated lymphoid tussue lymphoma",
-          "Bronchio-alveolar carcinoma, mixed mucinous and non-mucinous",
-          "Bronchio-alveolar carcinoma, mucinous",
-          "Bronchiolar adenocarcinoma",
-          "Bronchiolar carcinoma",
-          "Bronchiolo-alveolar adenocarcinoma, NOS",
-          "Bronchiolo-alveolar carcinoma, Clara cell",
-          "Bronchiolo-alveolar carcinoma, Clara cell and goblet cell type",
-          "Bronchiolo-alveolar carcinoma, goblet cell type",
-          "Bronchiolo-alveolar carcinoma, indeterminate type",
-          "Bronchiolo-alveolar carcinoma, non-mucinous",
-          "Bronchiolo-alveolar carcinoma, NOS",
-          "Bronchiolo-alveolar carcinoma, type II pneumocyte and goblet cell type",
-          "Bronchiolo-alveolar carcinoma; type II pneumocyte",
-          "Brooke tumor",
-          "Brown fat tumor",
-          "Burkitt cell leukemia",
-          "Burkitt lymphoma, NOS (Includes all variants, see also M-9826/3)",
-          "Burkitt tumor [obs]",
-          "Burkitt-like lymphoma",
-          "C cell carcinoma",
-          "c-ALL",
-          "Calcifying epithelial odontogenic tumor",
-          "Calcifying epithelioma of Malherbe",
-          "Calcifying nested epithelial stromal tumor",
-          "Calcifying odontogenic cyst",
-          "Canalicular adenoma",
-          "Cancer",
-          "Capillary hemangioma",
-          "Capillary lymphangioma",
-          "Carcinofibroma",
-          "Carcinoid tumor of uncertain malignant potential",
-          "Carcinoid tumor, argentaffin, malignant",
-          "Carcinoid tumor, argentaffin, NOS",
-          "Carcinoid tumor, NOS",
-          "Carcinoid tumor, NOS, of appendix",
-          "Carcinoid, NOS",
-          "Carcinoid, NOS, of appendix",
-          "Carcinoma in a polyp, NOS",
-          "Carcinoma in adenomatous polyp",
-          "Carcinoma in pleomorphic adenoma",
-          "Carcinoma in situ in a polyp, NOS",
-          "Carcinoma in situ in adenomatous polyp",
-          "Carcinoma in situ, NOS",
-          "Carcinoma showing thymus-like differentiation",
-          "Carcinoma showing thymus-like element",
-          "Carcinoma simplex",
-          "Carcinoma with apocrine metaplasia",
-          "Carcinoma with neuroendocrine differentiation",
-          "Carcinoma with osteoclast-like giant cells",
-          "Carcinoma with productive fibrosis",
-          "Carcinoma, anaplastic, NOS",
-          "Carcinoma, diffuse type",
-          "Carcinoma, intestinal type",
-          "Carcinoma, metastatic, NOS",
-          "Carcinoma, NOS",
-          "Carcinoma, undifferentiated, NOS",
-          "Carcinomatosis",
-          "Carcinosarcoma, embryonal",
-          "Carcinosarcoma, NOS",
-          "Carotid body paraganglioma",
-          "Carotid body tumor",
-          "Cartilaginous exostosis",
-          "CASTLE",
-          "Cavernous hemangioma",
-          "Cavernous lymphangioma",
-          "Cellular angiofibroma",
-          "Cellular blue nevus",
-          "Cellular ependymoma",
-          "Cellular fibroma",
-          "Cellular leiomyoma",
-          "Cellular schwannoma",
-          "Cementifying fibroma",
-          "Cemento-ossifying fibroma",
-          "Cementoblastoma, benign",
-          "Cementoma, NOS",
-          "Central neuroblastoma",
-          "Central neurocytoma",
-          "Central odontogenic fibroma",
-          "Central osteosarcoma",
-          "Central primitive neuroectodermal tumor, NOS",
-          "Cerebellar liponeurocytoma",
-          "Cerebellar sarcoma, NOS",
-          "Ceruminous adenocarcinoma",
-          "Ceruminous adenoma",
-          "Ceruminous carcinoma",
-          "Cervical intraepithelial neoplasia, grade III",
-          "Cervical intraepithelial neoplasia, low grade",
-          "Chemodectoma",
-          "Chief cell adenoma",
-          "Chloroma",
-          "Cholangiocarcinoma",
-          "Cholangioma",
-          "Chondroblastic osteosarcoma",
-          "Chondroblastoma, malignant",
-          "Chondroblastoma, NOS",
-          "Chondroid chordoma",
-          "Chondroid lipoma",
-          "Chondroid syringoma",
-          "Chondroma, NOS",
-          "Chondromatosis, NOS",
-          "Chondromatous giant cell tumor",
-          "Chondromyxoid fibroma",
-          "Chondrosarcoma, NOS",
-          "Chordoid glioma",
-          "Chordoid glioma of third ventricle",
-          "Chordoid meningioma",
-          "Chordoma, NOS",
-          "Chorioadenoma",
-          "Chorioadenoma destruens",
-          "Chorioangioma",
-          "Choriocarcinoma combined with embryonal carcinoma",
-          "Choriocarcinoma combined with other germ cell elements",
-          "Choriocarcinoma combined with teratorna",
-          "Choriocarcinoma, NOS",
-          "Chorioepithelioma",
-          "Chorionepithelioma",
-          "Choroid plexus carcinoma",
-          "Choroid plexus papilloma, anaplastic",
-          "Choroid plexus papilloma, malignant",
-          "Choroid plexus papilloma, NOS",
-          "Chromaffin paraganglioma",
-          "Chromaffin tumor",
-          "Chromaffinoma",
-          "Chromophobe adenocarcinoma",
-          "Chromophobe adenoma",
-          "Chromophobe carcinoma",
-          "Chromophobe cell renal carcinoma",
-          "Chronic eosinophilic leukemia, NOS",
-          "Chronic erythremia [obs]",
-          "Chronic granulocytic leukemia, BCR/ABL",
-          "Chronic granulocytic leukemia, NOS",
-          "Chronic granulocytic leukemia, Philadelphia chromosome (Ph1) positive",
-          "Chronic granulocytic leukemia, t(9;22)(q34;q11)",
-          "Chronic idiopathic myelofibrosis",
-          "Chronic leukemia, NOS [obs]",
-          "Chronic lymphatic leukemia",
-          "Chronic lymphocytic leukemia",
-          "Chronic lymphocytic leukemia, B-cell type  (includes all variants of BCLL)",
-          "Chronic lymphoid leukemia",
-          "Chronic lymphoproliferative disorder of NK cells",
-          "Chronic monocytic leukemia [obs]",
-          "Chronic myelocytic leukemia, NOS",
-          "Chronic myelogenous leukemia, BCR-ABL positive",
-          "Chronic myelogenous leukemia, Philadelphia chromosome (Ph 1) positive",
-          "Chronic myelogenous leukemia, t(9;22)(q34;q11)",
-          "Chronic myeloid leukemia, NOS",
-          "Chronic myelomonocytic leukemia in transformation [obs]",
-          "Chronic myelomonocytic leukemia, NOS",
-          "Chronic myelomonocytic leukemia, Type 1",
-          "Chronic myelomonocytic leukemia, Type II",
-          "Chronic myeloproliferative disease, NOS",
-          "Chronic myeloproliferative disorder",
-          "Chronic neutrophilic leukemia",
-          "CIN III with severe dysplasia",
-          "Cin III, NOS",
-          "Circumscribed arachnoidal cerebellar sarcoma",
-          "Classical Hodggkin lymphoma, lymphocyte depletion, diffuse fibrosis",
-          "Classical Hodgkin lymphoma, lymphocyte depletion, NOS",
-          "Classical Hodgkin lymphoma, lymphocyte depletion, reticular",
-          "Classical Hodgkin lymphoma, lymphocyte-rich",
-          "Classical Hodgkin lymphoma, mixed cellularity, NOS",
-          "Classical Hodgkin lymphoma, nodular sclerosis, cellular phase",
-          "Classical Hodgkin lymphoma, nodular sclerosis, grade 1",
-          "Classical Hodgkin lymphoma, nodular sclerosis, grade 2",
-          "Classical Hodgkin lymphoma, nodular sclerosis, NOS",
-          "Clear cell adenocarcinofibroma",
-          "Clear cell adenocarcinoma, mesonephroid",
-          "Clear cell adenocarcinoma, NOS",
-          "Clear cell adenofibroma",
-          "Clear cell adenofibroma of borderline malignancy",
-          "Clear cell adenoma",
-          "Clear cell carcinoma",
-          "Clear cell chondrosarcoma",
-          "Clear cell cystadenocarcinofibroma",
-          "Clear cell cystadenofibroma",
-          "Clear cell cystadenofibroma of borderline malignancy",
-          "Clear cell cystadenoma",
-          "Clear cell cystic tumor of borderline malignancy",
-          "Clear cell ependymoma",
-          "Clear cell hidradenoma",
-          "Clear cell meningioma",
-          "Clear cell odontogenic tumor",
-          "Clear cell sarcoma of kidney",
-          "Clear cell sarcoma, NOS (except of kidney M-8964/3)",
-          "Clear cell sarcoma, of tendons and aponeuroses",
-          "Clear cell tumor, NOS",
-          "Cloacogenic carcinoma",
-          "Codman tumor",
-          "Collecting duct carcinoma",
-          "Colloid adenocarcinoma",
-          "Colloid adenoma",
-          "Colloid carcinoma",
-          "Columnar cell papilloma",
-          "Combined carcinoid and adenocarcinoma",
-          "Combined hepatocellular carcinoma and cholangiocarcinoma",
-          "Combined small cell carcinoma",
-          "Combined small cell-adenocarcinoma",
-          "Combined small cell-large carcinoma",
-          "Combined small cell-squamous cell carcinoma",
-          "Combined/mixed carcinoid and adenocarcinoma",
-          "Comedocarcinoma, noninfiltrating",
-          "Comedocarcinoma, NOS",
-          "Common ALL",
-          "Common precursor B ALL",
-          "Complete hydatidiform mole",
-          "Complex odontoma",
-          "Composite carcinoid",
-          "Composite Hodgkin and non-Hodgkin lymphoma",
-          "Compound nevus",
-          "Compound odontoma",
-          "Condylomatous carcinoma",
-          "Congenital fibrosarcoma",
-          "Congenital generalized fibromatosis",
-          "Congenital peribronchial myofibroblastic tumor",
-          "Conventional central osteosarcoma",
-          "Cortical T ALL",
-          "CPNET",
-          "Craniopharyngioma",
-          "Craniopharyngioma, adamantinomatous",
-          "Craniopharyngioma, papillary",
-          "Cribriform carcinoma in situ",
-          "Cribriform carcinoma, NOS",
-          "Cribriform comedo-type carcinoma",
-          "Cutaneous histiocytoma, NOS",
-          "Cutaneous lymphoma, NOS",
-          "Cutaneous mastocytosis",
-          "Cutaneous T-cell lymphoma, NOS",
-          "Cylindrical cell carcinoma",
-          "Cylindrical cell papilloma",
-          "Cylindroma of skin",
-          "Cylindroma, NOS (except cylindroma of skin M-8200/0)",
-          "Cyst-associated renal cell carcinoma",
-          "Cystadenocarcinoma, NOS",
-          "Cystadenofibroma, NOS",
-          "Cystadenoma, NOS",
-          "Cystic astrocytoma",
-          "Cystic hygroma",
-          "Cystic hypersecretory carcinoma",
-          "Cystic lymphangioma",
-          "Cystic mesothelioma, benign",
-          "Cystic mesothelioma, NOS",
-          "Cystic partially differentiated nephroblastoma",
-          "Cystic teratoma, NOS",
-          "Cystic tumor of atrio-ventricular node",
-          "Cystoma, NOS",
-          "Cystosarcoma phyllodes, benign",
-          "Cystosarcoma phyllodes, malignant",
-          "Cystosarcoma phyllodes, NOS",
-          "Dabska tumor",
-          "DCIS, comedo type",
-          "DCIS, NOS",
-          "DCIS, papillary",
-          "Dedifferentiated chondrosarcoma",
-          "Dedifferentiated chordoma",
-          "Dedifferentiated liposarcoma",
-          "Deep histiocytoma",
-          "Degenerated schwannoma",
-          "Dendritic cell sarcoma, NOS",
-          "Dentinoma",
-          "Dermal and epidermal nevus",
-          "Dermal nevus",
-          "Dermatofibroma lenticulare",
-          "Dermatofibroma, NOS",
-          "Dermatofibrosarcoma protuberans, NOS",
-          "Dermatofibrosarcoma, NOS",
-          "Dermoid cyst with malignant transformation",
-          "Dermoid cyst with secondary tumor",
-          "Dermoid cyst, NOS",
-          "Dermoid, NOS",
-          "Desmoid, NOS",
-          "Desmoplastic fibroma",
-          "Desmoplastic infantile astrocytoma",
-          "Desmoplastic infantile ganglioglioma",
-          "Desmoplastic medulloblastoma",
-          "Desmoplastic melanoma, amelanotic",
-          "Desmoplastic melanoma, malignant",
-          "Desmoplastic mesothelioma",
-          "Desmoplastic nodular medulloblastoma",
-          "Desmoplastic small round cell tumor",
-          "Di Guglielmo disease [obs]",
-          "Diffuse astrocytoma",
-          "Diffuse astrocytoma, low grade",
-          "Diffuse cutaneous mastocytosis",
-          "Diffuse intraductal papillomatosis",
-          "Diffuse large B-cell lymphoma associated with chronic inflammation",
-          "Diffuse large B-cell lymphoma, NOS",
-          "Diffuse melanocytosis",
-          "Diffuse meningiomatosis",
-          "Digital papillary adenocarcinoma",
-          "Diktyoma, benign",
-          "Diktyoma, malignant",
-          "DIN 3",
-          "Duct adenocarcinoma, NOS",
-          "Duct adenoma, NOS",
-          "Duct carcinoma, desmoplastic type",
-          "Duct carcinoma, NOS",
-          "Duct cell carcinoma",
-          "Ductal carcinoma in situ, comedo type",
-          "Ductal carcinoma in situ, cribriform type",
-          "Ductal carcinoma in situ, micropapillary",
-          "Ductal carcinoma in situ, NOS",
-          "Ductal carcinoma in situ, papillary",
-          "Ductal carcinoma in situ, solid type",
-          "Ductal carcinoma, cribriform type",
-          "Ductal carcinoma, NOS",
-          "Ductal intraepithelial neoplasia 3",
-          "Ductal papilloma",
-          "Dysembryoplastic neuroepithelial tumor",
-          "Dysgerminoma",
-          "Dysplastic gangliocytoma of cerebellum (Lhermitte-Duclos)",
-          "Dysplastic nevus",
-          "EBV positive diffuse large B-cell lymphoma of the elderly",
-          "EC cell carcinoid",
-          "Ecchondroma",
-          "Ecchondrosis",
-          "Eccrine acrospiroma",
-          "Eccrine adenocarcinoma",
-          "Eccrine cystadenoma",
-          "Eccrine dermal cylindroma",
-          "Eccrine papillary adenocarcinoma",
-          "Eccrine papillary adenoma",
-          "Eccrine poroma",
-          "Eccrine poroma, malignant",
-          "Eccrine spiradenoma",
-          "ECL cell carcinoid, malignant",
-          "ECL cell carcinoid, NOS",
-          "Ectomesenchymoma",
-          "Ectopic hamartomatous thymoma",
-          "Elastofibroma",
-          "Embryonal adenocarcinoma",
-          "Embryonal adenoma",
-          "Embryonal carcinoma, infantile",
-          "Embryonal carcinoma, NOS",
-          "Embryonal carcinoma, polyembryonal type",
-          "Embryonal hepatoma",
-          "Embryonal rhabdomyosarcoma, NOS",
-          "Embryonal rhabdomyosarcoma, pleomorphic",
-          "Embryonal sarcoma",
-          "Embryonal teratoma",
-          "Enchondroma",
-          "Endocrine adenomatosis",
-          "Endocrine tumor, functioning, NOS",
-          "Endodermal sinus tumor",
-          "Endolymphatic stromal myosis",
-          "Endometrial sarcoma, NOS",
-          "Endometrial stromal nodule",
-          "Endometrial stromal sarcoma, high grade",
-          "Endometrial stromal sarcoma, low grade",
-          "Endometrial stromal sarcoma, NOS",
-          "Endometrial stromatosis",
-          "Endometrioid adenocarcinoma, ciliated cell variant",
-          "Endometrioid adenocarcinoma, NOS",
-          "Endometrioid adenocarcinoma, secretory variant",
-          "Endometrioid adenofibroma, borderline malignancy",
-          "Endometrioid adenofibroma, malignant",
-          "Endometrioid adenofibroma, NOS",
-          "Endometrioid adenoma, borderline malignancy",
-          "Endometrioid adenoma, NOS",
-          "Endometrioid carcinoma, NOS",
-          "Endometrioid cystadenocarcinoma",
-          "Endometrioid cystadenofibroma, borderline malignancy",
-          "Endometrioid cystadenofibroma, malignant",
-          "Endometrioid cystadenofibroma, NOS",
-          "Endometrioid cystadenoma, borderline malignancy",
-          "Endometrioid cystadenoma, NOS",
-          "Endometrioid tumor of low malignant potential",
-          "Endotheliomatous meningioma",
-          "Endovascular papillary angioendothelioma",
-          "Enterochromaffin cell carcinoid",
-          "Enterochromaffin-like cell carcinoid, NOS",
-          "Enterochromaffin-like cell tumor, malignant",
-          "Enteroglucagonoma, malignant",
-          "Enteroglucagonoma, NOS",
-          "Enteropathy associated T-cell lymphoma",
-          "Enteropathy type intestinal T-cell lymphoma",
-          "Eosinophil adenocarcinoma",
-          "Eosinophil adenoma",
-          "Eosinophil carcinoma",
-          "Eosinophilic granuloma",
-          "Eosinophilic leukemia",
-          "Ependymoblastoma",
-          "Ependymoma, anaplastic",
-          "Ependymoma, NOS",
-          "Epidermoid carcinoma in situ with questionable stromal invasion",
-          "Epidermoid carcinoma in situ, NOS",
-          "Epidermoid carcinoma, keratinizing",
-          "Epidermoid carcinoma, large cell, nonkeratinizing",
-          "Epidermoid carcinoma, NOS",
-          "Epidermoid carcinoma, small cell, nonkeratinizing",
-          "Epidermoid carcinoma, spindle cell",
-          "Epithelial ependymoma",
-          "Epithelial tumor, benign",
-          "Epithelial tumor, malignant",
-          "Epithelial-myoepithelial carcinoma",
-          "Epithelioid and spindle cell nevus",
-          "Epithelioid cell melanoma",
-          "Epithelioid cell nevus",
-          "Epithelioid cell sarcoma",
-          "Epithelioid hemangioendothelioma, malignant",
-          "Epithelioid hemangioendothelioma, NOS",
-          "Epithelioid hemangioma",
-          "Epithelioid leiomyoma",
-          "Epithelioid leiomyosarcoma",
-          "Epithelioid mesothelioma, benign",
-          "Epithelioid mesothelioma, malignant",
-          "Epithelioid mesothelioma, NOS",
-          "Epithelioid MPNST",
-          "Epithelioid sarcoma",
-          "Epithelioma adenoides cysticum",
-          "Epithelioma, benign",
-          "Epithelioma, malignant",
-          "Epithelioma, NOS",
-          "Erythremic myelosis, NOS",
-          "Erythroleukemia",
-          "Esophageal glandular dysplasia (intraepithelial neoplasia), high grade",
-          "Esophageal glandular dysplasia (intraepithelial neoplasia), low grade",
-          "Esophageal intraepithelial neoplasia, high grade",
-          "Esophageal squamous intraepithelial neoplasia (dysplasia), high grade",
-          "Esophageal squamous intraepithelial neoplasia (dysplasia), low grade",
-          "Essential hemorrhagic thrombocythaemia",
-          "Essential thrombocythemia",
-          "Esthesioneuroblastoma",
-          "Esthesioneurocytoma",
-          "Esthesioneuroepithelioma",
-          "Ewing sarcoma",
-          "Ewing tumor",
-          "Extra-abdominal desmoid",
-          "Extra-adrenal paraganglioma, malignant",
-          "Extra-adrenal paraganglioma, NOS",
-          "Extracutaneous mastocytoma",
-          "Extranodal marginal zone lymphoma of mucosa-associated lymphoid tissue",
-          "Extranodal NK/T-cell lymphoma, nasal type",
-          "Extraosseous plasmacytoma",
-          "Extraventricular neurocytoma",
-          "FAB L2",
-          "FAB L3 [obs]",
-          "FAB Ll [obs]",
-          "FAB M1",
-          "FAB M2, AML1(CBF-alpha)/ETO",
-          "FAB M2, NOS",
-          "FAB M2, t(8;21)(q22;q22)",
-          "FAB M3 (includes all variants)",
-          "FAB M4",
-          "FAB M4Eo",
-          "FAB M5 (includes all variants)",
-          "FAB M6",
-          "FAB M7",
-          "FAB MO",
-          "Familial polyposis coli",
-          "Fascial fibroma",
-          "Fascial fibrosarcoma",
-          "Fetal adenocarcinoma",
-          "Fetal adenoma",
-          "Fetal fat cell lipoma",
-          "Fetal lipoma, NOS",
-          "Fetal lipomatosis",
-          "Fetal rhabdomyoma",
-          "Fibrillary astrocytoma",
-          "Fibro-osteoma",
-          "Fibroadenoma, NOS",
-          "Fibroameloblastic odontoma",
-          "Fibroblastic liposarcoma",
-          "Fibroblastic meningioma",
-          "Fibroblastic osteosarcoma",
-          "Fibroblastic reticular cell tumor",
-          "Fibrochondrosarcoma",
-          "Fibroepithelial basal cell carcinoma, Pinkus type",
-          "Fibroepithelioma of Pinkus type",
-          "Fibroepithelioma, NOS",
-          "Fibrofolliculoma",
-          "Fibroid uterus",
-          "Fibrolipoma",
-          "Fibroliposarcoma",
-          "Fibroma, NOS",
-          "Fibromyoma",
-          "Fibromyxolipoma",
-          "Fibromyxoma",
-          "Fibromyxosarcoma",
-          "Fibrosarcoma, NOS",
-          "Fibrous astrocytoma",
-          "Fibrous histiocytoma of tendon sheath",
-          "Fibrous histiocytoma, NOS",
-          "Fibrous meningioma",
-          "Fibrous mesothelioma, benign",
-          "Fibrous mesothelioma, malignant",
-          "Fibrous mesothelioma, NOS",
-          "Fibrous papule of nose",
-          "Fibroxanthoma, malignant",
-          "Fibroxanthoma, NOS",
-          "Flat adenoma",
-          "Flat intraepithelial glandular neoplasia, high grade",
-          "Flat intraepithelial neoplasia (dysplasia), high grade",
-          "Flat intraepithelial neoplasia, high grade",
-          "Florid osseous dysplasia",
-          "Follicular adenocarcinoma, moderately differentiated",
-          "Follicular adenocarcinoma, NOS",
-          "Follicular adenocarcinoma, trabecular",
-          "Follicular adenocarcinoma, well differentiated",
-          "Follicular adenoma",
-          "Follicular adenoma, oxyphilic cell",
-          "Follicular carcinoma, encapsulated",
-          "Follicular carcinoma, minimally invasive",
-          "Follicular carcinoma, moderately differentiated",
-          "Follicular carcinoma, NOS",
-          "Follicular carcinoma, oxyphilic cell",
-          "Follicular carcinoma, trabecular",
-          "Follicular carcinoma, well differentiated",
-          "Follicular dendritic cell sarcoma",
-          "Follicular dendritic cell tumor",
-          "Follicular fibroma",
-          "Follicular lymphoma, grade 1",
-          "Follicular lymphoma, grade 2",
-          "Follicular lymphoma, grade 3",
-          "Follicular lymphoma, grade 3A",
-          "Follicular lymphoma, grade 3B",
-          "Follicular lymphoma, NOS",
-          "Follicular lymphoma, small cleaved cell",
-          "Folliculome lipidique",
-          "Franklin disease",
-          "G cell tumor, malignant",
-          "G cell tumor, NOS",
-          "Gamma heavy chain disease",
-          "Gangliocytic paraganglioma",
-          "Gangliocytoma",
-          "Ganglioglioma, anaplastic",
-          "Ganglioglioma, NOS",
-          "Ganglioneuroblastoma",
-          "Ganglioneuroma",
-          "Ganglioneuromatosis",
-          "GANT",
-          "Gastrin cell tumor",
-          "Gastrin cell tumor, malignant",
-          "Gastrinoma, malignant",
-          "Gastrinoma, NOS",
-          "Gastrointestinal autonomic nerve tumor",
-          "Gastrointestinal pacemaker cell tumor",
-          "Gastrointestinal stromal sarcoma",
-          "Gastrointestinal stromal tumor, benign",
-          "Gastrointestinal stromal tumor, malignant",
-          "Gastrointestinal stromal tumor, NOS",
-          "Gastrointestinal stromal tumor, uncertain malignant potential",
-          "Gelatinous adenocarcinoma [obs]",
-          "Gelatinous carcinoma [obs]",
-          "Gemistocytic astrocytoma",
-          "Gemistocytoma",
-          "Genital rhabdomyoma",
-          "Germ cell tumor, nonseminomatous",
-          "Germ cell tumor, NOS",
-          "Germinoma",
-          "Giant cell and spindle cell carcinoma",
-          "Giant cell angiofibroma",
-          "Giant cell carcinoma",
-          "Giant cell fibroblastoma",
-          "Giant cell glioblastoma",
-          "Giant cell sarcoma (except of bone M-9250/3)",
-          "Giant cell sarcoma of bone",
-          "Giant cell tumor of bone, malignant",
-          "Giant cell tumor of bone, NOS",
-          "Giant cell tumor of soft parts, NOS",
-          "Giant cell tumor of tendon sheath",
-          "Giant cell tumor of tendon sheath, malignant",
-          "Giant fibroadenoma",
-          "Giant osteoid osteoma",
-          "Giant pigmented nevus, NOS",
-          "Gigantiform cementoma",
-          "GIST, benign",
-          "GIST, malignant",
-          "GIST, NOS",
-          "Glandular intraepithelial neoplasia, grade I",
-          "Glandular intraepithelial neoplasia, grade II",
-          "Glandular intraepithelial neoplasia, grade III",
-          "Glandular intraepithelial neoplasia, high grade",
-          "Glandular intraepithelial neoplasia, low grade",
-          "Glandular papilloma",
-          "Glassy cell carcinoma",
-          "Glioblastoma",
-          "Glioblastoma multiforme",
-          "Glioblastoma with sarcomatous component",
-          "Gliofibroma",
-          "Glioma, malignant",
-          "Glioma, NOS (except nasal glioma, not neoplastic)",
-          "Gliomatosis cerebri",
-          "Glioneuroma [obs]",
-          "Gliosarcoma",
-          "Glomangioma",
-          "Glomangiomyoma",
-          "Glomangiosarcoma",
-          "Glomoid sarcoma",
-          "Glomus jugulare tumor, NOS",
-          "Glomus tumor, malignant",
-          "Glomus tumor, NOS",
-          "Glucagon-like peptide-producing tumor",
-          "Glucagonoma, malignant",
-          "Glucagonoma, NOS",
-          "Glycogen-rich carcinoma",
-          "Glycogenic rhabdomyoma",
-          "Goblet cell carcinoid",
-          "Gonadal stromal tumor, NOS",
-          "Gonadoblastoma",
-          "Gonocytoma",
-          "Granular cell adenocarcinoma",
-          "Granular cell carcinoma",
-          "Granular cell myoblastoma, malignant",
-          "Granular cell myoblastoma, NOS",
-          "Granular cell tumor of the sellar region",
-          "Granular cell tumor, malignant",
-          "Granular cell tumor, NOS",
-          "Granulocytic leukemia, NOS",
-          "Granulocytic sarcoma",
-          "Granulosa cell carcinoma",
-          "Granulosa cell tumor, adult type",
-          "Granulosa cell tumor, juvenile",
-          "Granulosa cell tumor, malignant",
-          "Granulosa cell tumor, NOS",
-          "Granulosa cell tumor, sarcomatoid",
-          "Granulosa cell-theca cell tumor",
-          "Grawitz tumor",
-          "Gynandroblastoma",
-          "Haemangioblastoma",
-          "Haemangiosarcoma",
-          "Hairy cell leukaemia variant",
-          "Hairy cell leukemia",
-          "Hairy cell leukemia variant",
-          "Hairy nevus",
-          "Halo nevus",
-          "Hand-Schuller-Christian disease",
-          "Heavy chain disease, NOS",
-          "Hemangioblastic meningioma [obs]",
-          "Hemangioendothelial sarcoma",
-          "Hemangioendothelioma, benign",
-          "Hemangioendothelioma, malignant",
-          "Hemangioendothelioma, NOS",
-          "Hemangioma simplex",
-          "Hemangioma, NOS",
-          "Hemangiopericytic meningioma",
-          "Hemangiopericytoma, benign",
-          "Hemangiopericytoma, malignant",
-          "Hemangiopericytoma, NOS",
-          "Hemolymphangioma",
-          "Hepatoblastoma",
-          "Hepatoblastoma, epithelioid",
-          "Hepatoblastoma, mixed epithelial-mesenchymal",
-          "Hepatocarcinoma",
-          "Hepatocellular adenoma",
-          "Hepatocellular carcinoma, clear cell type",
-          "Hepatocellular carcinoma, fibrolamellar",
-          "Hepatocellular carcinoma, NOS",
-          "Hepatocellular carcinoma, pleomorphic type",
-          "Hepatocellular carcinoma, sarcomatoid",
-          "Hepatocellular carcinoma, scirrhous",
-          "Hepatocellular carcinoma, spindle cell variant",
-          "Hepatocholangiocarcinoma",
-          "Hepatoid adenocarcinoma",
-          "Hepatoid carcinoma",
-          "Hepatoid yolk sac tumor",
-          "Hepatoma, benign",
-          "Hepatoma, malignant",
-          "Hepatoma, NOS",
-          "Hepatosplenic T-cell lymphoma",
-          "Hepatosplenic gamma-delta cell lymphoma",
-          "Hibernoma",
-          "Hidradenocarcinoma",
-          "Hidradenoma papilliferum",
-          "Hidradenoma, NOS",
-          "Hidrocystoma",
-          "High grade surface osteosarcoma",
-          "Hilar cell tumor",
-          "Hilus cell tumor",
-          "Histiocyte-rich large B-cell lymphoma",
-          "Histiocytic medullary reticulosis [obs]",
-          "Histiocytic sarcoma",
-          "Histiocytoid hemangioma",
-          "Histiocytoma, NOS",
-          "Histiocytosis X, NOS",
-          "Hodgkin disease, lymphocyte predominance, diffuse [obs]",
-          "Hodgkin disease, lymphocyte predominance, NOS [obs]",
-          "Hodgkin disease, lymphocytic-histiocytic predominance [obs]",
-          "Hodgkin disease, nodular sclerosis, lymphocyte depletion",
-          "Hodgkin disease, nodular sclerosis, lymphocyte predominance",
-          "Hodgkin disease, nodular sclerosis, mixed cellularity",
-          "Hodgkin disease, nodular sclerosis, NOS",
-          "Hodgkin disease, nodular sclerosis, syncytial variant",
-          "Hodgkin disease, NOS",
-          "Hodgkin granuloma [obs]",
-          "Hodgkin lymphoma, lymphocyte depletion, diffuse fibrosis",
-          "Hodgkin lymphoma, lymphocyte depletion, NOS",
-          "Hodgkin lymphoma, lymphocyte depletion, reticular",
-          "Hodgkin lymphoma, lymphocyte predominance, nodular",
-          "Hodgkin lymphoma, lymphocyte-rich",
-          "Hodgkin lymphoma, mixed cellularity, NOS",
-          "Hodgkin lymphoma, nodular lymphocyte predominance",
-          "Hodgkin lymphoma, nodular sclerosis, cellular phase",
-          "Hodgkin lymphoma, nodular sclerosis, grade 1",
-          "Hodgkin lymphoma, nodular sclerosis, grade 2",
-          "Hodgkin lymphoma, nodular sclerosis, NOS",
-          "Hodgkin lymphoma, NOS",
-          "Hodgkin paragranuloma, nodular [obs]",
-          "Hodgkin paragranuloma, NOS [obs]",
-          "Hodgkin sarcoma [obs]",
-          "Hurthle cell adenocarcinoma",
-          "Hurthle cell adenoma",
-          "Hurthle cell carcinoma",
-          "Hurthle cell tumor",
-          "Hutchinson melanotic freckle, NOS",
-          "Hyalinizing trabecular adenoma",
-          "Hydatid mole",
-          "Hydatidiform mole, NOS",
-          "Hydroa vacciniforme-like lymphoma",
-          "Hygroma, NOS",
-          "Hypereosinophilic syndrome",
-          "Hypernephroid tumor [obs]",
-          "Hypernephroma",
-          "Idiopathic hemorrhagic thrombocythaemia",
-          "Idiopathic thrombocythemia",
-          "Immature teratoma, malignant",
-          "Immature teratoma, NOS",
-          "Immunoblastic sarcoma [obs]",
-          "Immunocytoma [obs]",
-          "Immunoglobulin deposition disease",
-          "Immunoproliferative disease, NOS",
-          "Immunoproliferative small intestinal disease",
-          "Indeterminate dendritic cell tumor",
-          "Indolent systemic mastocytosis",
-          "Infantile fibrosarcoma",
-          "Infantile hemangioma",
-          "Infantile myofibromatosis",
-          "Infiltrating and papillary adenocarcinoma",
-          "Infiltrating angiolipoma",
-          "Infiltrating basal cell carcinoma, non-sclerosing",
-          "Infiltrating basal cell carcinoma, NOS",
-          "Infiltrating basal cell carcinoma, sclerosing",
-          "Infiltrating duct adenocarcinoma",
-          "Infiltrating duct and colloid carcinoma",
-          "Infiltrating duct and cribriform carcinoma",
-          "Infiltrating duct and lobular carcinoma",
-          "Infiltrating duct and lobular carcinoma in situ",
-          "Infiltrating duct and mucinous carcinoma",
-          "Infiltrating duct and tubular carcinoma",
-          "Infiltrating duct carcinoma, NOS",
-          "Infiltrating duct mixed with other types of carcinoma",
-          "Infiltrating ductular carcinoma",
-          "Infiltrating lipoma",
-          "Infiltrating lobular carcinoma and ductal carcinoma in situ",
-          "Infiltrating lobular carcinoma, NOS",
-          "Infiltrating lobular mixed with other types of carcinoma",
-          "Infiltrating papillary adenocarcinoma",
-          "Inflammatory adenocarcinoma",
-          "Inflammatory carcinoma",
-          "Inflammatory liposarcoma",
-          "Inflammatory myofibroblastic tumor",
-          "Insular carcinoma",
-          "Insulinoma, malignant",
-          "Insulinoma, NOS",
-          "Interdigitating cell sarcoma",
-          "Interdigitating dendritic cell sarcoma",
-          "Intermediate and giant congenital nevus",
-          "Interstitial cell tumor, benign",
-          "Interstitial cell tumor, malignant",
-          "Interstitial cell tumor, NOS",
-          "Intestinal T-cell lymphoma",
-          "Intracanalicular fibroadenoma",
-          "Intracortical osteosarcoma",
-          "Intracystic carcinoma, NOS",
-          "Intracystic papillary adenocarcinoma",
-          "Intracystic papillary adenoma",
-          "Intracystic papillary neoplasm with associated invasive carcinoma",
-          "Intracystic papillary neoplasm with high grade intraepithelial neoplasia",
-          "Intracystic papillary neoplasm with intermediate grade intraepithelial neoplasia",
-          "Intracystic papillary neoplasm with low grade intraepithelial neoplasia",
-          "Intracystic papillary tumor with high grade dysplasia",
-          "Intracystic papillary tumor with high grade entraepithelial neoplasia",
-          "Intracystic papillary tumor with high grade intraepithelial neoplasia",
-          "Intracystic papilloma",
-          "Intradermal nevus",
-          "Intraductal adenocarcinoma, noninfiltrating, NOS",
-          "Intraductal and lobular carcinoma",
-          "Intraductal carcinoma and lobular carcinoma in situ",
-          "Intraductal carcinoma, clinging",
-          "Intraductal carcinoma, noninfiltrating, NOS",
-          "Intraductal carcinoma, NOS",
-          "Intraductal carcinoma, solid type",
-          "Intraductal micropapillary carcinoma",
-          "Intraductal papillary adenocarcinoma with invasion",
-          "Intraductal papillary adenocarcinoma, NOS",
-          "Intraductal papillary carcinoma",
-          "Intraductal papillary mucinous neoplasm with an associated invasive carcinoma",
-          "Intraductal papillary mucinous neoplasm with high grade dysplasia",
-          "Intraductal papillary neoplasm with associated invasive carcinoma",
-          "Intraductal papillary neoplasm with high grade dysplasia",
-          "Intraductal papillary neoplasm with high grade intraepithelial neoplasia",
-          "Intraductal papillary neoplasm with intermediate grade neoplasia",
-          "Intraductal papillary neoplasm with low grade intraepithelial neoplasia",
-          "Intraductal papillary neoplasm, NOS",
-          "Intraductal papillary tumor with high grade dysplasia",
-          "Intraductal papillary tumor with high grade intraepithelial neoplasia",
-          "Intraductal papillary-mucinous adenoma",
-          "Intraductal papillary-mucinous carcinoma, invasive",
-          "Intraductal papillary-mucinous carcinoma, non-invasive",
-          "Intraductal papillary-mucinous neoplasm with low grade dysplasia",
-          "Intraductal papillary-mucinous neoplasm with moderate dysplasia",
-          "Intraductal papillary-mucinous tumor with intermediate dysplasia",
-          "Intraductal papillary-mucinous tumor with low grade dysplasia",
-          "Intraductal papillary-mucinous tumor with moderate dysplasia",
-          "Intraductal papilloma",
-          "Intraductal papillomatosis, NOS",
-          "Intraductal tubular-papillary neoplasm, high grade",
-          "Intraductal tubular-papillary neoplasm, low grade",
-          "Intraepidermal carcinoma, NOS",
-          "Intraepidermal epithelioma of Jadassohn",
-          "Intraepidermal nevus",
-          "Intraepidermal squamous cell carcinoma, Bowen type",
-          "Intraepithelial carcinoma, NOS",
-          "Intraepithelial squamous cell carcinoma",
-          "Intraglandular papillary neoplasm with low grade intraepithelial neoplasia",
-          "Intramuscular hemangioma",
-          "Intramuscular lipoma",
-          "Intraneural perineurioma",
-          "Intraosseous low grade osteosarcoma",
-          "Intraosseous well differentiated osteosarcoma",
-          "Intratubular germ cell neoplasia",
-          "Intratubular malignant germ cells",
-          "Intravascular B-cell lymphoma",
-          "Intravascular bronchial alveolar tumor",
-          "Intravascular large B-cell lymphoma",
-          "Intravascular leiomyomatosis",
-          "Invasive fibroma",
-          "Invasive hydatidiform mole",
-          "Invasive mole, NOS",
-          "Involuting nevus",
-          "Islet cell adenocarcinoma",
-          "Islet cell adenoma",
-          "Islet cell adenomatosis",
-          "Islet cell carcinoma",
-          "Islet cell tumor, benign",
-          "Islet cell tumor, NOS",
-          "Jadassohn blue nevus",
-          "Jugular paraganglioma",
-          "Jugulotympanic paraganglioma",
-          "Junction nevus",
-          "Junctional nevus, NOS",
-          "Juvenile angiofibroma",
-          "Juvenile astrocytoma",
-          "Juvenile carcinoma of breast",
-          "Juvenile chronic myelomonocytic leukemia",
-          "Juvenile fibroadenoma",
-          "Juvenile hemangioma",
-          "Juvenile histiocytoma",
-          "Juvenile melanoma",
-          "Juvenile myelomonocytic leukemia",
-          "Juvenile nevus",
-          "Juxtacortical chondroma",
-          "Juxtacortical chondrosarcoma",
-          "Juxtacortical osteosarcoma",
-          "Juxtaglomerular tumor",
-          "Kaposi sarcoma",
-          "Kaposiform hemangioendothelioma",
-          "Keratotoc papilloma",
-          "Klatskin tumor",
-          "Krukenberg tumor",
-          "Kupffer cell sarcoma",
-          "L-cell tumor",
-          "Lactating adenoma",
-          "Langerhans cell granulomatosis",
-          "Langerhans cell granulomatosis, unifocal",
-          "Langerhans cell histiocytosis, disseminated",
-          "Langerhans cell histiocytosis, generalized",
-          "Langerhans cell histiocytosis, mono-ostotic",
-          "Langerhans cell histiocytosis, multifocal",
-          "Langerhans cell histiocytosis, NOS",
-          "Langerhans cell histiocytosis, poly-ostotic",
-          "Langerhans cell histiocytosis, unifocal",
-          "Langerhans cell sarcoma",
-          "Large B-cell lymphoma arising in HHV8-associated multicentric Castleman disease",
-          "Large cell (Ki-1+) lymphoma",
-          "Large cell calcifying Sertoli cell tumor",
-          "Large cell carcinoma with rhabdoid phenotype",
-          "Large cell carcinoma, NOS",
-          "Large cell medulloblastoma",
-          "Large cell neuroendocrine carcinoma",
-          "Large granular lymphocytosis, NOS",
-          "LCIS, NOS",
-          "Leiomyoblastoma",
-          "Leiomyofibroma",
-          "Leiomyoma, NOS",
-          "Leiomyomatosis, NOS",
-          "Leiomyosarcoma, NOS",
-          "Lennert lymphoma",
-          "Lentigo maligna",
-          "Lentigo maligna melanoma",
-          "Leptomeningeal sarcoma",
-          "Letterer-Siwe disease",
-          "Leukaemic reticuloendotheliosis",
-          "Leukemia, NOS",
-          "Leydig cell tumor, benign",
-          "Leydig cell tumor, malignant",
-          "Leydig cell tumor, NOS",
-          "Linitis plastica",
-          "Lipid cell tumor of ovary",
-          "Lipid-rich carcinoma",
-          "Lipid-rich Sertoli cell tumor",
-          "Lipoadenoma",
-          "Lipoarcoma, well differentiated",
-          "Lipoblastoma",
-          "Lipoblastomatosis",
-          "Lipoid cell tumor of ovary",
-          "Lipoleiomyoma",
-          "Lipoma-like liposarcoma",
-          "Lipoma, NOS",
-          "Lipomatous medulloblastoma",
-          "Liposarcoma, differentiated",
-          "Liposarcoma, NOS",
-          "Liver cell adenoma",
-          "Liver cell carcinoma",
-          "Lobular adenocarcinoma",
-          "Lobular and ductal carcinoma",
-          "Lobular carcinoma in situ, NOS",
-          "Lobular carcinoma, noninfiltrating",
-          "Lobular carcinoma, NOS",
-          "Localized fibrous tumor",
-          "Low grade appendiceal mucinous neoplasm",
-          "Luteinoma",
-          "Luteoma, NOS",
-          "Lymphangioendothelial sarcoma",
-          "Lymphangioendothelioma, malignant",
-          "Lymphangioendothelioma, NOS",
-          "Lymphangioleiomyomatosis",
-          "Lymphangioma, NOS",
-          "Lymphangiomyoma",
-          "Lymphangiomyomatosis",
-          "Lymphangiosarcoma",
-          "Lymphatic leukemis, NOS [obs]",
-          "Lymphoblastic leukemia, NOS",
-          "Lymphoblastoma [obs]",
-          "Lymphocytic leukemia, NOS [obs]",
-          "Lymphoepithelial carcinoma",
-          "Lymphoepithelioid lymphoma",
-          "Lymphoepithelioma",
-          "Lymphoepithelioma-like carcinoma",
-          "Lymphoid leukemia, NOS",
-          "Lymphoma, NOS",
-          "Lymphomatoid granulomatosis",
-          "Lymphomatoid papulosis",
-          "Lymphoplasmacyte-rich meningioma",
-          "Lymphoproliferative disease, NOS",
-          "Lymphoproliferative disorder, NOS",
-          "Lymphosarcoma cell leukemia [obs]",
-          "Lymphosarcoma, diffuse [obs]",
-          "Lymphosarcoma, NOS [obs]",
-          "M6A",
-          "M6B",
-          "Macrofollicular adenoma",
-          "Magnocellular nevus",
-          "Malignancy",
-          "Malignant chondroid syringoma",
-          "Malignant cystic nephroma",
-          "Malignant eccrine spiradenoma",
-          "Malignant fibrous histiocytoma",
-          "Malignant giant cell tumor of soft parts",
-          "Malignant histiocytosis",
-          "Malignant hydatidiform mole",
-          "Malignant lymphoma, centroblastic, diffuse",
-          "Malignant lymphoma, centroblastic, follicular",
-          "Malignant lymphoma, centroblastic, NOS",
-          "Malignant lymphoma, centroblasticcentrocytic, diffuse [obs]",
-          "Malignant lymphoma, centroblasticcentrocytic, follicular [obs]",
-          "Malignant lymphoma, centroblasticcentrocytic, NOS [obs]",
-          "Malignant lymphoma, centrocytic [obs]",
-          "Malignant lymphoma, cleaved cell, NOS [obs]",
-          "Malignant lymphoma, convoluted cell [obs]",
-          "Malignant lymphoma, diffuse, NOS",
-          "Malignant lymphoma, follicle center, follicular",
-          "Malignant lymphoma, follicle center, NOS",
-          "Malignant lymphoma, follicular, NOS",
-          "Malignant lymphoma, histiocytic, diffuse",
-          "Malignant lymphoma, histiocytic, nodular [obs]",
-          "Malignant lymphoma, histiocytic, NOS [obs]",
-          "Malignant lymphoma, Hodgkin",
-          "Malignant lymphoma, immunoblastic, NOS",
-          "Malignant lymphoma, large B-cell, diffuse, centroblastic, NOS",
-          "Malignant lymphoma, large B-cell, diffuse, immunoblastic, NOS",
-          "Malignant lymphoma, large B-cell, diffuse, NOS",
-          "Malignant lymphoma, large B-cell, NOS",
-          "Malignant lymphoma, large cell, cleaved and noncleaved [obs]",
-          "Malignant lymphoma, large cell, cleaved, diffuse",
-          "Malignant lymphoma, large cell, cleaved, NOS [obs]",
-          "Malignant lymphoma, large cell, diffuse, NOS [obs]",
-          "Malignant lymphoma, large cell, follicular, NOS",
-          "Malignant lymphoma, large cell, immunoblastic",
-          "Malignant lymphoma, large cell, noncleaved, diffuse",
-          "Malignant lymphoma, large cell, noncleaved, follicular [obs]",
-          "Malignant lymphoma, large cell, noncleaved, NOS",
-          "Malignant lymphoma, large cell, NOS",
-          "Malignant lymphoma, large cleaved cell, follicular [obs]",
-          "Malignant lymphoma, large cleaved cell, NOS [obs]",
-          "Malignant lymphoma, lymphoblastic, NOS",
-          "Malignant lymphoma, lymphocytec, nodular, NOS [obs]",
-          "Malignant lymphoma, lymphocytec, poorly differentiated, nodular [obs]",
-          "Malignant lymphoma, lymphocytec, well differentiated, nodular [obs]",
-          "Malignant lymphoma, lymphocytic, diffuse, NOS",
-          "Malignant lymphoma, lymphocytic, intermediate differentiation, diffuse [obs]",
-          "Malignant lymphoma, lymphocytic, intermediate differentiation, nodular [obs]",
-          "Malignant lymphoma, lymphocytic, NOS",
-          "Malignant lymphoma, lymphocytic, poorly differentiated, diffuse [obs]",
-          "Malignant lymphoma, lymphocytic, well differentiated, diffuse",
-          "Malignant lymphoma, lymphoplasmacytic",
-          "Malignant lymphoma, lymphoplasmacytoid",
-          "Malignant lymphoma, mixed cell type, diffuse [obs]",
-          "Malignant lymphoma, mixed cell type, follicular [obs]",
-          "Malignant lymphoma, mixed cell type, nodular [obs]",
-          "Malignant lymphoma, mixed lymphocytec-histiocytic, nodular [obs]",
-          "Malignant lymphoma, mixed lymphocytic-histiocytic, diffuse [obs]",
-          "Malignant lymphoma, mixed small and large cell, diffuse",
-          "Malignant lymphoma, mixed small cleaved and large cell, follicular [obs]",
-          "Malignant lymphoma, nodular, NOS [obs]",
-          "Malignant lymphoma, non-cleaved cell, NOS",
-          "Malignant lymphoma, non-Hodgkin, NOS",
-          "Malignant lymphoma, noncleaved cell, follicular, NOS [obs]",
-          "Malignant lymphoma, noncleaved, diffuse, NOS [obs]",
-          "Malignant lymphoma, noncleaved, NOS",
-          "Malignant lymphoma, NOS",
-          "Malignant lymphoma, plasmacytoid [obs]",
-          "Malignant lymphoma, small B lymphocytic, NOS",
-          "Malignant lymphoma, small cell diffuse",
-          "Malignant lymphoma, small cell, noncleaved, diffuse [obs]",
-          "Malignant lymphoma, small cell, NOS",
-          "Malignant lymphoma, small cleaved cell, diffuse [obs]",
-          "Malignant lymphoma, small cleaved cell, follicular [obs]",
-          "Malignant lymphoma, small cleaved cell, NOS [obs]",
-          "Malignant lymphoma, small lymphocytic, diffuse",
-          "Malignant lymphoma, small lymphocytic, NOS",
-          "Malignant lymphoma, small noncleaved, Burkitt type [obs]",
-          "Malignant lymphoma, undifferentiated cell type, NOS [obs]",
-          "Malignant lymphoma, undifferentiated cell, non-Burkitt [obs]",
-          "Malignant lymphoma, undifferentiated, Burkitt type [obs]",
-          "Malignant lymphomatous polyposis",
-          "Malignant mast cell tumor",
-          "Malignant mastocytoma",
-          "Malignant mastocytosis",
-          "Malignant melanoma in congenital melanocytic nevus",
-          "Malignant melanoma in giant pigmented nevus",
-          "Malignant melanoma in Hutchinson melanotic freckle",
-          "Malignant melanoma in junctional nevus",
-          "Malignant melanoma in precancerous melanosis",
-          "Malignant melanoma, NOS (except juvenile melanoma)",
-          "Malignant melanoma, regressing",
-          "Malignant midline reticulosis [obs]",
-          "Malignant mucinous adenofibroma",
-          "Malignant mucinous cystadenofibroma",
-          "Malignant multilocular cystic nephroma",
-          "Malignant myelosclerosis [obs]",
-          "Malignant myoepithelioma",
-          "Malignant peripheral nerve sheath tumor",
-          "Malignant peripheral nerve sheath tumor with rhabdomyoblastic differentation",
-          "Malignant reticulosis, NOS [obs]",
-          "Malignant rhabdoid tumor",
-          "Malignant schwannoma with rhabdomyoblastic differentiation",
-          "Malignant schwannoma, NOS [obs]",
-          "Malignant serous adenofibroma",
-          "Malignant serous cystadenofibroma",
-          "Malignant tenosynovial giant cell tumor",
-          "Malignant teratoma, anaplastic",
-          "Malignant teratoma, intermediate",
-          "Malignant teratoma, trophoblastic",
-          "Malignant teratoma, undifferentiated",
-          "Malignant tumor, clear cell type",
-          "Malignant tumor, fusiform cell type",
-          "Malignant tumor, glant cell type",
-          "Malignant tumor, small cell type",
-          "Malignant tumor, spindle cell type",
-          "MALT lymphoma",
-          "MANEC",
-          "Mantle cell lymphoma (Includes all variants; blastic, pleomorphic, small cell)",
-          "Mantle zone lymphoma [obs]",
-          "Marginal zone B-cell lymphoma, NOS",
-          "Marginal zone lymphoma, NOS",
-          "Masculinovoblastoma",
-          "Mast cell leukaemia",
-          "Mast cell sarcoma",
-          "Mast cell tumor, NOS",
-          "Mastocytoma, NOS",
-          "Matrical carcinoma",
-          "Mature T ALL",
-          "Mature T-cell lymphoma, NOS",
-          "Mature teratoma",
-          "Mediastinal (thymic) large B-cell lymphoma)",
-          "Mediterranean lymphoma",
-          "Medullary adenocarcinoma",
-          "Medullary carcinoma with amyloid stroma",
-          "Medullary carcinoma with lymphoid stroma",
-          "Medullary carcinoma, NOS",
-          "Medullary osteosarcoma",
-          "Medulloblastoma with extensive nodularity",
-          "Medulloblastoma, NOS",
-          "Medullocytoma",
-          "Medulloepithelioma, benign",
-          "Medulloepithelioma, NOS",
-          "Medullomyoblastoma",
-          "Megakaryocytic leukemia",
-          "Megakaryocytic myelosclerosis",
-          "Melanoameloblastoma",
-          "Melanocytic nevus",
-          "Melanocytoma, eyeball",
-          "Melanocytoma, NOS",
-          "Melanoma in situ",
-          "Melanoma, malignant, of soft parts",
-          "Melanoma, NOS",
-          "Melanotic medulloblastoma",
-          "Melanotic MPNST",
-          "Melanotic neuroectodermal tumor",
-          "Melanotic neurofibroma",
-          "Melanotic progonoma",
-          "Melanotic psammomatous MPNST",
-          "Melanotic schwannoma",
-          "Meningeal melanocytoma",
-          "Meningeal melanomatosis",
-          "Meningeal sarcoma",
-          "Meningeal sarcomatosis",
-          "Meningioma, anaplastic",
-          "Meningioma, malignant",
-          "Meningioma, NOS",
-          "Meningiomatosis, NOS",
-          "Meningothelial meningioma",
-          "Meningothelial sarcoma",
-          "Merkel cell carcinoma",
-          "Merkel cell tumor",
-          "Mesenchymal chondrosarcoma",
-          "Mesenchymal tumor, malignant",
-          "Mesenchymoma, benign",
-          "Mesenchymoma, malignant",
-          "Mesenchymoma, NOS",
-          "Mesenteric fibromatosis",
-          "Mesoblastic nephroma",
-          "Mesodermal mixed tumor",
-          "Mesonephric adenocarcinoma",
-          "Mesonephric adenoma",
-          "Mesonephric tumor, NOS",
-          "Mesonephroma, benign",
-          "Mesonephroma, malignant",
-          "Mesonephroma, NOS",
-          "Mesothelial papilloma",
-          "Mesothelioma, benign",
-          "Mesothelioma, biphasic, malignant",
-          "Mesothelioma, biphasic, NOS",
-          "Mesothelioma, malignant",
-          "Mesothelioma, NOS",
-          "Metanephric adenoma",
-          "Metaplastic carcinoma, NOS",
-          "Metaplastic meningioma",
-          "Metastasizing leiomyoma",
-          "Metastatic signet ring cell carcinoma",
-          "Metatypical carcinoma",
-          "MGUS",
-          "Microcystic adenoma",
-          "Microcystic adnexal carcinoma",
-          "Microcystic meningioma",
-          "Microfollicular adenoma, NOS",
-          "Microglioma",
-          "Micropapillary carcinoma, NOS",
-          "Micropapillary serous carcinoma",
-          "Mixed acidophil-basophil adenoma",
-          "Mixed acidophil-basophil carcinoma",
-          "Mixed acinar-ductal carcinoma",
-          "Mixed acinar-endocrine carcinoma",
-          "Mixed acinar-endocrine-ductal carcinoma",
-          "Mixed adenocarcinoma and epidermoid carcinoma",
-          "Mixed adenocarcinoma and squamous cell carcinoma",
-          "Mixed adenomatous and hyperplastic polyp",
-          "Mixed adenoneuroendocrine carcinoma",
-          "Mixed basal-squamous cell carcinoma",
-          "Mixed carcinoid-adenocarcinoma",
-          "Mixed cell adenocarcinoma",
-          "Mixed cell adenoma",
-          "Mixed ductal-endocrine carcinoma",
-          "Mixed embryonal carcinoma and teratoma",
-          "Mixed embryonal rhabdomyosarcoma and alveolar rhabdomyosarcoma",
-          "Mixed endocrine and exocrine adenocarcinoma",
-          "Mixed epithelioid and spindle cell melanoma",
-          "Mixed germ cell tumor",
-          "Mixed glioma",
-          "Mixed hepatocellular and bile duct carcinoma",
-          "Mixed islet cell and exocrine adenocarcinoma",
-          "Mixed liposarcoma",
-          "Mixed medullary-follicular carcinoma",
-          "Mixed medullary-papillary carcinoma",
-          "Mixed meningioma",
-          "Mixed mesenchymal sarcoma",
-          "Mixed mesenchymal tumor",
-          "Mixed pancreatic endocrine and exocrine tumor, malignant",
-          "Mixed phenotype acute leukemia with t (9;22) (q34;q11.2); BCR-ABL1",
-          "Mixed phenotype acute leukemia with t(v;11q23); MLL rearranged",
-          "Mixed phenotype acute leukemia, B/myeloid, NOS",
-          "Mixed phenotype acute leukemia, T/myeloid, NOS",
-          "Mixed pineal tumor",
-          "Mixed pineocytoma-pineoblastoma",
-          "Mixed small cell carcinoma",
-          "Mixed squamous cell and glandular papilloma",
-          "Mixed subependymoma-ependymoma",
-          "Mixed teratoma and seminoma",
-          "Mixed tumor, malignant, NOS",
-          "Mixed tumor, NOS",
-          "Mixed tumor, salivary gland type, malignant",
-          "Mixed tumor, salivary gland type, NOS",
-          "Mixed type rhabdomyosarcoma",
-          "Monoblastic leukemia, Nos",
-          "Monoclonal gammopathy of undetermined significance",
-          "Monoclonal gammopathy, NOS",
-          "Monocytic leukemia, NOS",
-          "Monocytoid B-cell lymphoma",
-          "Monomorphic adenoma",
-          "Monstrocellular sarcoma",
-          "MPNST with glandular differentiation",
-          "MPNST with mesenchymal differentiation",
-          "MPNST with rhabdomyoblastic differentiation",
-          "MPNST, NOS",
-          "Mu heavy chain disease",
-          "Mucin-producing adenocarcinoma",
-          "Mucin-producing carcinoma",
-          "Mucin-secreting adenocarcinoma",
-          "Mucin-secreting carcinoma",
-          "Mucinous adenocarcinofibroma",
-          "Mucinous adenocarcinoma",
-          "Mucinous adenocarcinoma, endocervical type",
-          "Mucinous adenofibroma of borderline malignancy",
-          "Mucinous adenofibroma, NOS",
-          "Mucinous adenoma",
-          "Mucinous carcinoid",
-          "Mucinous carcinoma",
-          "Mucinous cystadenocarcinofibroma",
-          "Mucinous cystadenocarcinoma, non-invasive",
-          "Mucinous cystadenocarcinoma, NOS",
-          "Mucinous cystadenofibroma of borderline malignancy",
-          "Mucinous cystadenofibroma, NOS",
-          "Mucinous cystadenoma, borderline malignancy",
-          "Mucinous cystadenoma, NOS",
-          "Mucinous cystic neoplasm with an associated invasive carcinoma",
-          "Mucinous cystic neoplasm with high-grade dysplasia",
-          "Mucinous cystic neoplasm with high-grade intraepithelial neoplasia",
-          "Mucinous cystic neoplasm with intermediate-grade dysplasia",
-          "Mucinous cystic neoplasm with intermediate-grade intraepithelial neoplasia",
-          "Mucinous cystic neoplasm with low-grade dysplasia",
-          "Mucinous cystic neoplasm with low-grade intraepithelial neoplasia",
-          "Mucinous cystic tumor of borderline malignancy",
-          "Mucinous cystic tumor with an associated invasive carcinoma",
-          "Mucinous cystic tumor with high-grade dysplasia",
-          "Mucinous cystic tumor with intermediate dysplasia",
-          "Mucinous cystic tumor with low grade dysplasia",
-          "Mucinous cystic tumor with moderate dysplasia",
-          "Mucinous cystoma",
-          "Mucinous tumor, NOS, of low malignant potential",
-          "Mucocarcinoid tumor",
-          "Mucoepidermoid carcinoma",
-          "Mucoepidermoid tumor [obs]",
-          "Mucoid adenocarcinoma",
-          "Mucoid carcinoma",
-          "Mucoid cell adenocarcinoma",
-          "Mucoid cell adenoma",
-          "Mucosal lentiginous melanoma",
-          "Mucosal-associated lymphoid tissue lymphoma",
-          "Mucous adenocarcinoma",
-          "Mucous carcinoma",
-          "Mullerian mixed tumor",
-          "Multicentric basal cell carcinoma",
-          "Multicystic mesothelioma, benign",
-          "Multifocal superficial basal cell carcinoma",
-          "Multiple adenomatous polyps",
-          "Multiple endocrine adenomas",
-          "Multiple hemorrhagic sarcoma",
-          "Multiple meningiomas",
-          "Multiple myeloma",
-          "Multiple neurofibromatosis",
-          "Mycosis fungoides",
-          "Myelocytic leukemia, NOS",
-          "Myelodysplastic syndrome with 5q deletion (5q-) syndrome",
-          "Myelodysplastic syndrome with isolated del (5q)",
-          "Myelodysplastic syndrome, NOS",
-          "Myelodysplastic syndrome, unclassifiable",
-          "Myelodysplastic/myeloproliferative neoplasm, unclassifiable",
-          "Myelofibrosis as a result of myeloproliferative disease",
-          "Myelofibrosis with myeloid metaplasia",
-          "Myelogenous leukemia, NOS",
-          "Myeloid and lymphoid neoplasms with FGFR1 abnormalities",
-          "Myeloid and lymphoid neoplasms with PDGFRA rearrangement",
-          "Myeloid leukemia associated with Down Syndrome",
-          "Myeloid leukemia, NOS",
-          "Myeloid neoplasms with PDGFRB rearrangement",
-          "Myeloid sarcoma",
-          "Myelolipoma",
-          "Myeloma, NOS",
-          "Myelomatosis",
-          "Myelomonocytic leukemia, NOS",
-          "Myeloproliferative disease, NOS",
-          "Myeloproliferative neoplasm, NOS",
-          "Myelosclerosis with myeloid metaplasia",
-          "Myloproliferative neoplasm, unclassifiable",
-          "Myoepithelial adenoma",
-          "Myoepithelial carcinoma",
-          "Myoepithelial tumor",
-          "Myoepithelioma",
-          "Myofibroblastic tumor, NOS",
-          "Myofibroblastic tumor, peribronchial",
-          "Myofibroblastoma",
-          "Myofibroma",
-          "Myofibromatosis",
-          "Myoma",
-          "Myosarcoma",
-          "Myxofibroma, NOS",
-          "Myxoid chondrosarcoma",
-          "Myxoid fibroma",
-          "Myxoid leiomyosarcoma",
-          "Myxoid liposarcoma",
-          "Myxolipoma",
-          "Myxoliposarcoma",
-          "Myxoma, NOS",
-          "Myxopapillary ependymoma",
-          "Myxosarcoma",
-          "Neoplasm, benign",
-          "Neoplasm, malignant",
-          "Neoplasm, malignant, uncertain whether primary or metastatic",
-          "Neoplasm, metastatic",
-          "Neoplasm, NOS",
-          "Neoplasm, secondary",
-          "Neoplasm, uncertain whether benign or malignant",
-          "Nephroblastoma, NOS",
-          "Nephrogenic adenofibroma",
-          "Nephroma, NOS",
-          "Nerve sheath myxoma",
-          "Nesidioblastoma",
-          "Neurilemoma, malignant [obs]",
-          "Neurilemoma, NOS",
-          "Neurilemosarcoma [obs]",
-          "Neurinoma",
-          "Neurinomatosis",
-          "Neuroastrocytoma [obs]",
-          "Neuroblastoma, NOS",
-          "Neurocytoma",
-          "Neuroectodermal tumor, NOS",
-          "Neuroendocrine carcinoma, low grade",
-          "Neuroendocrine carcinoma, moderately differentiated",
-          "Neuroendocrine carcinoma, NOS",
-          "Neuroendocrine carcinoma, well-differentiated",
-          "Neuroendocrine tumor, grade 1",
-          "Neuroendocrine tumor, grade 2",
-          "Neuroepithelioma, NOS",
-          "Neurofibroma, NOS",
-          "Neurofibromatosis, NOS",
-          "Neurofibrosarcoma [obs]",
-          "Neurogenic sarcoma [obs]",
-          "Neurolipocytoma",
-          "Neuroma, NOS",
-          "Neuronevus",
-          "Neurosarcoma [obs]",
-          "Neurothekeoma",
-          "Neurotropic melanoma, malignant",
-          "Nevus, NOS",
-          "NK-cell large granular lymphocytic leukemia",
-          "NK/T-cell lymphoma, nasal and nasal-type",
-          "Nodal marginal zone lymphoma",
-          "Nodular hidradenoma",
-          "Nodular hidradenoma, malignant",
-          "Nodular melanoma",
-          "Non-Hodgkin lymphoma, NOS",
-          "Non-lymphocytic leukemia, NOS",
-          "Non-small cell carcinoma",
-          "Nonchromaffin paraganglioma, malignant",
-          "Nonchromaffin paraganglioma, NOS",
-          "Nonencapsulated sclerosing adenocarcinoma",
-          "Nonencapsulated sclerosing carcinoma",
-          "Nonencapsulated sclerosing tumor",
-          "Noninfiltrating intracystic carcinoma",
-          "Noninfiltrating intraductal papillary adenocarcinoma",
-          "Noninfiltrating intraductal papillary carcinoma",
-          "Noninvasive pancreatobiliary papillary neoplasm with high grade dysplasia",
-          "Noninvasive pancreatobiliary papillary neoplasm with high grade intraepithelial neoplasia",
-          "Noninvasive pancreatobiliary papillary neoplasm with low grade dysplasia",
-          "Noninvasive pancreatobiliary papillary neoplasm with low grade intraepithelial neoplasia",
-          "Nonlipid reticuloendotheliosis",
-          "Nonpigmented nevus",
-          "Oat cell carcinoma",
-          "Odontoameloblastoma",
-          "Odontogenic carcinoma",
-          "Odontogenic carcinosarcoma",
-          "Odontogenic fibroma, NOS",
-          "Odontogenic fibrosarcoma",
-          "Odontogenic ghost cell tumor",
-          "Odontogenic myxofibroma",
-          "Odontogenic myxoma",
-          "Odontogenic sarcoma",
-          "Odontogenic tumor, benign",
-          "Odontogenic tumor, malignant",
-          "Odontogenic tumor, NOS",
-          "Odontoma, NOS",
-          "Olfactory neuroblastoma",
-          "Olfactory neurocytoma",
-          "Olfactory neuroepithelioma",
-          "Olfactory neurogenic tumor",
-          "Oligoastrocytoma",
-          "Oligodendroblastoma",
-          "Oligodendroglioma, anaplastic",
-          "Oligodendroglioma, NOS",
-          "Oncocytic adenocarcinoma",
-          "Oncocytic adenoma",
-          "Oncocytic carcinoma",
-          "Oncocytic Schneiderian papilloma",
-          "Oncocytoma",
-          "Orchioblastoma",
-          "Ossifying fibroma",
-          "Ossifying fibromyxoid tumor",
-          "Ossifying renal tumor",
-          "Osteoblastic sarcoma",
-          "Osteoblastoma, malignant",
-          "Osteoblastoma, NOS",
-          "Osteocartilaginous exostosis",
-          "Osteochondroma",
-          "Osteochondromatosis, NOS",
-          "Osteochondrosarcoma",
-          "Osteofibroma",
-          "Osteofibrosarcoma",
-          "Osteogenic sarcoma, NOS",
-          "Osteoid osteoma, NOS",
-          "Osteoma, NOS",
-          "Osteosarcoma in Paget disease of bone",
-          "Osteosarcoma, NOS",
-          "Ovarian stromal tumor",
-          "Oxyphilic adenocarcinoma",
-          "Oxyphilic adenoma",
-          "Pacinian tumor",
-          "Paget disease and infiltrating duct carcinoma of breast",
-          "Paget disease and intraductal carcinoma of breast",
-          "Paget disease of breast",
-          "Paget disease, extramammary (except Paget disease of bone)",
-          "Paget disease, mammary",
-          "Pagetoid reticulosis",
-          "Pancreatic endocrine tumor, benign",
-          "Pancreatic endocrine tumor, malignant",
-          "Pancreatic endocrine tumor, nonfunctioning",
-          "Pancreatic endocrine tumor, NOS",
-          "Pancreatic microadenoma",
-          "Pancreatic peptide and pancreatic peptide-like peptide within terminal tyrosine amide producing tumor",
-          "Pancreatobiliary neoplasm, non-invasive",
-          "Pancreatobiliary-type carcinoma",
-          "Pancreatoblastoma",
-          "Papillary adenocarcinoma, follicular variant",
-          "Papillary adenocarcinoma, NOS",
-          "Papillary adenofibroma",
-          "Papillary adenoma, NOS",
-          "Papillary and follicular adenocarcinoma",
-          "Papillary and follicular carcinoma",
-          "Papillary carcinoma in situ",
-          "Papillary carcinoma of thyroid",
-          "Papillary carcinoma, columnar cell",
-          "Papillary carcinoma, diffuse sclerosing",
-          "Papillary carcinoma, encapsulated",
-          "Papillary carcinoma, follicular variant",
-          "Papillary carcinoma, NOS",
-          "Papillary carcinoma, oxyphilic cell",
-          "Papillary carcinoma, tall cell",
-          "Papillary cystadenocarcinoma, NOS",
-          "Papillary cystadenoma lymphomatosum",
-          "Papillary cystadenoma, borderline malignancy",
-          "Papillary cystadenoma, NOS",
-          "Papillary cystic tumor",
-          "Papillary ependymoma",
-          "Papillary epidermoid carcinoma",
-          "Papillary glioneuronal tumor",
-          "Papillary hidradenoma",
-          "Papillary meningioma",
-          "Papillary microcarcinoma",
-          "Papillary mucinous cystadenocarcinoma",
-          "Papillary mucinous cystadenoma, borderline malignancy",
-          "Papillary mucinous cystadenoma, NOS",
-          "Papillary mucinous tumor of low malignant potential",
-          "Papillary neoplasm, pancreatobiliary-type, with high grade intraepithelial neoplasia",
-          "Papillary pseudomucinous cystadenocarcinoma",
-          "Papillary pseudomucinous cystadenoma, borderline malignancy",
-          "Papillary pseudomucinous cystadenoma, NOS",
-          "Papillary renal cell carcinoma",
-          "Papillary serous adenocarcinoma",
-          "Papillary serous cystadenocarcinoma",
-          "Papillary serous cystadenoma, borderline malignancy",
-          "Papillary serous cystadenoma, NOS",
-          "Papillary serous tumor of low malignant potential",
-          "Papillary squamous cell carcinoma",
-          "Papillary squamous cell carcinoma in situ",
-          "Papillary squamous cell carcinoma, non-invasive",
-          "Papillary syringadenoma",
-          "Papillary syringocystadenoma",
-          "Papillary transitional cell carcinoma",
-          "Papillary transitional cell carcinoma, non-invasive",
-          "Papillary transitional cell neoplasm of low malignant potential",
-          "Papillary tumor of the pineal region",
-          "Papillary urothelial carcinoma",
-          "Papillary urothelial carcinoma, non-invasive",
-          "Papillary urothelial neoplasm of low malignant potential",
-          "Papillocystic adenocarcinoma",
-          "Papilloma of bladder",
-          "Papilloma, NOS (except papilloma of bladder M-8120/I)",
-          "Papillomatosis, glandular",
-          "Papillomatosis, NOS",
-          "Papillotubular adenocarcinoma",
-          "Papillotubular adenoma",
-          "Parachordoma",
-          "Parafollicular cell carcinoma",
-          "Paraganglioma, benign",
-          "Paraganglioma, malignant",
-          "Paraganglioma, NOS",
-          "Parasympathetic paraganglioma",
-          "Parietal cell adenocarcinoma",
-          "Parietal cell carcinoma",
-          "Parosteal osteosarcoma",
-          "Partial hydatidiform mole",
-          "Periapical cemental dysplasia",
-          "Periapical cemento-osseous dysplasia",
-          "Pericanalicular fibroadenoma",
-          "Perifollicular fibroma",
-          "Perineural MPNST",
-          "Perineurioma, malignant",
-          "Perineurioma, NOS",
-          "Periosteal chondroma",
-          "Periosteal chondrosarcoma",
-          "Periosteal fibroma",
-          "Periosteal fibrosarcoma",
-          "Periosteal osteosarcoma",
-          "Periosteal sarcoma, NOS",
-          "Peripheral neuroectodermal tumor",
-          "Peripheral odontogenic fibroma",
-          "Peripheral primitive neuroectodermal tumor, NOS",
-          "Peripheral T-cell lymphoma, AILD (Angioimmunoblastic Lymphadenopathy with Dysproteinemia)",
-          "Peripheral T-cell lymphoma, large cell",
-          "Peripheral T-cell lymphoma, NOS",
-          "Peripheral T-cell lymphoma, pleomorphic medium and large cell",
-          "Peripheral T-cell lymphoma, pleomorphic small cell",
-          "Pheochromoblastoma",
-          "Pheochromocytoma, malignant",
-          "Pheochromocytoma, NOS",
-          "Phyllodes tumor, benign",
-          "Phyllodes tumor, borderline",
-          "Phyllodes tumor, malignant",
-          "Phyllodes tumor, NOS",
-          "Pick tubular adenoma",
-          "Pigmented adenoma",
-          "Pigmented basal cell carcinoma",
-          "Pigmented dermatofibrosarcoma protuberans",
-          "Pigmented nevus, NOS",
-          "Pigmented schwannoma",
-          "Pigmented spindle cell nevus of Reed",
-          "Pilar tumor",
-          "Pilocytic astrocytoma",
-          "Piloid astrocytoma",
-          "Pilomatricoma, malignant",
-          "Pilomatricoma, NOS",
-          "Pilomatrix carcinoma",
-          "Pilomatrixoma, malignant",
-          "Pilomatrixoma, NOS",
-          "Pilomyxoid astrocytoma",
-          "PIN III",
-          "Pindborg tumor",
-          "Pineal parenchymal tumor of intermediate differentiation",
-          "Pinealoma",
-          "Pineoblastoma",
-          "Pineocytoma",
-          "Pinkus tumor",
-          "Pituicytoma",
-          "Pituitary adenoma, NOS",
-          "Pituitary carcinoma, NOS",
-          "Placental site trophoblastic tumor",
-          "Plasma cell leukemia",
-          "Plasma cell myeloma",
-          "Plasma cell tumor",
-          "Plasmablastic lymphoma",
-          "Plasmacytic leukemia",
-          "Plasmacytic lymphoma [obs]",
-          "Plasmacytoma of bone",
-          "Plasmacytoma, extramedullary (not occurring in bone)",
-          "Plasmacytoma, NOS",
-          "Pleomorphic adenoma",
-          "Pleomorphic carcinoma",
-          "Pleomorphic cell sarcoma",
-          "Pleomorphic leiomyoma",
-          "Pleomorphic lipoma",
-          "Pleomorphic liposarcoma",
-          "Pleomorphic rhabdomyosarcoma, adult type",
-          "Pleomorphic rhabdomyosarcoma, NOS",
-          "Pleomorphic xanthoastrocytoma",
-          "Pleuropulmonary blastoma",
-          "Plexiform fibrohistiocytic tumor",
-          "Plexiform fibromyxoma",
-          "Plexiform hemangioma",
-          "Plexiform leiomyoma",
-          "Plexiform neurofibroma",
-          "Plexiform neuroma",
-          "Plexiform schwannoma",
-          "PNET, NOS",
-          "Pneumoblastoma",
-          "Polar spongioblastoma",
-          "Polycythemia rubra vera",
-          "Polycythemia vera",
-          "Polyembryoma",
-          "Polygonal cell carcinoma",
-          "Polymorphic post transplant lymphoproliferative disorder",
-          "Polymorphic reticulosis [obs]",
-          "Polymorphous low grade adenocarcinoma",
-          "Polypoid adenoma",
-          "Polyvesicular vitelline tumor",
-          "Poorly cohesive carcinoma",
-          "Porocarcinoma",
-          "Post transplant lymphoproliferative disorder, NOS",
-          "PP/PYY producing tumor",
-          "PPNET",
-          "Pre-B ALL",
-          "Pre-pre-B ALL",
-          "Pre-T ALL",
-          "Precancerous melanosis, NOS",
-          "Precursor B-cell lymphoblastic leukemia",
-          "Precursor B-cell lymphoblastic lymphoma",
-          "Precursor cell lymphoblastic leukemia, NOS",
-          "Precursor cell lymphoblastic leukemia, not phenotyped",
-          "Precursor cell lymphoblastic lymphoma, NOS",
-          "Precursor T-cell lymphoblastic leukemia",
-          "Precursor T-cell lymphoblastic lymphoma",
-          "Preleukaemia [obs]",
-          "Preleukemic syndrome [obs]",
-          "Primary amyloidosis",
-          "Primary cutaneous anaplastic large cell lymphoma",
-          "Primary cutaneous CD30+ large T-cell lymphoma",
-          "Primary cutaneous CD30+ T-cell lymphoproliferative disorder",
-          "Primary cutaneous CD4-positive small/medium T-cell lymphoma",
-          "Primary cutaneous CD8-positive aggressive epidermotropic cytotoxic T-cell lymphoma",
-          "Primary cutaneous DLBCL, leg type",
-          "Primary cutaneous follicle centre lymphoma",
-          "Primary cutaneous gamma-delta T-cell lymphoma",
-          "Primary cutaneous neuroendocrine carcinoma",
-          "Primary diffuse large B-cell lymphoma of the CNS",
-          "Primary effusion lymphoma",
-          "Primary intraosseous carcinoma",
-          "Primary myelofibrosis",
-          "Primary serous papillary carcinoma of peritoneum",
-          "Primitive neuroectodermal tumor, NOS",
-          "Primitive polar spongioblastoma",
-          "Pro-B ALL",
-          "Pro-T ALL",
-          "Prolactinoma",
-          "Proliferating trichilemmal cyst",
-          "Proliferating trichilemmal tumor",
-          "Proliferative dermal lesion in congenital nevus",
-          "Proliferative polycythemia",
-          "Prolymphocytic leukemia, B-cell type",
-          "Prolymphocytic leukemia, NOS",
-          "Prolymphocytic leukemia, T-cell type",
-          "Prostatic intraepithelial neoplasia, grade III",
-          "Protoplasmic astrocytoma",
-          "Psammomatous meningioma",
-          "Psammomatous schwannoma",
-          "Pseudomucinous adenocarcinoma",
-          "Pseudomucinous cystadenocarcinoma, NOS",
-          "Pseudomucinous cystadenoma, borderline malignancy",
-          "Pseudomucinous cystadenoma, NOS",
-          "Pseudomyxoma peritonei",
-          "Pseudomyxoma peritonei with unknown primary site",
-          "Pseudosarcomatous carcinoma",
-          "PTLD, NOS",
-          "Pulmonary adenomatosis",
-          "Pulmonary blastoma",
-          "Queyrat erythroplasia",
-          "Racemose hemangioma",
-          "RAEB",
-          "RAEB I",
-          "RAEB II",
-          "RAEB-T",
-          "RARS",
-          "Rathke pouch tumor",
-          "Recklinghausen disease (except of bone)",
-          "Refractory anemia",
-          "Refractory anemia with excess blasts",
-          "Refractory anemia with excess blasts in transformation [obs]",
-          "Refractory anemia with ring sideroblasts associated with marked thrombocytosis",
-          "Refractory anemia with ringed sideroblasts",
-          "Refractory anemia with sideroblasts",
-          "Refractory anemia without sideroblasts",
-          "Refractory cytopenia of childhood",
-          "Refractory cytopenia with multilineage dysplasia",
-          "Refractory neutropenia",
-          "Refractory thrombocytopenia",
-          "Regressing nevus",
-          "Renal carcinoma, collecting duct type",
-          "Renal cell adenocarcinoma",
-          "Renal cell carcinoma, chromophobe type",
-          "Renal cell carcinoma, NOS",
-          "Renal cell carcinoma, sarcomatoid",
-          "Renal cell carcinoma, spindle cell",
-          "Reninoma",
-          "Renomedullary fibroma",
-          "Renomedullary interstitial cell tumor",
-          "Reserve cell carcinoma",
-          "Reticulohistiocytoma",
-          "Reticulosarcoma, diffuse [obs]",
-          "Reticulosarcoma, NOS [obs]",
-          "Reticulum cell sarcoma, diffuse [obs]",
-          "Reticulum cell sarcoma, NOS [obs]",
-          "Retinal anlage tumor",
-          "Retinoblastoma, differentiated",
-          "Retinoblastoma, diffuse",
-          "Retinoblastoma, NOS",
-          "Retinoblastoma, spontaneously regressed",
-          "Retinoblastoma, undifferentiated",
-          "Retinocytoma",
-          "Retroperitoneal fibromatosis",
-          "Rhabdoid meningioma",
-          "Rhabdoid sarcoma",
-          "Rhabdoid tumor, NOS",
-          "Rhabdomyoma, NOS",
-          "Rhabdomyosarcoma with ganglionic differentiation",
-          "Rhabdomyosarcoma, NOS",
-          "Rhabdosarcoma",
-          "Rodent ulcer",
-          "Rosette-forming glioneuronal tumor",
-          "Round cell carcinoma",
-          "Round cell liposarcoma",
-          "Round cell osteosarcoma",
-          "Round cell sarcoma",
-          "SALT lymphoma",
-          "Sarcoma botryoides",
-          "Sarcoma, NOS",
-          "Sarcomatoid carcinoma",
-          "Sarcomatoid mesothelioma",
-          "Sarcomatosis, NOS",
-          "Schmincke tumor",
-          "Schneiderian carcinoma",
-          "Schneiderian papilloma, inverted",
-          "Schneiderian papilloma, NOS",
-          "Schwannoma, NOS",
-          "Scirrhous adenocarcinoma",
-          "Scirrhous carcinoma",
-          "Sclerosing hemangioma",
-          "Sclerosing hepatic carcinoma",
-          "Sclerosing liposarcoma",
-          "Sclerosing stromal tumor",
-          "Sclerosing sweat duct carcinoma",
-          "Sebaceous adenocarcinoma",
-          "Sebaceous adenoma",
-          "Sebaceous carcinoma",
-          "Sebaceous epithelioma",
-          "Secondary carcinoma",
-          "Secretory carcinoma of breast",
-          "Secretory meningioma",
-          "Seminoma with high mitotic index",
-          "Seminoma, anaplastic",
-          "Seminoma, NOS",
-          "Serotonin producing carcinoid",
-          "Serous adenocarcinofibroma",
-          "Serous adenocarcinoma, NOS",
-          "Serous adenofibroma of borderline malignancy",
-          "Serous adenofibroma, NOS",
-          "Serous carcinoma, NOS",
-          "Serous cystadenocarcinofibroma",
-          "Serous cystadenocarcinoma, NOS",
-          "Serous cystadenofibroma of borderline malignancy",
-          "Serous cystadenofibroma, NOS",
-          "Serous cystadenoma, borderline malignancy",
-          "Serous cystadenoma, NOS",
-          "Serous cystoma",
-          "Serous microcystic adenoma",
-          "Serous papillary cystic tumor of borderline malignancy",
-          "Serous surface papillary carcinoma",
-          "Serous surface papillary tumor of borderline malignancy",
-          "Serous surface papilloma",
-          "Serous tumor, NOS, of low malignant potential",
-          "Serrated adenocarcinoma",
-          "Serrated adenoma",
-          "Sertoli cell adenoma",
-          "Sertoli cell carcinoma",
-          "Sertoli cell tumor with lipid storage",
-          "Sertoli cell tumor, NOS",
-          "Sertoli-Leydig cell tumor of intermediate differentiation",
-          "Sertoli-Leydig cell tumor, intermediate differentiation, with heterologous elements",
-          "Sertoli-Leydig cell tumor, NOS",
-          "Sertoli-Leydig cell tumor, poorly differentiated",
-          "Sertoli-Leydig cell tumor, poorly differentiated, with heterologous elements",
-          "Sertoli-Leydig cell tumor, retiform",
-          "Sertoli-Leydig cell tumor, retiform, with heterologous elements",
-          "Sertoli-Leydig cell tumor, sarcomatoid",
-          "Sertoli-Leydig cell tumor, well differentiated",
-          "Sessile serrated adenoma",
-          "Sessile serrated polyp",
-          "SETTLE",
-          "Sex cord tumor with annular tubules",
-          "Sex cord tumor, NOS",
-          "Sex cord-gonadal stromal tumor, incompletely differentiated",
-          "Sex cord-gonadal stromal tumor, mixed forms",
-          "Sex cord-gonadal stromal tumor, NOS",
-          "Sezary disease",
-          "Sezary syndrome",
-          "Sialoblastoma",
-          "Signet ring cell adenocarcinoma",
-          "Signet ring cell carcinoma",
-          "Sinonasal papilloma, exophytic",
-          "Sinonasal papilloma, fungiform",
-          "Sinonasal papilloma, NOS",
-          "Skin appendage adenoma",
-          "Skin appendage carcinoma",
-          "Skin appendage tumor, benign",
-          "Skin-associated lymphoid tissue lymphoma",
-          "Small cell carcinoma, fusiform cell",
-          "Small cell carcinoma, intermediate cell",
-          "Small cell carcinoma, NOS",
-          "Small cell neuroendocrine carcinoma",
-          "Small cell osteosarcoma",
-          "Small cell sarcoma",
-          "Small congenital nevus",
-          "Smooth muscle tumor of uncertain malignant potential",
-          "Smooth muscle tumor, NOS",
-          "Soft tissue perineurioma",
-          "Soft tissue sarcoma",
-          "Soft tissue tumor, benign",
-          "Soft tissue tumor, malignant",
-          "Solid adenocarcinoma with mucin formation",
-          "Solid and cystic tumor",
-          "Solid and papillary epithelial neoplasm",
-          "Solid carcinoma with mucin formation",
-          "Solid carcinoma, NOS",
-          "Solid pseudopapillary carcinoma",
-          "Solid pseudopapillary tumor",
-          "Solid teratoma",
-          "Solitary fibrous tumor",
-          "Solitary fibrous tumor, malignant",
-          "Solitary mastocytoma of skin",
-          "Solitary myeloma",
-          "Solitary plasmacytoma",
-          "Somatostatin cell tumor, malignant",
-          "Somatostatin cell tumor, NOS",
-          "Somatostatinoma, malignant",
-          "Somatostatinoma, NOS",
-          "Spermatocytic seminoma",
-          "Spermatocytoma",
-          "Spindle cell angioendothelioma",
-          "Spindle cell carcinoma, NOS",
-          "Spindle cell hemangioendothelioma",
-          "Spindle cell lipoma",
-          "Spindle cell melanoma, NOS",
-          "Spindle cell melanoma, type A",
-          "Spindle cell melanoma, type B",
-          "Spindle cell nevus, NOS",
-          "Spindle cell oncocytoma",
-          "Spindle cell rhabdomyosarcoma",
-          "Spindle cell sarcoma",
-          "Spindle epithelial tumor with thymus-like differentiation",
-          "Spindle epithelial tumor with thymus-like element",
-          "Spindled mesothelioma",
-          "Spiradenoma, NOS",
-          "Spitz nevus",
-          "Splenic B-cell lymphoma/leukemia, unclassifiable",
-          "Splenic diffuse red pulp small B-cell lymphoma",
-          "Splenic lymphoma with villous lymphocytes",
-          "Splenic marginal zone B-cell lymphoma",
-          "Splenic marginal zone lymphoma, NOS",
-          "Spongioblastoma multiforme",
-          "Spongioblastoma polare",
-          "Spongioblastoma, NOS",
-          "Spongioneuroblastoma",
-          "Squamous carcinoma",
-          "Squamous cell carcinoma in situ with questionable stromal invasion",
-          "Squamous cell carcinoma in situ, NOS",
-          "Squamous cell carcinoma with horn formation",
-          "Squamous cell carcinoma, acantholytic",
-          "Squamous cell carcinoma, adenoid",
-          "Squamous cell carcinoma, clear cell type",
-          "Squamous cell carcinoma, keratinizing, NOS",
-          "Squamous cell carcinoma, large cell, keratinizing",
-          "Squamous cell carcinoma, large cell, nonkeratinizing, NOS",
-          "Squamous cell carcinoma, metastatic, NOS",
-          "Squamous cell carcinoma, microinvasive",
-          "Squamous cell carcinoma, nonkeratinizing, NOS",
-          "Squamous cell carcinoma, NOS",
-          "Squamous cell carcinoma, pseudoglandular",
-          "Squamous cell carcinoma, sarcomatoid",
-          "Squamous cell carcinoma, small cell, nonkeratinizing",
-          "Squamous cell carcinoma, spindle cell",
-          "Squamous cell epithelioma",
-          "Squamous cell papilloma, inverted",
-          "Squamous cell papilloma, NOS",
-          "Squamous intraepithelial neoplasia, grade I",
-          "Squamous intraepithelial neoplasia, grade II",
-          "Squamous intraepithelial neoplasia, grade III",
-          "Squamous intraepithelial neoplasia, high grade",
-          "Squamous intraepithelial neoplasia, low grade",
-          "Squamous odontogenic tumor",
-          "Squamous papilloma",
-          "Squamous papillomatosis",
-          "Stem cell leukemia",
-          "Steroid cell tumor, malignant",
-          "Steroid cell tumor, NOS",
-          "Stromal endometriosis",
-          "Stromal myosis, NOS",
-          "Stromal sarcoma, NOS",
-          "Stromal tumor with minor sex cord elements",
-          "Stromal tumor, benign",
-          "Stromal tumor, NOS",
-          "Struma ovarii and carcinoid",
-          "Struma ovarii, malignant",
-          "Struma ovarii, NOS",
-          "Strumal carcinoid",
-          "Subacute granulocytic leukemia [obs]",
-          "Subacute leukemia, NOS [obs]",
-          "Subacute lymphatic leukemia [obs]",
-          "Subacute lymphocytic leukemia [obs]",
-          "Subacute lymphoid leukemia [obs]",
-          "Subacute monocytic leukemia [obs]",
-          "Subacute myelogenous leukemia [obs]",
-          "Subacute myeloid leukemia [obs]",
-          "Subareolar duct papillomatosis",
-          "Subcutaneous panniculitis-like T-cell lymphoma",
-          "Subependymal astrocytoma, NOS",
-          "Subependymal giant cell astrocytoma",
-          "Subependymal glioma",
-          "Subependymoma",
-          "Subepidermal nodular fibrosis",
-          "Superficial spreading adenocarcinoma",
-          "Superficial spreading melanoma",
-          "Superficial well differentated liposarcoma",
-          "Supratentorial PNET",
-          "Sweat gland adenocarcinoma",
-          "Sweat gland adenoma",
-          "Sweat gland carcinoma",
-          "Sweat gland tumor, benign",
-          "Sweat gland tumor, malignant",
-          "Sweat gland tumor, NOS",
-          "Sympathetic paraganglioma",
-          "Sympathicoblastoma",
-          "Symplastic leiomyoma",
-          "Syncytial meningioma",
-          "Synovial sarcoma, biphasic",
-          "Synovial sarcoma, epithelioid cell",
-          "Synovial sarcoma, monophasic fibrous",
-          "Synovial sarcoma, NOS",
-          "Synovial sarcoma, spindle cell",
-          "Synovioma, benign",
-          "Synovioma, malignant",
-          "Synovioma, NOS",
-          "Syringadenoma, NOS",
-          "Syringocystadenoma papilliferum",
-          "Syringofibroadenoma",
-          "Syringoma, NOS",
-          "Syringomatous carcinoma",
-          "Systemic EBV positive T-cell lymphoproliferative disease of childhood",
-          "Systemic light chain disease",
-          "Systemic mastocytosis with AHNMD",
-          "Systemic mastocytosis with associated hematological clonal non-mast cell disorder",
-          "Systemic tissue mast cell disease",
-          "T lymphoblastic leukemia/lymphoma",
-          "T-cell large granular lymphocytic leukemia",
-          "T-cell large granular lymphocytosis",
-          "T-cell lymphoma, NOS",
-          "T-cell rich large B-cell lymphoma",
-          "T-cell rich/histiocyte-rich large B-cell lymphoma",
-          "T-gamma lymphoproliferative disease",
-          "T-zone lymphoma",
-          "T/NK-cell lymphoma",
-          "Tanycytic ependymoma",
-          "Telangiectatic osteosarcoma",
-          "Tenosynovial giant cell tumor",
-          "Teratoblastoma, malignant",
-          "Teratocarcinoma",
-          "Teratoid medulloepithelioma",
-          "Teratoid medulloepithelioma, benign",
-          "Teratoma with malignant transformation",
-          "Teratoma, benign",
-          "Teratoma, differentiated",
-          "Teratoma, malignant, NOS",
-          "Teratoma, NOS",
-          "Terminal duct adenocarcinoma",
-          "Testicular adenoma",
-          "Testicular stromal tumor",
-          "Theca cell tumor",
-          "Theca cell-granulosa cell tumor",
-          "Thecoma, luteinized",
-          "Thecoma, malignant",
-          "Thecoma, NOS",
-          "Therapy related myeloid neoplasm",
-          "Therapy-related acute myeloid leukemia, alkylating agent related",
-          "Therapy-related acute myeloid leukemia, epipodophyllotoxin-related",
-          "Therapy-related acute myeloid leukemia, NOS",
-          "Therapy-related myelodysplastic syndrome, alkylating agent related",
-          "Therapy-related myelodysplastic syndrome, epipodophyllotoxin-related",
-          "Therapy-related myelodysplastic syndrome, NOS",
-          "Thymic carcinoma, NOS",
-          "Thymic large B-cell lymphoma",
-          "Thymoma, atypical, malignant",
-          "Thymoma, atypical, NOS",
-          "Thymoma, benign",
-          "Thymoma, cortical, malignant",
-          "Thymoma, cortical, NOS",
-          "Thymoma, epithelial, malignant",
-          "Thymoma, epithelial, NOS",
-          "Thymoma, lymphocyte-rich, malignant",
-          "Thymoma, lymphocyte-rich, NOS",
-          "Thymoma, lymphocytic, malignant",
-          "Thymoma, lymphocytic, NOS",
-          "Thymoma, malignant, NOS",
-          "Thymoma, medullary, malignant",
-          "Thymoma, medullary, NOS",
-          "Thymoma, mixed type, malignant",
-          "Thymoma, mixed type, NOS",
-          "Thymoma, NOS",
-          "Thymoma, organoid, malignant",
-          "Thymoma, organoid, NOS",
-          "Thymoma, predominantly cortical, malignant",
-          "Thymoma, predominantly cortical, NOS",
-          "Thymoma, spindle cell, malignant",
-          "Thymoma, spindle cell, NOS",
-          "Thymoma, type A, malignant",
-          "Thymoma, type A, NOS",
-          "Thymoma, type AB, malignant",
-          "Thymoma, type AB, NOS",
-          "Thymoma, type B1, malignant",
-          "Thymoma, type B1, NOS",
-          "Thymoma, type B2, malignant",
-          "Thymoma, type B2, NOS",
-          "Thymoma, type B3, malignant",
-          "Thymoma, type B3, NOS",
-          "Thymoma, type C",
-          "Tibial adamantinoma",
-          "Trabecular adenocarcinoma",
-          "Trabecular adenoma",
-          "Trabecular carcinoma",
-          "Traditional serrated adenoma",
-          "Traditional sessile serrated adenoma",
-          "Transient abnormal myelopoiesis",
-          "Transitional carcinoma",
-          "Transitional cell carcinoma",
-          "Transitional cell carcinoma in situ",
-          "Transitional cell carcinoma, micropapillary",
-          "Transitional cell carcinoma, sarcomatoid",
-          "Transitional cell carcinoma, spindle cell",
-          "Transitional cell papilloma, benign",
-          "Transitional cell papilloma, inverted, benign",
-          "Transitional cell papilloma, inverted, NOS",
-          "Transitional cell papilloma, NOS",
-          "Transitional meningioma",
-          "Transitional papilloma",
-          "Transitional papilloma, inverted, benign",
-          "Transitional papilloma, inverted, NOS",
-          "Transitional pineal tumor",
-          "Trichilemmal carcinoma",
-          "Trichilemmocarcinoma",
-          "Trichilemmoma",
-          "Trichodiscoma",
-          "Trichoepithelioma",
-          "Trichofolliculoma",
-          "Triton tumor, malignant",
-          "Trophoblastic tumor, epithelioid",
-          "True histiocytic lymphoma",
-          "Tubular adenocarcinoma",
-          "Tubular adenoma, NOS",
-          "Tubular androblastoma with lipid storage",
-          "Tubular androblastoma, NOS",
-          "Tubular carcinoid",
-          "Tubular carcinoma",
-          "Tubulo-papillary adenoma",
-          "Tubulopapillary adenocarcinoma",
-          "Tubulovillous adenoma, NOS",
-          "Tumor cells, benign",
-          "Tumor cells, malignant",
-          "Tumor cells, NOS",
-          "Tumor cells, uncertain whether benign or malignant",
-          "Tumor embolus",
-          "Tumor, benign",
-          "Tumor, malignant, NOS",
-          "Tumor, metastatic",
-          "Tumor, NOS",
-          "Tumor, secondary",
-          "Tumorlet, benign",
-          "Tumorlet, NOS",
-          "Turban tumor",
-          "Typical carcinoid",
-          "Unclassified tumor, benign",
-          "Unclassified tumor, borderline malignancy",
-          "Unclassified tumor, malignant",
-          "Unclassified tumor, malignant, uncertain whether primary or metastatic",
-          "Unclassified tumor, uncertain whether benign or malignant",
-          "Undifferentiated leukaemia",
-          "Undifferentiated sarcoma",
-          "Urothelial carcinoma in situ",
-          "Urothelial carcinoma, NOS",
-          "Urothelial papilloma, NOS",
-          "Urticaria pigmentosa",
-          "Vaginal intraepithelial neoplasia, grade III",
-          "VAIN III",
-          "Vascular leiomyoma",
-          "Venous hemangioma",
-          "Verrucous carcinoma, NOS",
-          "Verrucous epidermoid carcinoma",
-          "Verrucous keratotic hemangioma",
-          "Verrucous papilloma",
-          "Verrucous squamous cell carcinoma",
-          "Villoglandular adenoma",
-          "Villous adenocarcinoma",
-          "Villous adenoma, NOS",
-          "Villous papilloma",
-          "VIN III",
-          "Vipoma, malignant",
-          "Vipoma, NOS",
-          "Von Recklinghausen disease (except of bone)",
-          "Vulvar intraepithelial neoplasia, grade III",
-          "Waldenstrom macroglobulinemia",
-          "Warthin tumor",
-          "Warty carcinoma",
-          "Water-clear cell adenocarcinoma",
-          "Water-clear cell adenoma",
-          "Water-clear cell carcinoma",
-          "Well differentiated liposarcoma of superficial soft tissue",
-          "Well differentiated papillary mesothelioma, benign",
-          "Well differentiated thymic carcinoma",
-          "Wilms tumor",
-          "Wolffian duct adenoma",
-          "Wolffian duct carcinoma",
-          "Wolffian duct tumor",
-          "Xanthofibroma",
-          "Yolk sac tumor"
-        ],
         "term": {
           "description": "Text term for the structural pattern of cancer cells used to define a microscopic diagnosis.\n",
           "termDef": {
@@ -10967,14 +5900,16 @@
             "term": "Neoplasm Histologic Type Name",
             "term_url": "https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=3081934&version=3.0"
           }
-        }
+        },
+        "type": "string"
       },
       "prior_malignancy": {
         "enum": [
-          "Yes",
-          "No",
-          "Unknown",
-          "Not Reported"
+          "yes",
+          "no",
+          "unknown",
+          "not reported",
+          "Not Allowed To Collect"
         ],
         "term": {
           "description": "Text term to describe the patient's history of prior cancer diagnosis and the spatial location of any previous cancer occurrence.\n",
@@ -10992,7 +5927,8 @@
           "Yes",
           "No",
           "Unknown",
-          "Not Reported"
+          "Not Reported",
+          "Not Allowed To Collect"
         ],
         "term": {
           "description": "A yes/no/unknown/not applicable indicator related to the administration of therapeutic agents received before the body specimen was collected.\n",
@@ -11005,18 +5941,24 @@
           }
         }
       },
-      "progression_free_survival": {
-        "description": "Number of days between the date used for index and the first date the patient is known to be free of disease progression.",
-        "type": "integer"
-      },
-      "progression_free_survival_event": {
-        "description": "The event used to define the patient's disease progression.",
+      "progression_or_recurrence": {
         "enum": [
-          "Death",
-          "Disease Progression",
-          "No Event",
-          "Unknown"
-        ]
+          "yes",
+          "no",
+          "unknown",
+          "not reported",
+          "Not Allowed To Collect"
+        ],
+        "term": {
+          "description": "Yes/No/Unknown indicator to identify whether a patient has had a new tumor event after initial treatment.\n",
+          "termDef": {
+            "cde_id": 3121376,
+            "cde_version": 1,
+            "source": "caDSR",
+            "term": "New Neoplasm Event Post Initial Therapy Indicator",
+            "term_url": "https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=3121376&version=1.0"
+          }
+        }
       },
       "project_id": {
         "term": {
@@ -11042,6 +5984,19 @@
           }
         }
       },
+      "site_of_resection_or_biopsy": {
+        "term": {
+          "description": "The third edition of the International Classification of Diseases for Oncology, published in 2000, used principally in tumor and cancer registries for coding the site (topography) and the histology (morphology) of neoplasms. The description of an anatomical region or of a body part. Named locations of, or within, the body. A system of numbered categories for representation of data.\n",
+          "termDef": {
+            "cde_id": 3226281,
+            "cde_version": 1,
+            "source": "caDSR",
+            "term": "International Classification of Diseases for Oncology, Third Edition ICD-O-3 Site Code",
+            "term_url": "https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=3226281&version=1.0"
+          }
+        },
+        "type": "string"
+      },
       "state": {
         "default": "validated",
         "downloadable": [
@@ -11084,9 +6039,9 @@
         }
       },
       "submitter_id": {
-        "description": "A project-specific identifier for a node. This property is the calling card/nickname/alias for a unit of submission. It can be used in place of the UUID for identifying or recalling a node.\n",
         "type": [
-          "string"
+          "string",
+          "null"
         ]
       },
       "tissue_or_organ_of_origin": {
@@ -11103,13 +6058,6 @@
         "type": "string"
       },
       "tumor_grade": {
-        "enum": [
-          "GX Grade cannot be assessed (undetermined grade)",
-          "G1 Well differentiated (low grade)",
-          "G2 Moderately differentiated (intermediate grade)",
-          "G3 Poorly differentiated (high grade)",
-          "G4 Undifferentiated (high grade)"
-        ],
         "term": {
           "description": "Numeric value to express the degree of abnormality of cancer cells, a measure of differentiation and aggressiveness.\n",
           "termDef": {
@@ -11119,7 +6067,21 @@
             "term": "Neoplasm Histologic Grade",
             "term_url": "https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=2785839&version=2.0"
           }
-        }
+        },
+        "type": "string"
+      },
+      "tumor_stage": {
+        "term": {
+          "description": "The extent of a cancer in the body. Staging is usually based on the size of the tumor, whether lymph nodes contain cancer, and whether the cancer has spread from the original site to other parts of the body. The accepted values for tumor_stage depend on the tumor site, type, and accepted staging system. These items should accompany the tumor_stage value as associated metadata.\n",
+          "termDef": {
+            "cde_id": "C16899",
+            "cde_version": null,
+            "source": "NCIt",
+            "term": "Tumor Stage",
+            "term_url": "https://ncit.nci.nih.gov/ncitbrowser/pages/concept_details.jsf?dictionary=NCI%20Thesaurus&code=C16899"
+          }
+        },
+        "type": "string"
       },
       "type": {
         "type": "string"
@@ -11137,17 +6099,79 @@
         "term": {
           "description": "A combination of date and time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]\n"
         }
+      },
+      "vascular_invasion_present": {
+        "enum": [
+          "Yes",
+          "No",
+          "Unknown",
+          "Not Reported",
+          "Not Allowed To Collect"
+        ],
+        "term": {
+          "description": "The yes/no indicator to ask if large vessel or venous invasion was detected by surgery or presence in a tumor specimen.\n",
+          "termDef": {
+            "cde_id": 64358,
+            "cde_version": 3,
+            "source": "caDSR",
+            "term": "Tumor Vascular Invasion Ind-3",
+            "term_url": "https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=64358&version=3.0"
+          }
+        }
+      },
+      "vital_status": {
+        "enum": [
+          "alive",
+          "dead",
+          "lost to follow-up",
+          "unknown",
+          "not reported",
+          "Not Allowed To Collect",
+          "pending"
+        ],
+        "term": {
+          "description": "The survival state of the person registered on the protocol.\n",
+          "termDef": {
+            "cde_id": 5,
+            "cde_version": 5,
+            "source": "caDSR",
+            "term": "Patient Vital Status",
+            "term_url": "https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=5&version=5.0"
+          }
+        }
+      },
+      "year_of_diagnosis": {
+        "term": {
+          "description": "Numeric value to represent the year of an individual's initial pathologic diagnosis of cancer.\n",
+          "termDef": {
+            "cde_id": 2896960,
+            "cde_version": 1,
+            "source": "caDSR",
+            "term": "Year of initial pathologic diagnosis",
+            "term_url": "https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=2896960&version=1.0"
+          }
+        },
+        "type": [
+          "number",
+          "null"
+        ]
       }
     },
     "required": [
-      "submitter_id",
-      "type",
-      "classification_of_tumor",
-      "days_to_diagnosis",
-      "morphology",
+      "age_at_diagnosis",
+      "days_to_last_follow_up",
+      "vital_status",
       "primary_diagnosis",
+      "morphology",
       "tissue_or_organ_of_origin",
-      "tumor_grade"
+      "site_of_resection_or_biopsy",
+      "classification_of_tumor",
+      "tumor_stage",
+      "tumor_grade",
+      "progression_or_recurrence",
+      "days_to_recurrence",
+      "days_to_last_known_disease_status",
+      "last_known_disease_status"
     ],
     "submittable": true,
     "systemProperties": [
@@ -11170,111 +6194,35 @@
     ],
     "validators": null
   },
-  "diagnostic_test": {
+  "experiment": {
+    "$schema": "http://json-schema.org/draft-04/schema#",
     "additionalProperties": false,
-    "category": "clinical",
-    "description": "The result of a standard clinical test that is performed for diagnostic or health monitoring purposes, including biopsies and other small surgical procedures, biomarker assays, and imaging tests.\n",
-    "id": "diagnostic_test",
+    "category": "administrative",
+    "description": "A coordinated set of actions and observations designed to generate data, with the ultimate goal of discovery or hypothesis testing.\n",
+    "id": "experiment",
     "links": [
       {
-        "backref": "diagnostic_tests",
-        "label": "describes",
+        "backref": "experiments",
+        "label": "performed_for",
         "multiplicity": "many_to_one",
-        "name": "cases",
+        "name": "projects",
         "required": true,
-        "target_type": "case"
-      },
-      {
-        "backref": "diagnostic_tests",
-        "label": "describes",
-        "multiplicity": "many_to_one",
-        "name": "followups",
-        "required": false,
-        "target_type": "followup"
-      },
-      {
-        "backref": "diagnostic_tests",
-        "label": "describes",
-        "multiplicity": "many_to_one",
-        "name": "diagnoses",
-        "required": false,
-        "target_type": "diagnosis"
+        "target_type": "project"
       }
     ],
-    "namespace": "https://www.bloodpac.org",
+    "namespace": "http://bloodprofilingatlas.org/bpa/",
     "program": "*",
     "project": "*",
     "properties": {
-      "analyte_name": {
-        "description": "The name of analyte or biomarker tested in the case that the test is a quantitative assay.\n",
-        "type": "string"
-      },
-      "assay_kit_name": {
-        "description": "The name of the kit used for the test or assay; please also indicate the kit vendor and version in 'assay_kit_vendor' and 'assay_kit_version'.\n",
-        "type": "string"
-      },
-      "assay_kit_vendor": {
-        "description": "The name of the vendor or manufacturer of the kit used for the test; please also indicate the kit name and version in 'assay_kit_name' and 'assay_kit_version'.\n",
-        "type": "string"
-      },
-      "assay_kit_version": {
-        "description": "The version of the kit used for the test; please also indicate the kit name and vendor in 'assay_kit_name' and 'assay_kit_vendor'.\n",
-        "type": "string"
-      },
-      "cases": {
-        "anyOf": [
-          {
-            "items": {
-              "additionalProperties": true,
-              "maxItems": 1,
-              "minItems": 1,
-              "properties": {
-                "id": {
-                  "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
-                  "term": {
-                    "description": "A 128-bit identifier. Depending on the mechanism used to generate it, it is either guaranteed to be different from all other UUIDs/GUIDs generated until 3400 AD or extremely likely to be different. Its relatively small size lends itself well to sorting, ordering, and hashing of all sorts, storing in databases, simple allocation, and ease of programming in general.\n",
-                    "termDef": {
-                      "cde_id": "C54100",
-                      "cde_version": null,
-                      "source": "NCIt",
-                      "term": "Universally Unique Identifier",
-                      "term_url": "https://ncit.nci.nih.gov/ncitbrowser/ConceptReport.jsp?dictionary=NCI_Thesaurus&version=16.02d&ns=NCI_Thesaurus&code=C54100"
-                    }
-                  },
-                  "type": "string"
-                },
-                "submitter_id": {
-                  "type": "string"
-                }
-              },
-              "type": "object"
-            },
-            "type": "array"
-          },
-          {
-            "additionalProperties": true,
-            "properties": {
-              "id": {
-                "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
-                "term": {
-                  "description": "A 128-bit identifier. Depending on the mechanism used to generate it, it is either guaranteed to be different from all other UUIDs/GUIDs generated until 3400 AD or extremely likely to be different. Its relatively small size lends itself well to sorting, ordering, and hashing of all sorts, storing in databases, simple allocation, and ease of programming in general.\n",
-                  "termDef": {
-                    "cde_id": "C54100",
-                    "cde_version": null,
-                    "source": "NCIt",
-                    "term": "Universally Unique Identifier",
-                    "term_url": "https://ncit.nci.nih.gov/ncitbrowser/ConceptReport.jsp?dictionary=NCI_Thesaurus&version=16.02d&ns=NCI_Thesaurus&code=C54100"
-                  }
-                },
-                "type": "string"
-              },
-              "submitter_id": {
-                "type": "string"
-              }
-            },
-            "type": "object"
-          }
+      "associated_experiment": {
+        "description": "The submitter_id for any experiment with which this experiment is associated, paired, or matched.",
+        "type": [
+          "string"
         ]
+      },
+      "copy_numbers_identified": {
+        "description": "Are copy number variations identified in this experiment?",
+        "type": "boolean"
       },
       "created_datetime": {
         "oneOf": [
@@ -11290,126 +6238,20 @@
           "description": "A combination of date and time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]\n"
         }
       },
-      "days_to_test": {
-        "description": "Number of days between the date used for index and the date the patient was diagnosed with a comorbidity.\n",
-        "type": "integer"
+      "data_description": {
+        "description": "Brief description of the data being provided for this experiment.",
+        "type": "string"
       },
-      "diagnoses": {
-        "anyOf": [
-          {
-            "items": {
-              "additionalProperties": true,
-              "maxItems": 1,
-              "minItems": 1,
-              "properties": {
-                "id": {
-                  "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
-                  "term": {
-                    "description": "A 128-bit identifier. Depending on the mechanism used to generate it, it is either guaranteed to be different from all other UUIDs/GUIDs generated until 3400 AD or extremely likely to be different. Its relatively small size lends itself well to sorting, ordering, and hashing of all sorts, storing in databases, simple allocation, and ease of programming in general.\n",
-                    "termDef": {
-                      "cde_id": "C54100",
-                      "cde_version": null,
-                      "source": "NCIt",
-                      "term": "Universally Unique Identifier",
-                      "term_url": "https://ncit.nci.nih.gov/ncitbrowser/ConceptReport.jsp?dictionary=NCI_Thesaurus&version=16.02d&ns=NCI_Thesaurus&code=C54100"
-                    }
-                  },
-                  "type": "string"
-                },
-                "submitter_id": {
-                  "type": "string"
-                }
-              },
-              "type": "object"
-            },
-            "type": "array"
-          },
-          {
-            "additionalProperties": true,
-            "properties": {
-              "id": {
-                "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
-                "term": {
-                  "description": "A 128-bit identifier. Depending on the mechanism used to generate it, it is either guaranteed to be different from all other UUIDs/GUIDs generated until 3400 AD or extremely likely to be different. Its relatively small size lends itself well to sorting, ordering, and hashing of all sorts, storing in databases, simple allocation, and ease of programming in general.\n",
-                  "termDef": {
-                    "cde_id": "C54100",
-                    "cde_version": null,
-                    "source": "NCIt",
-                    "term": "Universally Unique Identifier",
-                    "term_url": "https://ncit.nci.nih.gov/ncitbrowser/ConceptReport.jsp?dictionary=NCI_Thesaurus&version=16.02d&ns=NCI_Thesaurus&code=C54100"
-                  }
-                },
-                "type": "string"
-              },
-              "submitter_id": {
-                "type": "string"
-              }
-            },
-            "type": "object"
-          }
+      "experimental_description": {
+        "description": "A brief description of the experiment being performed.",
+        "type": [
+          "string"
         ]
       },
-      "equipment_manufacturer": {
-        "description": "The name of the manufacturer of the equipment used for the test; please also indicate the model number in 'equipment_model'.\n",
-        "type": "string"
-      },
-      "equipment_model": {
-        "description": "The equipment name and model number used for the test; please also indicate the manufacturer name in 'equipment_manufacturer'.\n",
-        "type": "string"
-      },
-      "followups": {
-        "anyOf": [
-          {
-            "items": {
-              "additionalProperties": true,
-              "maxItems": 1,
-              "minItems": 1,
-              "properties": {
-                "id": {
-                  "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
-                  "term": {
-                    "description": "A 128-bit identifier. Depending on the mechanism used to generate it, it is either guaranteed to be different from all other UUIDs/GUIDs generated until 3400 AD or extremely likely to be different. Its relatively small size lends itself well to sorting, ordering, and hashing of all sorts, storing in databases, simple allocation, and ease of programming in general.\n",
-                    "termDef": {
-                      "cde_id": "C54100",
-                      "cde_version": null,
-                      "source": "NCIt",
-                      "term": "Universally Unique Identifier",
-                      "term_url": "https://ncit.nci.nih.gov/ncitbrowser/ConceptReport.jsp?dictionary=NCI_Thesaurus&version=16.02d&ns=NCI_Thesaurus&code=C54100"
-                    }
-                  },
-                  "type": "string"
-                },
-                "submitter_id": {
-                  "type": "string"
-                }
-              },
-              "type": "object"
-            },
-            "type": "array"
-          },
-          {
-            "additionalProperties": true,
-            "properties": {
-              "id": {
-                "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
-                "term": {
-                  "description": "A 128-bit identifier. Depending on the mechanism used to generate it, it is either guaranteed to be different from all other UUIDs/GUIDs generated until 3400 AD or extremely likely to be different. Its relatively small size lends itself well to sorting, ordering, and hashing of all sorts, storing in databases, simple allocation, and ease of programming in general.\n",
-                  "termDef": {
-                    "cde_id": "C54100",
-                    "cde_version": null,
-                    "source": "NCIt",
-                    "term": "Universally Unique Identifier",
-                    "term_url": "https://ncit.nci.nih.gov/ncitbrowser/ConceptReport.jsp?dictionary=NCI_Thesaurus&version=16.02d&ns=NCI_Thesaurus&code=C54100"
-                  }
-                },
-                "type": "string"
-              },
-              "submitter_id": {
-                "type": "string"
-              }
-            },
-            "type": "object"
-          }
+      "experimental_intent": {
+        "description": "Summary of the goals the experiment is designed to discover.",
+        "type": [
+          "string"
         ]
       },
       "id": {
@@ -11425,6 +6267,381 @@
             "term_url": "https://ncit.nci.nih.gov/ncitbrowser/ConceptReport.jsp?dictionary=NCI_Thesaurus&version=16.02d&ns=NCI_Thesaurus&code=C54100"
           }
         },
+        "type": "string"
+      },
+      "indels_identified": {
+        "description": "Are indels identified in this experiment?",
+        "type": "boolean"
+      },
+      "marker_panel_description": {
+        "description": "Brief description of the marker panel used in this experiment.",
+        "type": "string"
+      },
+      "number_experimental_group": {
+        "description": "The number denoting this experiment's place within the group within the whole.",
+        "type": [
+          "integer"
+        ]
+      },
+      "number_samples_per_experimental_group": {
+        "description": "The number of samples contained within this experimental group.",
+        "type": [
+          "integer"
+        ]
+      },
+      "project_id": {
+        "term": {
+          "description": "Unique ID for any specific defined piece of work that is undertaken or attempted to meet a single requirement.\n"
+        },
+        "type": "string"
+      },
+      "projects": {
+        "anyOf": [
+          {
+            "items": {
+              "additionalProperties": true,
+              "maxItems": 1,
+              "minItems": 1,
+              "properties": {
+                "id": {
+                  "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
+                  "term": {
+                    "description": "A 128-bit identifier. Depending on the mechanism used to generate it, it is either guaranteed to be different from all other UUIDs/GUIDs generated until 3400 AD or extremely likely to be different. Its relatively small size lends itself well to sorting, ordering, and hashing of all sorts, storing in databases, simple allocation, and ease of programming in general.\n",
+                    "termDef": {
+                      "cde_id": "C54100",
+                      "cde_version": null,
+                      "source": "NCIt",
+                      "term": "Universally Unique Identifier",
+                      "term_url": "https://ncit.nci.nih.gov/ncitbrowser/ConceptReport.jsp?dictionary=NCI_Thesaurus&version=16.02d&ns=NCI_Thesaurus&code=C54100"
+                    }
+                  },
+                  "type": "string"
+                },
+                "submitter_id": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "type": "array"
+          },
+          {
+            "additionalProperties": true,
+            "properties": {
+              "id": {
+                "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
+                "term": {
+                  "description": "A 128-bit identifier. Depending on the mechanism used to generate it, it is either guaranteed to be different from all other UUIDs/GUIDs generated until 3400 AD or extremely likely to be different. Its relatively small size lends itself well to sorting, ordering, and hashing of all sorts, storing in databases, simple allocation, and ease of programming in general.\n",
+                  "termDef": {
+                    "cde_id": "C54100",
+                    "cde_version": null,
+                    "source": "NCIt",
+                    "term": "Universally Unique Identifier",
+                    "term_url": "https://ncit.nci.nih.gov/ncitbrowser/ConceptReport.jsp?dictionary=NCI_Thesaurus&version=16.02d&ns=NCI_Thesaurus&code=C54100"
+                  }
+                },
+                "type": "string"
+              },
+              "submitter_id": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          }
+        ]
+      },
+      "somatic_mutations_identified": {
+        "description": "Are somatic mutations identified for this experiment?",
+        "type": "boolean"
+      },
+      "state": {
+        "default": "validated",
+        "downloadable": [
+          "uploaded",
+          "md5summed",
+          "validating",
+          "validated",
+          "error",
+          "invalid",
+          "released"
+        ],
+        "oneOf": [
+          {
+            "enum": [
+              "uploading",
+              "uploaded",
+              "md5summing",
+              "md5summed",
+              "validating",
+              "error",
+              "invalid",
+              "suppressed",
+              "redacted",
+              "live"
+            ]
+          },
+          {
+            "enum": [
+              "validated",
+              "submitted",
+              "released"
+            ]
+          }
+        ],
+        "public": [
+          "live"
+        ],
+        "term": {
+          "description": "The current state of the object.\n"
+        }
+      },
+      "submitter_id": {
+        "type": [
+          "string",
+          "null"
+        ]
+      },
+      "type": {
+        "enum": [
+          "experiment"
+        ]
+      },
+      "type_of_data": {
+        "description": "Is the data raw or processed?",
+        "enum": [
+          "Raw",
+          "Processed"
+        ]
+      },
+      "type_of_sample": {
+        "description": "String indicator identifying the types of samples as contrived or clinical.",
+        "type": [
+          "string"
+        ]
+      },
+      "type_of_specimen": {
+        "description": "Broad description of the specimens used in the experiment.",
+        "type": [
+          "string"
+        ]
+      },
+      "updated_datetime": {
+        "oneOf": [
+          {
+            "format": "date-time",
+            "type": "string"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "term": {
+          "description": "A combination of date and time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]\n"
+        }
+      }
+    },
+    "required": [
+      "submitter_id",
+      "projects"
+    ],
+    "submittable": true,
+    "systemProperties": [
+      "id",
+      "project_id",
+      "created_datetime",
+      "updated_datetime",
+      "state"
+    ],
+    "title": "Experiment",
+    "type": "object",
+    "uniqueKeys": [
+      [
+        "id"
+      ],
+      [
+        "project_id",
+        "submitter_id"
+      ]
+    ],
+    "validators": null
+  },
+  "experimental_metadata": {
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "additionalProperties": false,
+    "category": "metadata_file",
+    "description": "Data file containing the metadata for the experiment performed.\n",
+    "id": "experimental_metadata",
+    "links": [
+      {
+        "backref": "experiment_metadata_files",
+        "label": "derived_from",
+        "multiplicity": "many_to_many",
+        "name": "experiments",
+        "required": false,
+        "target_type": "experiment"
+      }
+    ],
+    "namespace": "http://gdc.nci.nih.gov",
+    "program": "*",
+    "project": "*",
+    "properties": {
+      "created_datetime": {
+        "oneOf": [
+          {
+            "format": "date-time",
+            "type": "string"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "term": {
+          "description": "A combination of date and time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]\n"
+        }
+      },
+      "data_category": {
+        "term": {
+          "description": "Broad categorization of the contents of the data file.\n"
+        },
+        "type": [
+          "string"
+        ]
+      },
+      "data_format": {
+        "term": {
+          "description": "Format of the data files.\n"
+        },
+        "type": [
+          "string"
+        ]
+      },
+      "data_type": {
+        "enum": [
+          "Experimental Metadata"
+        ],
+        "term": {
+          "description": "Specific content type of the data file.\n"
+        }
+      },
+      "error_type": {
+        "enum": [
+          "file_size",
+          "file_format",
+          "md5sum"
+        ],
+        "term": {
+          "description": "Type of error for the data file object.\n"
+        }
+      },
+      "experiments": {
+        "anyOf": [
+          {
+            "items": {
+              "additionalProperties": true,
+              "maxItems": 1,
+              "minItems": 1,
+              "properties": {
+                "id": {
+                  "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
+                  "term": {
+                    "description": "A 128-bit identifier. Depending on the mechanism used to generate it, it is either guaranteed to be different from all other UUIDs/GUIDs generated until 3400 AD or extremely likely to be different. Its relatively small size lends itself well to sorting, ordering, and hashing of all sorts, storing in databases, simple allocation, and ease of programming in general.\n",
+                    "termDef": {
+                      "cde_id": "C54100",
+                      "cde_version": null,
+                      "source": "NCIt",
+                      "term": "Universally Unique Identifier",
+                      "term_url": "https://ncit.nci.nih.gov/ncitbrowser/ConceptReport.jsp?dictionary=NCI_Thesaurus&version=16.02d&ns=NCI_Thesaurus&code=C54100"
+                    }
+                  },
+                  "type": "string"
+                },
+                "submitter_id": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "type": "array"
+          },
+          {
+            "additionalProperties": true,
+            "properties": {
+              "id": {
+                "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
+                "term": {
+                  "description": "A 128-bit identifier. Depending on the mechanism used to generate it, it is either guaranteed to be different from all other UUIDs/GUIDs generated until 3400 AD or extremely likely to be different. Its relatively small size lends itself well to sorting, ordering, and hashing of all sorts, storing in databases, simple allocation, and ease of programming in general.\n",
+                  "termDef": {
+                    "cde_id": "C54100",
+                    "cde_version": null,
+                    "source": "NCIt",
+                    "term": "Universally Unique Identifier",
+                    "term_url": "https://ncit.nci.nih.gov/ncitbrowser/ConceptReport.jsp?dictionary=NCI_Thesaurus&version=16.02d&ns=NCI_Thesaurus&code=C54100"
+                  }
+                },
+                "type": "string"
+              },
+              "submitter_id": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          }
+        ]
+      },
+      "file_name": {
+        "term": {
+          "description": "The name (or part of a name) of a file (of any type).\n"
+        },
+        "type": "string"
+      },
+      "file_size": {
+        "term": {
+          "description": "The size of the data file (object) in bytes.\n"
+        },
+        "type": "integer"
+      },
+      "file_state": {
+        "default": "registered",
+        "enum": [
+          "registered",
+          "uploading",
+          "uploaded",
+          "validating",
+          "validated",
+          "submitted",
+          "processing",
+          "processed",
+          "released",
+          "error"
+        ],
+        "term": {
+          "description": "The current state of the data file object.\n"
+        }
+      },
+      "id": {
+        "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
+        "systemAlias": "node_id",
+        "term": {
+          "description": "A 128-bit identifier. Depending on the mechanism used to generate it, it is either guaranteed to be different from all other UUIDs/GUIDs generated until 3400 AD or extremely likely to be different. Its relatively small size lends itself well to sorting, ordering, and hashing of all sorts, storing in databases, simple allocation, and ease of programming in general.\n",
+          "termDef": {
+            "cde_id": "C54100",
+            "cde_version": null,
+            "source": "NCIt",
+            "term": "Universally Unique Identifier",
+            "term_url": "https://ncit.nci.nih.gov/ncitbrowser/ConceptReport.jsp?dictionary=NCI_Thesaurus&version=16.02d&ns=NCI_Thesaurus&code=C54100"
+          }
+        },
+        "type": "string"
+      },
+      "md5sum": {
+        "pattern": "^[a-f0-9]{32}$",
+        "term": {
+          "description": "The 128-bit hash value expressed as a 32 digit hexadecimal number used as a file's digital fingerprint.\n"
+        },
+        "type": "string"
+      },
+      "object_id": {
+        "description": "The GUID of the object in the index service.",
         "type": "string"
       },
       "project_id": {
@@ -11474,426 +6691,21 @@
           "description": "The current state of the object.\n"
         }
       },
+      "state_comment": {
+        "description": "Optional comment about why the file is in the current state, mainly for invalid state.\n",
+        "type": "string"
+      },
       "submitter_id": {
-        "description": "A project-specific identifier for a node. This property is the calling card/nickname/alias for a unit of submission. It can be used in place of the UUID for identifying or recalling a node.\n",
+        "description": "The file ID assigned by the submitter.",
         "type": [
-          "string"
+          "string",
+          "null"
         ]
-      },
-      "test_anatomic_site": {
-        "description": "Indicate the anatomic site of the biopsy, image or other diagnostic test\n",
-        "enum": [
-          "Abdomen",
-          "Abdominal Wall",
-          "Acetabulum",
-          "Adenoid",
-          "Adipose",
-          "Adrenal",
-          "Alveolar Ridge",
-          "Amniotic Fluid",
-          "Ampulla of Vater",
-          "Anal Sphincter",
-          "Ankle",
-          "Anorectum",
-          "Antecubital Fossa",
-          "Antrum",
-          "Anus",
-          "Aorta",
-          "Aortic Body",
-          "Appendix",
-          "Aqueous Fluid",
-          "Arm",
-          "Artery",
-          "Ascending Colon",
-          "Ascending Colon Hepatic Flexure",
-          "Auditory Canal",
-          "Autonomic Nervous System",
-          "Axilla",
-          "Back",
-          "Bile Duct",
-          "Bladder",
-          "Blood",
-          "Blood Vessel",
-          "Bone",
-          "Bone Marrow",
-          "Bowel",
-          "Brain",
-          "Brain Stem",
-          "Breast",
-          "Broad Ligament",
-          "Bronchiole",
-          "Bronchus",
-          "Brow",
-          "Buccal Cavity",
-          "Buccal Mucosa",
-          "Buttock",
-          "Calf",
-          "Capillary",
-          "Cardia",
-          "Carina",
-          "Carotid Artery",
-          "Carotid Body",
-          "Cartilage",
-          "Cecum",
-          "Cell-Line",
-          "Central Nervous System",
-          "Cerebellum",
-          "Cerebral Cortex",
-          "Cerebrospinal Fluid",
-          "Cerebrum",
-          "Cervical Spine",
-          "Cervix",
-          "Chest",
-          "Chest Wall",
-          "Chin",
-          "Clavicle",
-          "Clitoris",
-          "Colon",
-          "Colon (Mucosa Only)",
-          "Common Duct",
-          "Conjunctiva",
-          "Connective Tissue",
-          "Dermal",
-          "Descending Colon",
-          "Diaphragm",
-          "Duodenum",
-          "Ear",
-          "Ear Canal",
-          "Ear, Pinna (External)",
-          "Effusion",
-          "Elbow",
-          "Endocrine Gland",
-          "Epididymis",
-          "Epidural Space",
-          "Esophagogastric Junction",
-          "Esophagus",
-          "Esophagus (Mucosa Only)",
-          "Eye",
-          "Fallopian Tube",
-          "Femoral Artery",
-          "Femoral Vein",
-          "Femur",
-          "Fibroblasts",
-          "Fibula",
-          "Finger",
-          "Floor of Mouth",
-          "Fluid",
-          "Foot",
-          "Forearm",
-          "Forehead",
-          "Foreskin",
-          "Frontal Cortex",
-          "Frontal Lobe",
-          "Fundus of Stomach",
-          "Gallbladder",
-          "Ganglia",
-          "Gastroesophageal Junction",
-          "Gastrointestinal Tract",
-          "Groin",
-          "Gum",
-          "Hand",
-          "Hard Palate",
-          "Head and Neck",
-          "Head (Face Or Neck) NOS",
-          "Heart",
-          "Hepatic",
-          "Hepatic Duct",
-          "Hepatic Vein",
-          "Hip",
-          "Hippocampus",
-          "Humerus",
-          "Hypopharynx",
-          "Ileum",
-          "Ilium",
-          "Index Finger",
-          "Ischium",
-          "Islet Cells",
-          "Jaw",
-          "Jejunum",
-          "Joint",
-          "Kidney",
-          "Knee",
-          "Lacrimal Gland",
-          "Large Bowel",
-          "Laryngopharynx",
-          "Larynx",
-          "Leg",
-          "Leptomeninges",
-          "Ligament",
-          "Lip",
-          "Liver",
-          "Lumbar Spine",
-          "Lung",
-          "Lymph Node",
-          "Lymph Node(s) Axilla",
-          "Lymph Node(s) Cervical",
-          "Lymph Node(s) Distant",
-          "Lymph Node(s) Epitrochlear",
-          "Lymph Node(s) Femoral",
-          "Lymph Node(s) Hilar",
-          "Lymph Node(s) Iliac-Common",
-          "Lymph Node(s) Iliac-External",
-          "Lymph Node(s) Inguinal",
-          "Lymph Node(s) Internal Mammary",
-          "Lymph Node(s) Mammary",
-          "Lymph Node(s) Mesenteric",
-          "Lymph Node(s) Occipital",
-          "Lymph Node(s) Paraaortic",
-          "Lymph Node(s) Parotid",
-          "Lymph Node(s) Pelvic",
-          "Lymph Node(s) Popliteal",
-          "Lymph Node(s) Regional",
-          "Lymph Node(s) Retroperitoneal",
-          "Lymph Node(s) Scalene",
-          "Lymph Node(s) Splenic",
-          "Lymph Node(s) Subclavicular",
-          "Lymph Node(s) Submandibular",
-          "Lymph Node(s) Supraclavicular",
-          "Lymph Nodes(s) Mediastinal",
-          "Mandible",
-          "Maxilla",
-          "Mediastinal Soft Tissue",
-          "Mediastinum",
-          "Mesentery",
-          "Mesothelium",
-          "Middle Finger",
-          "Mitochondria",
-          "Muscle",
-          "Nails",
-          "Nasal Cavity",
-          "Nasal Soft Tissue",
-          "Nasopharynx",
-          "Neck",
-          "Nerve",
-          "Nerve(s) Cranial",
-          "Occipital Cortex",
-          "Ocular Orbits",
-          "Omentum",
-          "Oral Cavity",
-          "Oral Cavity (Mucosa Only)",
-          "Oropharynx",
-          "Other",
-          "Ovary",
-          "Palate",
-          "Pancreas",
-          "Paraspinal Ganglion",
-          "Parathyroid",
-          "Parotid Gland",
-          "Patella",
-          "Pelvis",
-          "Penis",
-          "Pericardium",
-          "Periorbital Soft Tissue",
-          "Peritoneal Cavity",
-          "Peritoneum",
-          "Pharynx",
-          "Pineal",
-          "Pineal Gland",
-          "Pituitary Gland",
-          "Placenta",
-          "Pleura",
-          "Popliteal Fossa",
-          "Prostate",
-          "Pylorus",
-          "Rectosigmoid Junction",
-          "Rectum",
-          "Retina",
-          "Retro-Orbital Region",
-          "Retroperitoneum",
-          "Rib",
-          "Ring Finger",
-          "Round Ligament",
-          "Sacrum",
-          "Salivary Gland",
-          "Scalp",
-          "Scapula",
-          "Sciatic Nerve",
-          "Scrotum",
-          "Seminal Vesicle",
-          "Shoulder",
-          "Sigmoid Colon",
-          "Sinus",
-          "Sinus(es), Maxillary",
-          "Skeletal Muscle",
-          "Skin",
-          "Skull",
-          "Small Bowel",
-          "Small Bowel (Mucosa Only)",
-          "Small Finger",
-          "Soft Tissue",
-          "Spinal Column",
-          "Spinal Cord",
-          "Spleen",
-          "Splenic Flexure",
-          "Sternum",
-          "Stomach",
-          "Stomach (Mucosa Only)",
-          "Subcutaneous Tissue",
-          "Synovium",
-          "Temporal Cortex",
-          "Tendon",
-          "Testis",
-          "Thigh",
-          "Thoracic Spine",
-          "Thorax",
-          "Throat",
-          "Thumb",
-          "Thymus",
-          "Thyroid",
-          "Tibia",
-          "Tongue",
-          "Tonsil",
-          "Tonsil (Pharyngeal)",
-          "Trachea Major Bronchi",
-          "Transverse Colon",
-          "Trunk",
-          "Umbilical Cord",
-          "Ureter",
-          "Urethra",
-          "Urinary Tract",
-          "Uterus",
-          "Uvula",
-          "Vagina",
-          "Vas Deferens",
-          "Vein",
-          "Venous",
-          "Vertebra",
-          "Vulva",
-          "White Blood Cells",
-          "Wrist",
-          "Unknown"
-        ]
-      },
-      "test_result": {
-        "description": "The categorical result of the laboratory test.\n",
-        "enum": [
-          "1 plus",
-          "2 plus",
-          "3 plus",
-          "Abnormal",
-          "Anisocytosis",
-          "Clinically Significant Abnormal",
-          "Elliptocytosis",
-          "Equivocal",
-          "Hypochromic",
-          "Microcytic",
-          "Macrocytic",
-          "Negative",
-          "No",
-          "Normal",
-          "Normocytic",
-          "Not Identified w/in stability",
-          "Not Reported",
-          "Polychromatophilia",
-          "Poikilocytosis",
-          "Positive",
-          "Too Low",
-          "Too High",
-          "Trace",
-          "Unknown",
-          "Yes"
-        ]
-      },
-      "test_sample_composition": {
-        "description": "Indicate the composition or type of biological sample used for the test (e.g., blood, urine, solid tissue, saliva, etc.)\n",
-        "enum": [
-          "Buccal Cells",
-          "Buffy Coat",
-          "Bone Marrow Components",
-          "Bone Marrow Components NOS",
-          "Cerebrospinal Fluid (CSF)",
-          "Control Analyte",
-          "Cell",
-          "Circulating Tumor Cell (CTC)",
-          "Derived Cell Line",
-          "EBV Immortalized",
-          "Fibroblasts from Bone Marrow Normal",
-          "Granulocytes",
-          "Human Original Cells",
-          "Lymphocytes",
-          "Mononuclear Cells from Bone Marrow Normal",
-          "Not Applicable",
-          "Oral Swab",
-          "Other (specify)",
-          "Peripheral Blood Components NOS",
-          "Peripheral Blood Nucleated Cells",
-          "Pleural Effusion",
-          "Plasma",
-          "Peripheral Whole Blood",
-          "Serum",
-          "Saliva",
-          "Sputum",
-          "Solid Normal Tissue",
-          "Solid Tumor Tissue",
-          "Whole Bone Marrow",
-          "Whole Blood",
-          "Unknown",
-          "Urine"
-        ]
-      },
-      "test_sample_composition_other": {
-        "desciption": "If 'Other (specify)' was chosen for 'test_sample_composition', enter a description of the sample used for the test here\n",
-        "type": "string"
-      },
-      "test_type": {
-        "description": "The general type or category of the laboratory test\n",
-        "enum": [
-          "Abnormal Laboratory Test",
-          "Biopsy",
-          "Blood Chemistry Test",
-          "Coagulation Panel",
-          "Complete Blood Count",
-          "Cultures",
-          "Imaging",
-          "Lipid Panel",
-          "Liver Panel",
-          "Prothrombin Time",
-          "Serum Test",
-          "Urinalysis"
-        ]
-      },
-      "test_units": {
-        "description": "The units corresponding to a test_value for a test_analyte_type\n",
-        "enum": [
-          "Array Signal (log2)",
-          "Average Ct",
-          "copies/microliter",
-          "cells/microliter",
-          "Cell Count",
-          "Coefficient of Variance (PCT)",
-          "Copy Number per 25ng RNA",
-          "counts",
-          "Cycle threshold (Ct)",
-          "katal",
-          "mg/mL",
-          "mg/dL",
-          "micrograms/mL",
-          "mM",
-          "micromoles/g/h",
-          "ng/mL",
-          "nM",
-          "Normalized Ion Intensity by Endogenous Arginine and Autoscaled",
-          "Not Applicable",
-          "Optical Density",
-          "Other (specify)",
-          "pg/mL",
-          "SD",
-          "Standard Deviation Ct",
-          "U/mL",
-          "uIU/mL",
-          "Units of Activity"
-        ]
-      },
-      "test_units_other": {
-        "description": "The units corresponding to a 'test_value' for an 'analyte_name' if 'Other (specify)' was chosen for 'test_units'\n",
-        "type": "string"
-      },
-      "test_value": {
-        "description": "The numerical value representing the diagnostic test measurement of the 'analyte_name'; also indicate the 'test_units'.\n",
-        "type": "number"
       },
       "type": {
-        "type": "string"
+        "enum": [
+          "experimental_metadata"
+        ]
       },
       "updated_datetime": {
         "oneOf": [
@@ -11912,21 +6724,24 @@
     },
     "required": [
       "submitter_id",
-      "type",
-      "cases",
-      "days_to_test",
-      "test_type"
+      "file_name",
+      "file_size",
+      "md5sum",
+      "data_category",
+      "data_type",
+      "data_format"
     ],
-    "schema": "http://json-schema.org/draft-04/schema#",
     "submittable": true,
     "systemProperties": [
       "id",
       "project_id",
-      "state",
       "created_datetime",
-      "updated_datetime"
+      "updated_datetime",
+      "state",
+      "file_state",
+      "error_type"
     ],
-    "title": "Diagnostic Test",
+    "title": "Experimental Metadata",
     "type": "object",
     "uniqueKeys": [
       [
@@ -11955,7 +6770,11 @@
         "target_type": "case"
       }
     ],
-    "namespace": "https://www.bloodpac.org",
+    "namespace": "http://gdc.nci.nih.gov",
+    "preferred": [
+      "cigarettes_per_day",
+      "years_smoked"
+    ],
     "program": "*",
     "project": "*",
     "properties": {
@@ -11984,6 +6803,19 @@
           }
         },
         "type": "string"
+      },
+      "bmi": {
+        "term": {
+          "description": "The body mass divided by the square of the body height expressed in units of kg/m^2.\n",
+          "termDef": {
+            "cde_id": 4973892,
+            "cde_version": 1,
+            "source": "caDSR",
+            "term": "Body Mass Index (BMI)",
+            "term_url": "https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=4973892&version=1.0"
+          }
+        },
+        "type": "number"
       },
       "cases": {
         "anyOf": [
@@ -12067,6 +6899,19 @@
           "description": "A combination of date and time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]\n"
         }
       },
+      "height": {
+        "term": {
+          "description": "The height of the patient in centimeters.\n",
+          "termDef": {
+            "cde_id": 649,
+            "cde_version": 4.1,
+            "source": "caDSR",
+            "term": "Patient Height Measurement",
+            "term_url": "https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=649&version=4.1"
+          }
+        },
+        "type": "number"
+      },
       "id": {
         "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
         "systemAlias": "node_id",
@@ -12081,6 +6926,19 @@
           }
         },
         "type": "string"
+      },
+      "pack_years_smoked": {
+        "term": {
+          "description": "Numeric computed value to represent lifetime tobacco exposure defined as number of cigarettes smoked per day x number of years smoked divided by 20.\n",
+          "termDef": {
+            "cde_id": 2955385,
+            "cde_version": 1,
+            "source": "caDSR",
+            "term": "Person Cigarette Smoking History Pack Year Value",
+            "term_url": "https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=2955385&version=1.0"
+          }
+        },
+        "type": "number"
       },
       "project_id": {
         "term": {
@@ -12130,21 +6988,49 @@
         }
       },
       "submitter_id": {
-        "description": "A project-specific identifier for a node. This property is the calling card/nickname/alias for a unit of submission. It can be used in place of the UUID for identifying or recalling a node.\n",
         "type": [
-          "string"
+          "string",
+          "null"
         ]
+      },
+      "tobacco_smoking_onset_year": {
+        "term": {
+          "description": "The year in which the participant began smoking.\n",
+          "termDef": {
+            "cde_id": 2228604,
+            "cde_version": 1,
+            "source": "caDSR",
+            "term": "Started Smoking Year",
+            "term_url": "https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=2228604&version=1.0"
+          }
+        },
+        "type": "integer"
+      },
+      "tobacco_smoking_quit_year": {
+        "term": {
+          "description": "The year in which the participant quit smoking.\n",
+          "termDef": {
+            "cde_id": 2228610,
+            "cde_version": 1,
+            "source": "caDSR",
+            "term": "Stopped Smoking Year",
+            "term_url": "https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=2228610&version=1.0"
+          }
+        },
+        "type": "integer"
       },
       "tobacco_smoking_status": {
         "enum": [
-          "1",
-          "2",
-          "3",
-          "4",
-          "5",
-          "6",
-          "7",
-          "Unknown"
+          1,
+          2,
+          3,
+          4,
+          5,
+          6,
+          7,
+          "Unknown",
+          "Not Reported",
+          "Not Allowed To Collect"
         ],
         "term": {
           "description": "Category describing current smoking status and smoking history as self-reported by a patient.\n",
@@ -12158,7 +7044,9 @@
         }
       },
       "type": {
-        "type": "string"
+        "enum": [
+          "exposure"
+        ]
       },
       "updated_datetime": {
         "oneOf": [
@@ -12174,9 +7062,20 @@
           "description": "A combination of date and time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]\n"
         }
       },
+      "weight": {
+        "term": {
+          "description": "The weight of the patient measured in kilograms.\n",
+          "termDef": {
+            "cde_id": 651,
+            "cde_version": 4,
+            "source": "caDSR",
+            "term": "Patient Weight Measurement",
+            "term_url": "https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=651&version=4.0"
+          }
+        },
+        "type": "number"
+      },
       "years_smoked": {
-        "maximum": 89,
-        "minimum": 0,
         "term": {
           "description": "Numeric value (or unknown) to represent the number of years a person has been smoking.\n",
           "termDef": {
@@ -12190,11 +7089,6 @@
         "type": "number"
       }
     },
-    "required": [
-      "submitter_id",
-      "type",
-      "cases"
-    ],
     "submittable": true,
     "systemProperties": [
       "id",
@@ -12327,10 +7221,8 @@
         "type": "string"
       },
       "relationship_age_at_diagnosis": {
-        "maximum": 89,
-        "minimum": 0,
         "term": {
-          "description": "The age (in years) when the patient's relative was first diagnosed; if age is greater than 89 years, use 'relationship_age_at_diagnosis_gt89'.\n",
+          "description": "The age (in years) when the patient's relative was first diagnosed.\n",
           "termDef": {
             "cde_id": 5300571,
             "cde_version": 1,
@@ -12339,23 +7231,7 @@
             "term_url": "https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=5300571&version=1.0"
           }
         },
-        "type": "integer"
-      },
-      "relationship_age_at_diagnosis_gt89": {
-        "enum": [
-          "Yes",
-          "No"
-        ],
-        "term": {
-          "description": "Indicate whether the age (in years) when the patient's relative was first diagnosed is greater than 89 years.\n",
-          "termDef": {
-            "cde_id": 5300571,
-            "cde_version": 1,
-            "source": "caDSR",
-            "term": "Relative Diagnosis Age Value",
-            "term_url": "https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=5300571&version=1.0"
-          }
-        }
+        "type": "number"
       },
       "relationship_gender": {
         "enum": [
@@ -12487,10 +7363,6 @@
         }
       }
     },
-    "required": [
-      "submitter_id",
-      "type"
-    ],
     "submittable": true,
     "systemProperties": [
       "id",
@@ -12500,1374 +7372,6 @@
       "updated_datetime"
     ],
     "title": "Family History",
-    "type": "object",
-    "uniqueKeys": [
-      [
-        "id"
-      ],
-      [
-        "project_id",
-        "submitter_id"
-      ]
-    ],
-    "validators": null
-  },
-  "followup": {
-    "additionalProperties": false,
-    "category": "clinical",
-    "description": "A visit by a patient or study participant to a medical professional. A clinical encounter that encompasses planned and unplanned trial interventions, procedures and assessments that may be performed on a subject. A visit has a start and an end, each described with a rule. The process by which information about the health status of an individual is obtained before and after a study has officially closed; an activity that continues something that has already begun or that repeats something that has already been done.\n",
-    "id": "followup",
-    "links": [
-      {
-        "backref": "followups",
-        "label": "describes",
-        "multiplicity": "many_to_one",
-        "name": "cases",
-        "required": true,
-        "target_type": "case"
-      }
-    ],
-    "namespace": "https://www.bloodpac.org",
-    "program": "*",
-    "project": "*",
-    "properties": {
-      "adverse_event": {
-        "description": "Text that represents the Common Terminology Criteria for Adverse Events low level term name for an adverse event.",
-        "enum": [
-          "Abdominal distension",
-          "Abdominal infection",
-          "Abdominal pain",
-          "Abdominal soft tissue necrosis",
-          "Abducens nerve disorder",
-          "Accessory nerve disorder",
-          "Acidosis",
-          "Acoustic nerve disorder NOS",
-          "Activated partial thromboplastin time prolonged",
-          "Acute coronary syndrome",
-          "Acute kidney injury",
-          "Adrenal insufficiency",
-          "Adult respiratory distress syndrome",
-          "Agitation",
-          "Akathisia",
-          "Alanine aminotransferase increased",
-          "Alcohol intolerance",
-          "Alkaline phosphatase increased",
-          "Alkalosis",
-          "Allergic reaction",
-          "Allergic rhinitis",
-          "Alopecia",
-          "Amnesia",
-          "Anal fistula",
-          "Anal hemorrhage",
-          "Anal mucositis",
-          "Anal necrosis",
-          "Anal pain",
-          "Anal stenosis",
-          "Anal ulcer",
-          "Anaphylaxis",
-          "Anemia",
-          "Ankle fracture",
-          "Anorectal infection",
-          "Anorexia",
-          "Anorgasmia",
-          "Anxiety",
-          "Aortic injury",
-          "Aortic valve disease",
-          "Aphonia",
-          "Apnea",
-          "Appendicitis",
-          "Appendicitis perforated",
-          "Arachnoiditis",
-          "Arterial injury",
-          "Arteritis infective",
-          "Arthralgia",
-          "Arthritis",
-          "Ascites",
-          "Aspartate aminotransferase increased",
-          "Aspiration",
-          "Asystole",
-          "Ataxia",
-          "Atelectasis",
-          "Atrial fibrillation",
-          "Atrial flutter",
-          "Atrioventricular block complete",
-          "Atrioventricular block first degree",
-          "Autoimmune disorder",
-          "Avascular necrosis",
-          "Azoospermia",
-          "Back pain",
-          "Bile duct stenosis",
-          "Biliary anastomotic leak",
-          "Biliary fistula",
-          "Biliary tract infection",
-          "Bladder anastomotic leak",
-          "Bladder infection",
-          "Bladder perforation",
-          "Bladder spasm",
-          "Bloating",
-          "Blood and lymphatic system disorders",
-          "Blood antidiuretic hormone abnormal",
-          "Blood bilirubin increased",
-          "Blood corticotrophin decreased",
-          "Blood gonadotrophin abnormal",
-          "Blood prolactin abnormal",
-          "Blurred vision",
-          "Body odor",
-          "Bone infection",
-          "Bone marrow hypocellular",
-          "Bone pain",
-          "Brachial plexopathy",
-          "Breast atrophy",
-          "Breast infection",
-          "Breast pain",
-          "Bronchial fistula",
-          "Bronchial infection",
-          "Bronchial obstruction",
-          "Bronchial stricture",
-          "Bronchopleural fistula",
-          "Bronchopulmonary hemorrhage",
-          "Bronchospasm",
-          "Bruising",
-          "Bullous dermatitis",
-          "Burn",
-          "Buttock pain",
-          "Capillary leak syndrome",
-          "Carbon monoxide diffusing capacity decreased",
-          "Cardiac arrest",
-          "Cardiac disorders",
-          "Cardiac troponin I increased",
-          "Cardiac troponin T increased",
-          "Cataract",
-          "Catheter related infection",
-          "CD4 lymphocytes decreased",
-          "Cecal hemorrhage",
-          "Cecal infection",
-          "Central nervous system necrosis",
-          "Cerebrospinal fluid leakage",
-          "Cervicitis infection",
-          "Cheilitis",
-          "Chest pain - cardiac",
-          "Chest wall pain",
-          "Chills",
-          "Cholecystitis",
-          "Cholesterol high",
-          "Chronic kidney disease",
-          "Chylothorax",
-          "Cognitive disturbance",
-          "Colitis",
-          "Colonic fistula",
-          "Colonic hemorrhage",
-          "Colonic obstruction",
-          "Colonic perforation",
-          "Colonic stenosis",
-          "Colonic ulcer",
-          "Concentration impairment",
-          "Conduction disorder",
-          "Confusion",
-          "Congenital, familial and genetic disorders",
-          "Conjunctivitis",
-          "Conjunctivitis infective",
-          "Constipation",
-          "Constrictive pericarditis",
-          "Corneal infection",
-          "Corneal ulcer",
-          "Cough",
-          "CPK increased",
-          "Cranial nerve infection",
-          "Creatinine increased",
-          "Cushingoid",
-          "Cystitis noninfective",
-          "Cytokine release syndrome",
-          "Death neonatal",
-          "Death NOS",
-          "Dehydration",
-          "Delayed orgasm",
-          "Delayed puberty",
-          "Delirium",
-          "Delusions",
-          "Dental caries",
-          "Depressed level of consciousness",
-          "Depression",
-          "Dermatitis radiation",
-          "Device related infection",
-          "Diarrhea",
-          "Disseminated intravascular coagulation",
-          "Dizziness",
-          "Dry eye",
-          "Dry mouth",
-          "Dry skin",
-          "Duodenal fistula",
-          "Duodenal hemorrhage",
-          "Duodenal infection",
-          "Duodenal obstruction",
-          "Duodenal perforation",
-          "Duodenal stenosis",
-          "Duodenal ulcer",
-          "Dysarthria",
-          "Dysesthesia",
-          "Dysgeusia",
-          "Dysmenorrhea",
-          "Dyspareunia",
-          "Dyspepsia",
-          "Dysphagia",
-          "Dysphasia",
-          "Dyspnea",
-          "Ear and labyrinth disorders",
-          "Ear pain",
-          "Edema cerebral",
-          "Edema face",
-          "Edema limbs",
-          "Edema trunk",
-          "Ejaculation disorder",
-          "Ejection fraction decreased",
-          "Electrocardiogram QT corrected interval prolonged",
-          "Encephalitis infection",
-          "Encephalomyelitis infection",
-          "Encephalopathy",
-          "Endocarditis infective",
-          "Endocrine disorders",
-          "Endophthalmitis",
-          "Enterocolitis",
-          "Enterocolitis infectious",
-          "Enterovesical fistula",
-          "Epistaxis",
-          "Erectile dysfunction",
-          "Erythema multiforme",
-          "Erythroderma",
-          "Esophageal anastomotic leak",
-          "Esophageal fistula",
-          "Esophageal hemorrhage",
-          "Esophageal infection",
-          "Esophageal necrosis",
-          "Esophageal obstruction",
-          "Esophageal pain",
-          "Esophageal perforation",
-          "Esophageal stenosis",
-          "Esophageal ulcer",
-          "Esophageal varices hemorrhage",
-          "Esophagitis",
-          "Euphoria",
-          "Exostosis",
-          "External ear inflammation",
-          "External ear pain",
-          "Extraocular muscle paresis",
-          "Extrapyramidal disorder",
-          "Eye disorders",
-          "Eye infection",
-          "Eye pain",
-          "Eyelid function disorder",
-          "Facial muscle weakness",
-          "Facial nerve disorder",
-          "Facial pain",
-          "Fall",
-          "Fallopian tube anastomotic leak",
-          "Fallopian tube obstruction",
-          "Fallopian tube perforation",
-          "Fallopian tube stenosis",
-          "Fat atrophy",
-          "Fatigue",
-          "Febrile neutropenia",
-          "Fecal incontinence",
-          "Female genital tract fistula",
-          "Feminization acquired",
-          "Fetal death",
-          "Fetal growth retardation",
-          "Fever",
-          "Fibrinogen decreased",
-          "Fibrosis deep connective tissue",
-          "Flank pain",
-          "Flashing lights",
-          "Flatulence",
-          "Floaters",
-          "Flu like symptoms",
-          "Flushing",
-          "Forced expiratory volume decreased",
-          "Fracture",
-          "Gait disturbance",
-          "Gallbladder fistula",
-          "Gallbladder infection",
-          "Gallbladder necrosis",
-          "Gallbladder obstruction",
-          "Gallbladder pain",
-          "Gallbladder perforation",
-          "Gastric anastomotic leak",
-          "Gastric fistula",
-          "Gastric hemorrhage",
-          "Gastric necrosis",
-          "Gastric perforation",
-          "Gastric stenosis",
-          "Gastric ulcer",
-          "Gastritis",
-          "Gastroesophageal reflux disease",
-          "Gastrointestinal anastomotic leak",
-          "Gastrointestinal disorders",
-          "Gastrointestinal fistula",
-          "Gastrointestinal pain",
-          "Gastrointestinal stoma necrosis",
-          "Gastroparesis",
-          "General disorders and administration site conditions",
-          "Generalized muscle weakness",
-          "Genital edema",
-          "GGT increased",
-          "Gingival pain",
-          "Glaucoma",
-          "Glossopharyngeal nerve disorder",
-          "Glucose intolerance",
-          "Growth accelerated",
-          "Growth hormone abnormal",
-          "Growth suppression",
-          "Gum infection",
-          "Gynecomastia",
-          "Hallucinations",
-          "Haptoglobin decreased",
-          "Head soft tissue necrosis",
-          "Headache",
-          "Hearing impaired",
-          "Heart failure",
-          "Hematoma",
-          "Hematosalpinx",
-          "Hematuria",
-          "Hemoglobin increased",
-          "Hemoglobinuria",
-          "Hemolysis",
-          "Hemolytic uremic syndrome",
-          "Hemorrhoidal hemorrhage",
-          "Hemorrhoids",
-          "Hepatic failure",
-          "Hepatic hemorrhage",
-          "Hepatic infection",
-          "Hepatic necrosis",
-          "Hepatic pain",
-          "Hepatitis viral",
-          "Hepatobiliary disorders",
-          "Hiccups",
-          "Hip fracture",
-          "Hirsutism",
-          "Hoarseness",
-          "Hot flashes",
-          "Hydrocephalus",
-          "Hypercalcemia",
-          "Hyperglycemia",
-          "Hyperhidrosis",
-          "Hyperkalemia",
-          "Hypermagnesemia",
-          "Hypernatremia",
-          "Hyperparathyroidism",
-          "Hypersomnia",
-          "Hypertension",
-          "Hyperthyroidism",
-          "Hypertrichosis",
-          "Hypertriglyceridemia",
-          "Hyperuricemia",
-          "Hypoalbuminemia",
-          "Hypocalcemia",
-          "Hypoglossal nerve disorder",
-          "Hypoglycemia",
-          "Hypohidrosis",
-          "Hypokalemia",
-          "Hypomagnesemia",
-          "Hyponatremia",
-          "Hypoparathyroidism",
-          "Hypophosphatemia",
-          "Hypotension",
-          "Hypothermia",
-          "Hypothyroidism",
-          "Hypoxia",
-          "Ileal fistula",
-          "Ileal hemorrhage",
-          "Ileal obstruction",
-          "Ileal perforation",
-          "Ileal stenosis",
-          "Ileal ulcer",
-          "Ileus",
-          "Immune system disorders",
-          "Infections and infestations",
-          "Infective myositis",
-          "Infusion related reaction",
-          "Infusion site extravasation",
-          "Injection site reaction",
-          "Injury to carotid artery",
-          "Injury to inferior vena cava",
-          "Injury to jugular vein",
-          "Injury to superior vena cava",
-          "Injury, poisoning and procedural complications",
-          "INR increased",
-          "Insomnia",
-          "Intestinal stoma leak",
-          "Intestinal stoma obstruction",
-          "Intestinal stoma site bleeding",
-          "Intra-abdominal hemorrhage",
-          "Intracranial hemorrhage",
-          "Intraoperative arterial injury",
-          "Intraoperative breast injury",
-          "Intraoperative cardiac injury",
-          "Intraoperative ear injury",
-          "Intraoperative endocrine injury",
-          "Intraoperative gastrointestinal injury",
-          "Intraoperative head and neck injury",
-          "Intraoperative hemorrhage",
-          "Intraoperative hepatobiliary injury",
-          "Intraoperative musculoskeletal injury",
-          "Intraoperative neurological injury",
-          "Intraoperative ocular injury",
-          "Intraoperative renal injury",
-          "Intraoperative reproductive tract injury",
-          "Intraoperative respiratory injury",
-          "Intraoperative skin injury",
-          "Intraoperative splenic injury",
-          "Intraoperative urinary injury",
-          "Intraoperative venous injury",
-          "Investigations",
-          "Iron overload",
-          "Irregular menstruation",
-          "Irritability",
-          "Ischemia cerebrovascular",
-          "IVth nerve disorder",
-          "Jejunal fistula",
-          "Jejunal hemorrhage",
-          "Jejunal obstruction",
-          "Jejunal perforation",
-          "Jejunal stenosis",
-          "Jejunal ulcer",
-          "Joint effusion",
-          "Joint infection",
-          "Joint range of motion decreased",
-          "Joint range of motion decreased cervical spine",
-          "Joint range of motion decreased lumbar spine",
-          "Keratitis",
-          "Kidney anastomotic leak",
-          "Kidney infection",
-          "Kyphosis",
-          "Lactation disorder",
-          "Large intestinal anastomotic leak",
-          "Laryngeal edema",
-          "Laryngeal fistula",
-          "Laryngeal hemorrhage",
-          "Laryngeal inflammation",
-          "Laryngeal mucositis",
-          "Laryngeal obstruction",
-          "Laryngeal stenosis",
-          "Laryngitis",
-          "Laryngopharyngeal dysesthesia",
-          "Laryngospasm",
-          "Left ventricular systolic dysfunction",
-          "Lethargy",
-          "Leukemia secondary to oncology chemotherapy",
-          "Leukocytosis",
-          "Leukoencephalopathy",
-          "Libido decreased",
-          "Libido increased",
-          "Lip infection",
-          "Lip pain",
-          "Lipase increased",
-          "Lipohypertrophy",
-          "Localized edema",
-          "Lordosis",
-          "Lower gastrointestinal hemorrhage",
-          "Lung infection",
-          "Lymph gland infection",
-          "Lymph leakage",
-          "Lymph node pain",
-          "Lymphedema",
-          "Lymphocele",
-          "Lymphocyte count decreased",
-          "Lymphocyte count increased",
-          "Malabsorption",
-          "Malaise",
-          "Mania",
-          "Mediastinal hemorrhage",
-          "Mediastinal infection",
-          "Memory impairment",
-          "Meningismus",
-          "Meningitis",
-          "Menopause",
-          "Menorrhagia",
-          "Metabolism and nutrition disorders",
-          "Middle ear inflammation",
-          "Mitral valve disease",
-          "Mobitz (type) II atrioventricular block",
-          "Mobitz type I",
-          "Movements involuntary",
-          "Mucosal infection",
-          "Mucositis oral",
-          "Multi-organ failure",
-          "Muscle weakness left-sided",
-          "Muscle weakness lower limb",
-          "Muscle weakness right-sided",
-          "Muscle weakness trunk",
-          "Muscle weakness upper limb",
-          "Musculoskeletal and connective tissue disorders",
-          "Musculoskeletal deformity",
-          "Myalgia",
-          "Myelitis",
-          "Myelodysplastic syndrome",
-          "Myocardial infarction",
-          "Myocarditis",
-          "Myositis",
-          "Nail discoloration",
-          "Nail infection",
-          "Nail loss",
-          "Nail ridging",
-          "Nasal congestion",
-          "Nausea",
-          "Neck edema",
-          "Neck pain",
-          "Neck soft tissue necrosis",
-          "Neoplasms benign, malignant and unspecified (incl cysts and polyps)",
-          "Nervous system disorders",
-          "Neuralgia",
-          "Neutrophil count decreased",
-          "Night blindness",
-          "Nipple deformity",
-          "Non-cardiac chest pain",
-          "Nystagmus",
-          "Obesity",
-          "Obstruction gastric",
-          "Oculomotor nerve disorder",
-          "Olfactory nerve disorder",
-          "Oligospermia",
-          "Optic nerve disorder",
-          "Oral cavity fistula",
-          "Oral dysesthesia",
-          "Oral hemorrhage",
-          "Oral pain",
-          "Osteonecrosis of jaw",
-          "Osteoporosis",
-          "Otitis externa",
-          "Otitis media",
-          "Ovarian hemorrhage",
-          "Ovarian infection",
-          "Ovarian rupture",
-          "Ovulation pain",
-          "Pain",
-          "Pain in extremity",
-          "Pain of skin",
-          "Palmar-plantar erythrodysesthesia syndrome",
-          "Palpitations",
-          "Pancreas infection",
-          "Pancreatic anastomotic leak",
-          "Pancreatic duct stenosis",
-          "Pancreatic enzymes decreased",
-          "Pancreatic fistula",
-          "Pancreatic hemorrhage",
-          "Pancreatic necrosis",
-          "Pancreatitis",
-          "Papilledema",
-          "Papulopustular rash",
-          "Paresthesia",
-          "Paronychia",
-          "Paroxysmal atrial tachycardia",
-          "Pelvic floor muscle weakness",
-          "Pelvic infection",
-          "Pelvic pain",
-          "Pelvic soft tissue necrosis",
-          "Penile infection",
-          "Penile pain",
-          "Perforation bile duct",
-          "Pericardial effusion",
-          "Pericardial tamponade",
-          "Pericarditis",
-          "Perineal pain",
-          "Periodontal disease",
-          "Periorbital edema",
-          "Periorbital infection",
-          "Peripheral ischemia",
-          "Peripheral motor neuropathy",
-          "Peripheral nerve infection",
-          "Peripheral sensory neuropathy",
-          "Peritoneal infection",
-          "Peritoneal necrosis",
-          "Personality change",
-          "Phantom pain",
-          "Pharyngeal anastomotic leak",
-          "Pharyngeal fistula",
-          "Pharyngeal hemorrhage",
-          "Pharyngeal mucositis",
-          "Pharyngeal necrosis",
-          "Pharyngeal stenosis",
-          "Pharyngitis",
-          "Pharyngolaryngeal pain",
-          "Phlebitis",
-          "Phlebitis infective",
-          "Photophobia",
-          "Photosensitivity",
-          "Platelet count decreased",
-          "Pleural effusion",
-          "Pleural hemorrhage",
-          "Pleural infection",
-          "Pleuritic pain",
-          "Pneumonitis",
-          "Pneumothorax",
-          "Portal hypertension",
-          "Portal vein thrombosis",
-          "Postnasal drip",
-          "Postoperative hemorrhage",
-          "Postoperative thoracic procedure complication",
-          "Precocious puberty",
-          "Pregnancy, puerperium and perinatal conditions",
-          "Premature delivery",
-          "Premature menopause",
-          "Presyncope",
-          "Proctitis",
-          "Productive cough",
-          "Prolapse of intestinal stoma",
-          "Prolapse of urostomy",
-          "Prostate infection",
-          "Prostatic hemorrhage",
-          "Prostatic obstruction",
-          "Prostatic pain",
-          "Proteinuria",
-          "Pruritus",
-          "Psychiatric disorders",
-          "Psychosis",
-          "Pulmonary edema",
-          "Pulmonary fibrosis",
-          "Pulmonary fistula",
-          "Pulmonary hypertension",
-          "Pulmonary valve disease",
-          "Purpura",
-          "Pyramidal tract syndrome",
-          "Radiation recall reaction (dermatologic)",
-          "Radiculitis",
-          "Rash acneiform",
-          "Rash maculo-papular",
-          "Rash pustular",
-          "Rectal anastomotic leak",
-          "Rectal fistula",
-          "Rectal hemorrhage",
-          "Rectal mucositis",
-          "Rectal necrosis",
-          "Rectal obstruction",
-          "Rectal pain",
-          "Rectal perforation",
-          "Rectal stenosis",
-          "Rectal ulcer",
-          "Recurrent laryngeal nerve palsy",
-          "Renal and urinary disorders",
-          "Renal calculi",
-          "Renal colic",
-          "Renal hemorrhage",
-          "Reproductive system and breast disorders",
-          "Respiratory failure",
-          "Respiratory, thoracic and mediastinal disorders",
-          "Restlessness",
-          "Restrictive cardiomyopathy",
-          "Retinal detachment",
-          "Retinal tear",
-          "Retinal vascular disorder",
-          "Retinoic acid syndrome",
-          "Retinopathy",
-          "Retroperitoneal hemorrhage",
-          "Reversible posterior leukoencephalopathy syndrome",
-          "Rhinitis infective",
-          "Right ventricular dysfunction",
-          "Salivary duct inflammation",
-          "Salivary gland fistula",
-          "Salivary gland infection",
-          "Scalp pain",
-          "Scleral disorder",
-          "Scoliosis",
-          "Scrotal infection",
-          "Scrotal pain",
-          "Seizure",
-          "Sepsis",
-          "Seroma",
-          "Serum amylase increased",
-          "Serum sickness",
-          "Sick sinus syndrome",
-          "Sinus bradycardia",
-          "Sinus disorder",
-          "Sinus pain",
-          "Sinus tachycardia",
-          "Sinusitis",
-          "Skin and subcutaneous tissue disorders",
-          "Skin atrophy",
-          "Skin hyperpigmentation",
-          "Skin hypopigmentation",
-          "Skin induration",
-          "Skin infection",
-          "Skin ulceration",
-          "Sleep apnea",
-          "Small intestinal anastomotic leak",
-          "Small intestinal mucositis",
-          "Small intestinal obstruction",
-          "Small intestinal perforation",
-          "Small intestinal stenosis",
-          "Small intestine infection",
-          "Small intestine ulcer",
-          "Sneezing",
-          "Social circumstances",
-          "Soft tissue infection",
-          "Soft tissue necrosis lower limb",
-          "Soft tissue necrosis upper limb",
-          "Somnolence",
-          "Sore throat",
-          "Spasticity",
-          "Spermatic cord anastomotic leak",
-          "Spermatic cord hemorrhage",
-          "Spermatic cord obstruction",
-          "Spinal fracture",
-          "Spleen disorder",
-          "Splenic infection",
-          "Stenosis of gastrointestinal stoma",
-          "Stevens-Johnson syndrome",
-          "Stoma site infection",
-          "Stomach pain",
-          "Stomal ulcer",
-          "Stridor",
-          "Stroke",
-          "Sudden death NOS",
-          "Suicidal ideation",
-          "Suicide attempt",
-          "Superficial soft tissue fibrosis",
-          "Superficial thrombophlebitis",
-          "Superior vena cava syndrome",
-          "Supraventricular tachycardia",
-          "Surgical and medical procedures",
-          "Syncope",
-          "Telangiectasia",
-          "Testicular disorder",
-          "Testicular hemorrhage",
-          "Testicular pain",
-          "Thromboembolic event",
-          "Thrombotic thrombocytopenic purpura",
-          "Tinnitus",
-          "Tooth development disorder",
-          "Tooth discoloration",
-          "Tooth infection",
-          "Toothache",
-          "Toxic epidermal necrolysis",
-          "Tracheal fistula",
-          "Tracheal hemorrhage",
-          "Tracheal mucositis",
-          "Tracheal obstruction",
-          "Tracheal stenosis",
-          "Tracheitis",
-          "Tracheostomy site bleeding",
-          "Transient ischemic attacks",
-          "Treatment related secondary malignancy",
-          "Tremor",
-          "Tricuspid valve disease",
-          "Trigeminal nerve disorder",
-          "Trismus",
-          "Tumor lysis syndrome",
-          "Tumor pain",
-          "Typhlitis",
-          "Unequal limb length",
-          "Unintended pregnancy",
-          "Upper gastrointestinal hemorrhage",
-          "Upper respiratory infection",
-          "Ureteric anastomotic leak",
-          "Urethral anastomotic leak",
-          "Urethral infection",
-          "Urinary fistula",
-          "Urinary frequency",
-          "Urinary incontinence",
-          "Urinary retention",
-          "Urinary tract infection",
-          "Urinary tract obstruction",
-          "Urinary tract pain",
-          "Urinary urgency",
-          "Urine discoloration",
-          "Urine output decreased",
-          "Urostomy leak",
-          "Urostomy obstruction",
-          "Urostomy site bleeding",
-          "Urostomy stenosis",
-          "Urticaria",
-          "Uterine anastomotic leak",
-          "Uterine fistula",
-          "Uterine hemorrhage",
-          "Uterine infection",
-          "Uterine obstruction",
-          "Uterine pain",
-          "Uterine perforation",
-          "Uveitis",
-          "Vaginal anastomotic leak",
-          "Vaginal discharge",
-          "Vaginal dryness",
-          "Vaginal fistula",
-          "Vaginal hemorrhage",
-          "Vaginal infection",
-          "Vaginal inflammation",
-          "Vaginal obstruction",
-          "Vaginal pain",
-          "Vaginal perforation",
-          "Vaginal stricture",
-          "Vaginismus",
-          "Vagus nerve disorder",
-          "Vas deferens anastomotic leak",
-          "Vascular access complication",
-          "Vascular disorders",
-          "Vasculitis",
-          "Vasovagal reaction",
-          "Venous injury",
-          "Ventricular arrhythmia",
-          "Ventricular fibrillation",
-          "Ventricular tachycardia",
-          "Vertigo",
-          "Vestibular disorder",
-          "Virilization",
-          "Visceral arterial ischemia",
-          "Vital capacity abnormal",
-          "Vitreous hemorrhage",
-          "Voice alteration",
-          "Vomiting",
-          "Vulval infection",
-          "Watering eyes",
-          "Weight gain",
-          "Weight loss",
-          "Wheezing",
-          "White blood cell decreased",
-          "Wolff-Parkinson-White syndrome",
-          "Wound complication",
-          "Wound dehiscence",
-          "Wound infection",
-          "Wrist fracture"
-        ]
-      },
-      "bmi": {
-        "description": "The body mass divided by the square of the body height expressed in units of kg/m^2.",
-        "type": "number"
-      },
-      "cases": {
-        "anyOf": [
-          {
-            "items": {
-              "additionalProperties": true,
-              "maxItems": 1,
-              "minItems": 1,
-              "properties": {
-                "id": {
-                  "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
-                  "term": {
-                    "description": "A 128-bit identifier. Depending on the mechanism used to generate it, it is either guaranteed to be different from all other UUIDs/GUIDs generated until 3400 AD or extremely likely to be different. Its relatively small size lends itself well to sorting, ordering, and hashing of all sorts, storing in databases, simple allocation, and ease of programming in general.\n",
-                    "termDef": {
-                      "cde_id": "C54100",
-                      "cde_version": null,
-                      "source": "NCIt",
-                      "term": "Universally Unique Identifier",
-                      "term_url": "https://ncit.nci.nih.gov/ncitbrowser/ConceptReport.jsp?dictionary=NCI_Thesaurus&version=16.02d&ns=NCI_Thesaurus&code=C54100"
-                    }
-                  },
-                  "type": "string"
-                },
-                "submitter_id": {
-                  "type": "string"
-                }
-              },
-              "type": "object"
-            },
-            "type": "array"
-          },
-          {
-            "additionalProperties": true,
-            "properties": {
-              "id": {
-                "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
-                "term": {
-                  "description": "A 128-bit identifier. Depending on the mechanism used to generate it, it is either guaranteed to be different from all other UUIDs/GUIDs generated until 3400 AD or extremely likely to be different. Its relatively small size lends itself well to sorting, ordering, and hashing of all sorts, storing in databases, simple allocation, and ease of programming in general.\n",
-                  "termDef": {
-                    "cde_id": "C54100",
-                    "cde_version": null,
-                    "source": "NCIt",
-                    "term": "Universally Unique Identifier",
-                    "term_url": "https://ncit.nci.nih.gov/ncitbrowser/ConceptReport.jsp?dictionary=NCI_Thesaurus&version=16.02d&ns=NCI_Thesaurus&code=C54100"
-                  }
-                },
-                "type": "string"
-              },
-              "submitter_id": {
-                "type": "string"
-              }
-            },
-            "type": "object"
-          }
-        ]
-      },
-      "cause_of_response": {
-        "description": "A specific regimen or line of therapy responsible for the patient's observed improvement achived at a certain point in time during a patient's treatment protocol.\n",
-        "type": "string"
-      },
-      "created_datetime": {
-        "oneOf": [
-          {
-            "format": "date-time",
-            "type": "string"
-          },
-          {
-            "type": "null"
-          }
-        ],
-        "term": {
-          "description": "A combination of date and time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]\n"
-        }
-      },
-      "days_to_adverse_event": {
-        "description": "Number of days between the date used for index and the date the patient had an adverse event.",
-        "type": "integer"
-      },
-      "days_to_followup": {
-        "description": "Number of days between the date used for index and the date the patient was seen or contacted at follow-up.",
-        "type": "integer"
-      },
-      "days_to_progression": {
-        "description": "Number of days between the date used for index and the date the patient was diagnosed with progression of disease.",
-        "type": "integer"
-      },
-      "days_to_recurrence": {
-        "description": "Number of days between the date used for index and the date the patient was diagnosed with a recurrent malignancy.",
-        "type": "integer"
-      },
-      "disease_response": {
-        "description": "The observed improvement achieved at a certain point in time during a patient's treatment protocol.",
-        "enum": [
-          "AJ-Adjuvant Therapy",
-          "CPD-Clinical Progression",
-          "CR-Complete Response",
-          "CRU-Complete Response Unconfirmed",
-          "DU-Disease Unchanged",
-          "IMR-Immunoresponse",
-          "IPD-Immunoprogression",
-          "MR-Minimal/Marginal response",
-          "MX-Mixed response",
-          "Non-CR/Non-PD-Non-CR/Non-PD",
-          "NPB-No Palliative Benefit",
-          "NR-NO RESPONSE",
-          "PA-Palliative Therapy",
-          "PB-Palliative Benefit",
-          "PD-Progressive Disease",
-          "PPD-Pseudoprogression",
-          "PR-Partial Response",
-          "PSR-Pseudoresponse",
-          "RD-Responsive Disease",
-          "RP-Response",
-          "RPD-Radiographic Progressive Disease",
-          "sCR-Stringent Complete Response",
-          "SD-Stable Disease",
-          "SPD-Surgical progression",
-          "TE-Too early",
-          "VGPR-Very Good Partial Response"
-        ]
-      },
-      "ecog_performance_status": {
-        "description": "The ECOG functional performance status of the patient/participant.",
-        "enum": [
-          "0",
-          "1",
-          "2",
-          "3",
-          "4",
-          "5"
-        ]
-      },
-      "height": {
-        "description": "The height of the patient in centimeters.",
-        "type": "number"
-      },
-      "id": {
-        "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
-        "systemAlias": "node_id",
-        "term": {
-          "description": "A 128-bit identifier. Depending on the mechanism used to generate it, it is either guaranteed to be different from all other UUIDs/GUIDs generated until 3400 AD or extremely likely to be different. Its relatively small size lends itself well to sorting, ordering, and hashing of all sorts, storing in databases, simple allocation, and ease of programming in general.\n",
-          "termDef": {
-            "cde_id": "C54100",
-            "cde_version": null,
-            "source": "NCIt",
-            "term": "Universally Unique Identifier",
-            "term_url": "https://ncit.nci.nih.gov/ncitbrowser/ConceptReport.jsp?dictionary=NCI_Thesaurus&version=16.02d&ns=NCI_Thesaurus&code=C54100"
-          }
-        },
-        "type": "string"
-      },
-      "progression_or_recurrence": {
-        "description": "Indicator to identify whether a patient has had a recurrent or relapsed malignancy or a progression of disease.",
-        "enum": [
-          "Yes",
-          "No",
-          "Unknown"
-        ]
-      },
-      "project_id": {
-        "term": {
-          "description": "Unique ID for any specific defined piece of work that is undertaken or attempted to meet a single requirement.\n"
-        },
-        "type": "string"
-      },
-      "state": {
-        "default": "validated",
-        "downloadable": [
-          "uploaded",
-          "md5summed",
-          "validating",
-          "validated",
-          "error",
-          "invalid",
-          "released"
-        ],
-        "oneOf": [
-          {
-            "enum": [
-              "uploading",
-              "uploaded",
-              "md5summing",
-              "md5summed",
-              "validating",
-              "error",
-              "invalid",
-              "suppressed",
-              "redacted",
-              "live"
-            ]
-          },
-          {
-            "enum": [
-              "validated",
-              "submitted",
-              "released"
-            ]
-          }
-        ],
-        "public": [
-          "live"
-        ],
-        "term": {
-          "description": "The current state of the object.\n"
-        }
-      },
-      "submitter_id": {
-        "description": "A project-specific identifier for a node. This property is the calling card/nickname/alias for a unit of submission. It can be used in place of the UUID for identifying or recalling a node.\n",
-        "type": [
-          "string"
-        ]
-      },
-      "time_from_alcohol": {
-        "description": "Hours since the patient last consumed alcohol.\n",
-        "type": "number"
-      },
-      "time_from_biopsy": {
-        "description": "Hours since the patient last underwent a biopsy; please record the biopsy information in the 'diagnostic_test' node and link that record to this followup record.\n",
-        "type": "number"
-      },
-      "time_from_exercise": {
-        "description": "Hours since the patient last exercised.\n",
-        "type": "number"
-      },
-      "time_from_food": {
-        "description": "Hours since the patient last consumed food.\n",
-        "type": "number"
-      },
-      "time_from_physical_trauma": {
-        "description": "Hours since the patient last experienced physical trauma.\n",
-        "type": "number"
-      },
-      "time_from_recreational_drugs": {
-        "description": "Hours since the patient last used recreational drugs.\n",
-        "type": "number"
-      },
-      "time_from_tobacco": {
-        "description": "Hours since the patient last used tobacco.\n",
-        "type": "number"
-      },
-      "time_from_treatment": {
-        "description": "Hours since the patient received a treatment, including surgical procedures or medications; please record the treatment information in the 'treatment' node and link that record to this followup record.\n",
-        "type": "number"
-      },
-      "type": {
-        "type": "string"
-      },
-      "updated_datetime": {
-        "oneOf": [
-          {
-            "format": "date-time",
-            "type": "string"
-          },
-          {
-            "type": "null"
-          }
-        ],
-        "term": {
-          "description": "A combination of date and time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]\n"
-        }
-      },
-      "weight": {
-        "description": "The weight of the patient measured in kilograms.",
-        "type": "number"
-      }
-    },
-    "required": [
-      "submitter_id",
-      "type",
-      "days_to_followup",
-      "cases"
-    ],
-    "schema": "http://json-schema.org/draft-04/schema#",
-    "submittable": true,
-    "systemProperties": [
-      "id",
-      "project_id",
-      "state",
-      "created_datetime",
-      "updated_datetime"
-    ],
-    "title": "Follow-Up",
-    "type": "object",
-    "uniqueKeys": [
-      [
-        "id"
-      ],
-      [
-        "project_id",
-        "submitter_id"
-      ]
-    ],
-    "validators": null
-  },
-  "immunoassay": {
-    "$schema": "http://json-schema.org/draft-04/schema#",
-    "additionalProperties": false,
-    "category": "notation",
-    "description": "Information pertaining to processed results obtained from a immunoassay.\n",
-    "id": "immunoassay",
-    "links": [
-      {
-        "backref": "immunoassays",
-        "label": "data_from",
-        "multiplicity": "many_to_one",
-        "name": "analytes",
-        "required": true,
-        "target_type": "analyte"
-      }
-    ],
-    "namespace": "https://www.bloodpac.org",
-    "program": "*",
-    "project": "*",
-    "properties": {
-      "analytes": {
-        "anyOf": [
-          {
-            "items": {
-              "additionalProperties": true,
-              "maxItems": 1,
-              "minItems": 1,
-              "properties": {
-                "id": {
-                  "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
-                  "term": {
-                    "description": "A 128-bit identifier. Depending on the mechanism used to generate it, it is either guaranteed to be different from all other UUIDs/GUIDs generated until 3400 AD or extremely likely to be different. Its relatively small size lends itself well to sorting, ordering, and hashing of all sorts, storing in databases, simple allocation, and ease of programming in general.\n",
-                    "termDef": {
-                      "cde_id": "C54100",
-                      "cde_version": null,
-                      "source": "NCIt",
-                      "term": "Universally Unique Identifier",
-                      "term_url": "https://ncit.nci.nih.gov/ncitbrowser/ConceptReport.jsp?dictionary=NCI_Thesaurus&version=16.02d&ns=NCI_Thesaurus&code=C54100"
-                    }
-                  },
-                  "type": "string"
-                },
-                "submitter_id": {
-                  "type": "string"
-                }
-              },
-              "type": "object"
-            },
-            "type": "array"
-          },
-          {
-            "additionalProperties": true,
-            "properties": {
-              "id": {
-                "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
-                "term": {
-                  "description": "A 128-bit identifier. Depending on the mechanism used to generate it, it is either guaranteed to be different from all other UUIDs/GUIDs generated until 3400 AD or extremely likely to be different. Its relatively small size lends itself well to sorting, ordering, and hashing of all sorts, storing in databases, simple allocation, and ease of programming in general.\n",
-                  "termDef": {
-                    "cde_id": "C54100",
-                    "cde_version": null,
-                    "source": "NCIt",
-                    "term": "Universally Unique Identifier",
-                    "term_url": "https://ncit.nci.nih.gov/ncitbrowser/ConceptReport.jsp?dictionary=NCI_Thesaurus&version=16.02d&ns=NCI_Thesaurus&code=C54100"
-                  }
-                },
-                "type": "string"
-              },
-              "submitter_id": {
-                "type": "string"
-              }
-            },
-            "type": "object"
-          }
-        ]
-      },
-      "assay_instrument": {
-        "description": "The specific instrument type used to perform the assay.",
-        "enum": [
-          "Bruker Mass Spectrometer",
-          "CytoTrapNano CTC Platform",
-          "Epic Sciences CTC Platform",
-          "HD-SCA Platform",
-          "Multi-Array Assay, Meso Scale Discovery"
-        ]
-      },
-      "assay_instrument_model": {
-        "description": "The specific model of instrument used to perform the assay.",
-        "type": "string"
-      },
-      "assay_kit_name": {
-        "description": "Name of the assay kit used.",
-        "type": "string"
-      },
-      "assay_kit_vendor": {
-        "description": "Vendor that provided the assay kit.",
-        "type": "string"
-      },
-      "assay_kit_version": {
-        "description": "Version of the assay kit used.",
-        "type": "string"
-      },
-      "assay_method": {
-        "description": "General methodology used to perform the assay.",
-        "enum": [
-          "Enzyme-Linked Immunosorbent Assay (ELISA)",
-          "Immunohistochemistry",
-          "MALDI-TOF Mass Spectrometry"
-        ]
-      },
-      "assay_target": {
-        "description": "Target for the assay: can be a specific gene, protein, or otherwise.",
-        "type": "string"
-      },
-      "created_datetime": {
-        "oneOf": [
-          {
-            "format": "date-time",
-            "type": "string"
-          },
-          {
-            "type": "null"
-          }
-        ],
-        "term": {
-          "description": "A combination of date and time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]\n"
-        }
-      },
-      "id": {
-        "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
-        "systemAlias": "node_id",
-        "term": {
-          "description": "A 128-bit identifier. Depending on the mechanism used to generate it, it is either guaranteed to be different from all other UUIDs/GUIDs generated until 3400 AD or extremely likely to be different. Its relatively small size lends itself well to sorting, ordering, and hashing of all sorts, storing in databases, simple allocation, and ease of programming in general.\n",
-          "termDef": {
-            "cde_id": "C54100",
-            "cde_version": null,
-            "source": "NCIt",
-            "term": "Universally Unique Identifier",
-            "term_url": "https://ncit.nci.nih.gov/ncitbrowser/ConceptReport.jsp?dictionary=NCI_Thesaurus&version=16.02d&ns=NCI_Thesaurus&code=C54100"
-          }
-        },
-        "type": "string"
-      },
-      "project_id": {
-        "term": {
-          "description": "Unique ID for any specific defined piece of work that is undertaken or attempted to meet a single requirement.\n"
-        },
-        "type": "string"
-      },
-      "state": {
-        "default": "validated",
-        "downloadable": [
-          "uploaded",
-          "md5summed",
-          "validating",
-          "validated",
-          "error",
-          "invalid",
-          "released"
-        ],
-        "oneOf": [
-          {
-            "enum": [
-              "uploading",
-              "uploaded",
-              "md5summing",
-              "md5summed",
-              "validating",
-              "error",
-              "invalid",
-              "suppressed",
-              "redacted",
-              "live"
-            ]
-          },
-          {
-            "enum": [
-              "validated",
-              "submitted",
-              "released"
-            ]
-          }
-        ],
-        "public": [
-          "live"
-        ],
-        "term": {
-          "description": "The current state of the object.\n"
-        }
-      },
-      "submitter_id": {
-        "description": "A project-specific identifier for a node. This property is the calling card/nickname/alias for a unit of submission. It can be used in place of the UUID for identifying or recalling a node.\n",
-        "type": [
-          "string"
-        ]
-      },
-      "target_localization": {
-        "description": "The observed location of the assay target.",
-        "type": "string"
-      },
-      "target_measurement": {
-        "description": "Measurement for the assay target. Specify target_measurement_units as well.",
-        "type": "number"
-      },
-      "target_measurement_units": {
-        "description": "Units of measurement used when evaluating the assay target.",
-        "type": "string"
-      },
-      "type": {
-        "type": "string"
-      },
-      "updated_datetime": {
-        "oneOf": [
-          {
-            "format": "date-time",
-            "type": "string"
-          },
-          {
-            "type": "null"
-          }
-        ],
-        "term": {
-          "description": "A combination of date and time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]\n"
-        }
-      }
-    },
-    "required": [
-      "submitter_id",
-      "type",
-      "assay_instrument",
-      "assay_instrument_model",
-      "assay_method",
-      "assay_target",
-      "target_measurement",
-      "target_measurement_units",
-      "analytes"
-    ],
-    "submittable": true,
-    "systemProperties": [
-      "id",
-      "project_id",
-      "created_datetime",
-      "updated_datetime",
-      "state"
-    ],
-    "title": "Immunoassay",
     "type": "object",
     "uniqueKeys": [
       [
@@ -13943,9 +7447,6 @@
               "additionalProperties": true,
               "minItems": 1,
               "properties": {
-                "code": {
-                  "type": "string"
-                },
                 "id": {
                   "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
                   "term": {
@@ -13959,6 +7460,9 @@
                     }
                   },
                   "type": "string"
+                },
+                "submitter_id": {
+                  "type": "string"
                 }
               },
               "type": "object"
@@ -13968,9 +7472,6 @@
           {
             "additionalProperties": true,
             "properties": {
-              "code": {
-                "type": "string"
-              },
               "id": {
                 "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
                 "term": {
@@ -13983,6 +7484,9 @@
                     "term_url": "https://ncit.nci.nih.gov/ncitbrowser/ConceptReport.jsp?dictionary=NCI_Thesaurus&version=16.02d&ns=NCI_Thesaurus&code=C54100"
                   }
                 },
+                "type": "string"
+              },
+              "submitter_id": {
                 "type": "string"
               }
             },
@@ -14059,7 +7563,6 @@
     },
     "required": [
       "submitter_id",
-      "type",
       "projects"
     ],
     "submittable": true,
@@ -14071,737 +7574,6 @@
       "updated_datetime"
     ],
     "title": "Keyword",
-    "type": "object",
-    "uniqueKeys": [
-      [
-        "id"
-      ],
-      [
-        "project_id",
-        "submitter_id"
-      ]
-    ],
-    "validators": null
-  },
-  "mass_cytometry_assay": {
-    "$schema": "http://json-schema.org/draft-04/schema#",
-    "additionalProperties": false,
-    "category": "data_file",
-    "description": "Mass cytometry is a variation of flow cytometry in which antibodies are labeled with heavy metal ion tags rather than fluorochromes. Readout is by time-of-flight mass spectrometry. This allows for the combination of many more antibody specificities in a single samples, without significant spillover between channels.\n",
-    "id": "mass_cytometry_assay",
-    "links": [
-      {
-        "exclusive": false,
-        "required": true,
-        "subgroup": [
-          {
-            "backref": "mass_cytometry_assays",
-            "label": "data_from",
-            "multiplicity": "one_to_one",
-            "name": "core_metadata_collections",
-            "required": false,
-            "target_type": "core_metadata_collection"
-          },
-          {
-            "backref": "mass_cytometry_assays",
-            "label": "data_from",
-            "multiplicity": "one_to_one",
-            "name": "analytes",
-            "required": false,
-            "target_type": "analyte"
-          }
-        ]
-      }
-    ],
-    "namespace": "https://www.bloodpac.org/",
-    "program": "*",
-    "project": "*",
-    "properties": {
-      "analytes": {
-        "anyOf": [
-          {
-            "items": {
-              "additionalProperties": true,
-              "maxItems": 1,
-              "minItems": 1,
-              "properties": {
-                "id": {
-                  "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
-                  "term": {
-                    "description": "A 128-bit identifier. Depending on the mechanism used to generate it, it is either guaranteed to be different from all other UUIDs/GUIDs generated until 3400 AD or extremely likely to be different. Its relatively small size lends itself well to sorting, ordering, and hashing of all sorts, storing in databases, simple allocation, and ease of programming in general.\n",
-                    "termDef": {
-                      "cde_id": "C54100",
-                      "cde_version": null,
-                      "source": "NCIt",
-                      "term": "Universally Unique Identifier",
-                      "term_url": "https://ncit.nci.nih.gov/ncitbrowser/ConceptReport.jsp?dictionary=NCI_Thesaurus&version=16.02d&ns=NCI_Thesaurus&code=C54100"
-                    }
-                  },
-                  "type": "string"
-                },
-                "submitter_id": {
-                  "type": "string"
-                }
-              },
-              "type": "object"
-            },
-            "type": "array"
-          },
-          {
-            "additionalProperties": true,
-            "properties": {
-              "id": {
-                "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
-                "term": {
-                  "description": "A 128-bit identifier. Depending on the mechanism used to generate it, it is either guaranteed to be different from all other UUIDs/GUIDs generated until 3400 AD or extremely likely to be different. Its relatively small size lends itself well to sorting, ordering, and hashing of all sorts, storing in databases, simple allocation, and ease of programming in general.\n",
-                  "termDef": {
-                    "cde_id": "C54100",
-                    "cde_version": null,
-                    "source": "NCIt",
-                    "term": "Universally Unique Identifier",
-                    "term_url": "https://ncit.nci.nih.gov/ncitbrowser/ConceptReport.jsp?dictionary=NCI_Thesaurus&version=16.02d&ns=NCI_Thesaurus&code=C54100"
-                  }
-                },
-                "type": "string"
-              },
-              "submitter_id": {
-                "type": "string"
-              }
-            },
-            "type": "object"
-          }
-        ]
-      },
-      "assay_instrument": {
-        "type": "string"
-      },
-      "assay_instrument_model": {
-        "type": "string"
-      },
-      "assay_method": {
-        "enum": [
-          "Imaging Mass Cytometry"
-        ]
-      },
-      "core_metadata_collections": {
-        "anyOf": [
-          {
-            "items": {
-              "additionalProperties": true,
-              "maxItems": 1,
-              "minItems": 1,
-              "properties": {
-                "id": {
-                  "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
-                  "term": {
-                    "description": "A 128-bit identifier. Depending on the mechanism used to generate it, it is either guaranteed to be different from all other UUIDs/GUIDs generated until 3400 AD or extremely likely to be different. Its relatively small size lends itself well to sorting, ordering, and hashing of all sorts, storing in databases, simple allocation, and ease of programming in general.\n",
-                    "termDef": {
-                      "cde_id": "C54100",
-                      "cde_version": null,
-                      "source": "NCIt",
-                      "term": "Universally Unique Identifier",
-                      "term_url": "https://ncit.nci.nih.gov/ncitbrowser/ConceptReport.jsp?dictionary=NCI_Thesaurus&version=16.02d&ns=NCI_Thesaurus&code=C54100"
-                    }
-                  },
-                  "type": "string"
-                },
-                "submitter_id": {
-                  "type": "string"
-                }
-              },
-              "type": "object"
-            },
-            "type": "array"
-          },
-          {
-            "additionalProperties": true,
-            "properties": {
-              "id": {
-                "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
-                "term": {
-                  "description": "A 128-bit identifier. Depending on the mechanism used to generate it, it is either guaranteed to be different from all other UUIDs/GUIDs generated until 3400 AD or extremely likely to be different. Its relatively small size lends itself well to sorting, ordering, and hashing of all sorts, storing in databases, simple allocation, and ease of programming in general.\n",
-                  "termDef": {
-                    "cde_id": "C54100",
-                    "cde_version": null,
-                    "source": "NCIt",
-                    "term": "Universally Unique Identifier",
-                    "term_url": "https://ncit.nci.nih.gov/ncitbrowser/ConceptReport.jsp?dictionary=NCI_Thesaurus&version=16.02d&ns=NCI_Thesaurus&code=C54100"
-                  }
-                },
-                "type": "string"
-              },
-              "submitter_id": {
-                "type": "string"
-              }
-            },
-            "type": "object"
-          }
-        ]
-      },
-      "created_datetime": {
-        "oneOf": [
-          {
-            "format": "date-time",
-            "type": "string"
-          },
-          {
-            "type": "null"
-          }
-        ],
-        "term": {
-          "description": "A combination of date and time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]\n"
-        }
-      },
-      "data_category": {
-        "enum": [
-          "Mass Cytometry"
-        ],
-        "term": {
-          "description": "Broad categorization of the contents of the data file.\n"
-        }
-      },
-      "data_format": {
-        "enum": [
-          "TXT"
-        ],
-        "term": {
-          "description": "Format of the data files.\n"
-        }
-      },
-      "data_type": {
-        "enum": [
-          "Raw IMC Data"
-        ],
-        "term": {
-          "description": "Specific content type of the data file.\n"
-        }
-      },
-      "error_type": {
-        "enum": [
-          "file_size",
-          "file_format",
-          "md5sum"
-        ],
-        "term": {
-          "description": "Type of error for the data file object.\n"
-        }
-      },
-      "file_name": {
-        "term": {
-          "description": "The name (or part of a name) of a file (of any type).\n"
-        },
-        "type": "string"
-      },
-      "file_size": {
-        "term": {
-          "description": "The size of the data file (object) in bytes.\n"
-        },
-        "type": "integer"
-      },
-      "file_state": {
-        "default": "registered",
-        "enum": [
-          "registered",
-          "uploading",
-          "uploaded",
-          "validating",
-          "validated",
-          "submitted",
-          "processing",
-          "processed",
-          "released",
-          "error"
-        ],
-        "term": {
-          "description": "The current state of the data file object.\n"
-        }
-      },
-      "id": {
-        "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
-        "systemAlias": "node_id",
-        "term": {
-          "description": "A 128-bit identifier. Depending on the mechanism used to generate it, it is either guaranteed to be different from all other UUIDs/GUIDs generated until 3400 AD or extremely likely to be different. Its relatively small size lends itself well to sorting, ordering, and hashing of all sorts, storing in databases, simple allocation, and ease of programming in general.\n",
-          "termDef": {
-            "cde_id": "C54100",
-            "cde_version": null,
-            "source": "NCIt",
-            "term": "Universally Unique Identifier",
-            "term_url": "https://ncit.nci.nih.gov/ncitbrowser/ConceptReport.jsp?dictionary=NCI_Thesaurus&version=16.02d&ns=NCI_Thesaurus&code=C54100"
-          }
-        },
-        "type": "string"
-      },
-      "md5sum": {
-        "term": {
-          "description": "The 128-bit hash value expressed as a 32 digit hexadecimal number used as a file's digital fingerprint.\n"
-        },
-        "type": "string"
-      },
-      "object_id": {
-        "description": "The GUID of the object in the index service.",
-        "type": "string"
-      },
-      "panel_used": {
-        "description": "The name or general description of the panel used for this mass cytometry assay. Alternatively, if you have provided a protocol containing the panel, enter its file_name here.\n",
-        "type": "string"
-      },
-      "project_id": {
-        "term": {
-          "description": "Unique ID for any specific defined piece of work that is undertaken or attempted to meet a single requirement.\n"
-        },
-        "type": "string"
-      },
-      "protocol_used": {
-        "description": "The name or general description of the protocol used to run the mass cytometry assay. Alternatively, if you have provided a protocol, enter its file_name here.\n",
-        "type": "string"
-      },
-      "state": {
-        "default": "validated",
-        "downloadable": [
-          "uploaded",
-          "md5summed",
-          "validating",
-          "validated",
-          "error",
-          "invalid",
-          "released"
-        ],
-        "oneOf": [
-          {
-            "enum": [
-              "uploading",
-              "uploaded",
-              "md5summing",
-              "md5summed",
-              "validating",
-              "error",
-              "invalid",
-              "suppressed",
-              "redacted",
-              "live"
-            ]
-          },
-          {
-            "enum": [
-              "validated",
-              "submitted",
-              "released"
-            ]
-          }
-        ],
-        "public": [
-          "live"
-        ],
-        "term": {
-          "description": "The current state of the object.\n"
-        }
-      },
-      "submitter_id": {
-        "description": "A project-specific identifier for a node. This property is the calling card/nickname/alias for a unit of submission. It can be used in place of the UUID for identifying or recalling a node.\n",
-        "type": [
-          "string"
-        ]
-      },
-      "type": {
-        "type": "string"
-      },
-      "updated_datetime": {
-        "oneOf": [
-          {
-            "format": "date-time",
-            "type": "string"
-          },
-          {
-            "type": "null"
-          }
-        ],
-        "term": {
-          "description": "A combination of date and time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]\n"
-        }
-      }
-    },
-    "required": [
-      "submitter_id",
-      "type",
-      "file_name",
-      "file_size",
-      "md5sum",
-      "data_category",
-      "data_type",
-      "data_format",
-      "assay_method",
-      "assay_instrument",
-      "assay_instrument_model"
-    ],
-    "submittable": true,
-    "systemProperties": [
-      "id",
-      "project_id",
-      "created_datetime",
-      "updated_datetime",
-      "state",
-      "file_state",
-      "error_type"
-    ],
-    "title": "Mass Cytometry Assay",
-    "type": "object",
-    "uniqueKeys": [
-      [
-        "id"
-      ],
-      [
-        "project_id",
-        "submitter_id"
-      ]
-    ],
-    "validators": null
-  },
-  "mass_cytometry_image": {
-    "$schema": "http://json-schema.org/draft-04/schema#",
-    "additionalProperties": false,
-    "category": "data_file",
-    "description": "Following an imaging mass cytometry experiment, the raw data output can be converted into antibody-specific images.\n",
-    "id": "mass_cytometry_image",
-    "links": [
-      {
-        "exclusive": false,
-        "required": true,
-        "subgroup": [
-          {
-            "backref": "mass_cytometry_images",
-            "label": "data_from",
-            "multiplicity": "one_to_one",
-            "name": "core_metadata_collections",
-            "required": false,
-            "target_type": "core_metadata_collection"
-          },
-          {
-            "backref": "mass_cytometry_images",
-            "label": "data_from",
-            "multiplicity": "many_to_one",
-            "name": "mass_cytometry_assays",
-            "required": false,
-            "target_type": "mass_cytometry_assay"
-          }
-        ]
-      }
-    ],
-    "namespace": "https://www.bloodpac.org/",
-    "program": "*",
-    "project": "*",
-    "properties": {
-      "assay_target": {
-        "description": "The protein marker identified in this assay.",
-        "type": "string"
-      },
-      "core_metadata_collections": {
-        "anyOf": [
-          {
-            "items": {
-              "additionalProperties": true,
-              "maxItems": 1,
-              "minItems": 1,
-              "properties": {
-                "id": {
-                  "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
-                  "term": {
-                    "description": "A 128-bit identifier. Depending on the mechanism used to generate it, it is either guaranteed to be different from all other UUIDs/GUIDs generated until 3400 AD or extremely likely to be different. Its relatively small size lends itself well to sorting, ordering, and hashing of all sorts, storing in databases, simple allocation, and ease of programming in general.\n",
-                    "termDef": {
-                      "cde_id": "C54100",
-                      "cde_version": null,
-                      "source": "NCIt",
-                      "term": "Universally Unique Identifier",
-                      "term_url": "https://ncit.nci.nih.gov/ncitbrowser/ConceptReport.jsp?dictionary=NCI_Thesaurus&version=16.02d&ns=NCI_Thesaurus&code=C54100"
-                    }
-                  },
-                  "type": "string"
-                },
-                "submitter_id": {
-                  "type": "string"
-                }
-              },
-              "type": "object"
-            },
-            "type": "array"
-          },
-          {
-            "additionalProperties": true,
-            "properties": {
-              "id": {
-                "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
-                "term": {
-                  "description": "A 128-bit identifier. Depending on the mechanism used to generate it, it is either guaranteed to be different from all other UUIDs/GUIDs generated until 3400 AD or extremely likely to be different. Its relatively small size lends itself well to sorting, ordering, and hashing of all sorts, storing in databases, simple allocation, and ease of programming in general.\n",
-                  "termDef": {
-                    "cde_id": "C54100",
-                    "cde_version": null,
-                    "source": "NCIt",
-                    "term": "Universally Unique Identifier",
-                    "term_url": "https://ncit.nci.nih.gov/ncitbrowser/ConceptReport.jsp?dictionary=NCI_Thesaurus&version=16.02d&ns=NCI_Thesaurus&code=C54100"
-                  }
-                },
-                "type": "string"
-              },
-              "submitter_id": {
-                "type": "string"
-              }
-            },
-            "type": "object"
-          }
-        ]
-      },
-      "created_datetime": {
-        "oneOf": [
-          {
-            "format": "date-time",
-            "type": "string"
-          },
-          {
-            "type": "null"
-          }
-        ],
-        "term": {
-          "description": "A combination of date and time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]\n"
-        }
-      },
-      "data_category": {
-        "enum": [
-          "Mass Cytometry"
-        ],
-        "term": {
-          "description": "Broad categorization of the contents of the data file.\n"
-        }
-      },
-      "data_format": {
-        "enum": [
-          "PNG",
-          "JPG",
-          "TIF"
-        ],
-        "term": {
-          "description": "Format of the data files.\n"
-        }
-      },
-      "data_type": {
-        "enum": [
-          "Single Channel IMC Image"
-        ],
-        "term": {
-          "description": "Specific content type of the data file.\n"
-        }
-      },
-      "error_type": {
-        "enum": [
-          "file_size",
-          "file_format",
-          "md5sum"
-        ],
-        "term": {
-          "description": "Type of error for the data file object.\n"
-        }
-      },
-      "file_name": {
-        "term": {
-          "description": "The name (or part of a name) of a file (of any type).\n"
-        },
-        "type": "string"
-      },
-      "file_size": {
-        "term": {
-          "description": "The size of the data file (object) in bytes.\n"
-        },
-        "type": "integer"
-      },
-      "file_state": {
-        "default": "registered",
-        "enum": [
-          "registered",
-          "uploading",
-          "uploaded",
-          "validating",
-          "validated",
-          "submitted",
-          "processing",
-          "processed",
-          "released",
-          "error"
-        ],
-        "term": {
-          "description": "The current state of the data file object.\n"
-        }
-      },
-      "id": {
-        "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
-        "systemAlias": "node_id",
-        "term": {
-          "description": "A 128-bit identifier. Depending on the mechanism used to generate it, it is either guaranteed to be different from all other UUIDs/GUIDs generated until 3400 AD or extremely likely to be different. Its relatively small size lends itself well to sorting, ordering, and hashing of all sorts, storing in databases, simple allocation, and ease of programming in general.\n",
-          "termDef": {
-            "cde_id": "C54100",
-            "cde_version": null,
-            "source": "NCIt",
-            "term": "Universally Unique Identifier",
-            "term_url": "https://ncit.nci.nih.gov/ncitbrowser/ConceptReport.jsp?dictionary=NCI_Thesaurus&version=16.02d&ns=NCI_Thesaurus&code=C54100"
-          }
-        },
-        "type": "string"
-      },
-      "mass_cytometry_assays": {
-        "anyOf": [
-          {
-            "items": {
-              "additionalProperties": true,
-              "maxItems": 1,
-              "minItems": 1,
-              "properties": {
-                "id": {
-                  "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
-                  "term": {
-                    "description": "A 128-bit identifier. Depending on the mechanism used to generate it, it is either guaranteed to be different from all other UUIDs/GUIDs generated until 3400 AD or extremely likely to be different. Its relatively small size lends itself well to sorting, ordering, and hashing of all sorts, storing in databases, simple allocation, and ease of programming in general.\n",
-                    "termDef": {
-                      "cde_id": "C54100",
-                      "cde_version": null,
-                      "source": "NCIt",
-                      "term": "Universally Unique Identifier",
-                      "term_url": "https://ncit.nci.nih.gov/ncitbrowser/ConceptReport.jsp?dictionary=NCI_Thesaurus&version=16.02d&ns=NCI_Thesaurus&code=C54100"
-                    }
-                  },
-                  "type": "string"
-                },
-                "submitter_id": {
-                  "type": "string"
-                }
-              },
-              "type": "object"
-            },
-            "type": "array"
-          },
-          {
-            "additionalProperties": true,
-            "properties": {
-              "id": {
-                "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
-                "term": {
-                  "description": "A 128-bit identifier. Depending on the mechanism used to generate it, it is either guaranteed to be different from all other UUIDs/GUIDs generated until 3400 AD or extremely likely to be different. Its relatively small size lends itself well to sorting, ordering, and hashing of all sorts, storing in databases, simple allocation, and ease of programming in general.\n",
-                  "termDef": {
-                    "cde_id": "C54100",
-                    "cde_version": null,
-                    "source": "NCIt",
-                    "term": "Universally Unique Identifier",
-                    "term_url": "https://ncit.nci.nih.gov/ncitbrowser/ConceptReport.jsp?dictionary=NCI_Thesaurus&version=16.02d&ns=NCI_Thesaurus&code=C54100"
-                  }
-                },
-                "type": "string"
-              },
-              "submitter_id": {
-                "type": "string"
-              }
-            },
-            "type": "object"
-          }
-        ]
-      },
-      "md5sum": {
-        "term": {
-          "description": "The 128-bit hash value expressed as a 32 digit hexadecimal number used as a file's digital fingerprint.\n"
-        },
-        "type": "string"
-      },
-      "object_id": {
-        "description": "The GUID of the object in the index service.",
-        "type": "string"
-      },
-      "project_id": {
-        "term": {
-          "description": "Unique ID for any specific defined piece of work that is undertaken or attempted to meet a single requirement.\n"
-        },
-        "type": "string"
-      },
-      "state": {
-        "default": "validated",
-        "downloadable": [
-          "uploaded",
-          "md5summed",
-          "validating",
-          "validated",
-          "error",
-          "invalid",
-          "released"
-        ],
-        "oneOf": [
-          {
-            "enum": [
-              "uploading",
-              "uploaded",
-              "md5summing",
-              "md5summed",
-              "validating",
-              "error",
-              "invalid",
-              "suppressed",
-              "redacted",
-              "live"
-            ]
-          },
-          {
-            "enum": [
-              "validated",
-              "submitted",
-              "released"
-            ]
-          }
-        ],
-        "public": [
-          "live"
-        ],
-        "term": {
-          "description": "The current state of the object.\n"
-        }
-      },
-      "submitter_id": {
-        "description": "A project-specific identifier for a node. This property is the calling card/nickname/alias for a unit of submission. It can be used in place of the UUID for identifying or recalling a node.\n",
-        "type": [
-          "string"
-        ]
-      },
-      "type": {
-        "type": "string"
-      },
-      "updated_datetime": {
-        "oneOf": [
-          {
-            "format": "date-time",
-            "type": "string"
-          },
-          {
-            "type": "null"
-          }
-        ],
-        "term": {
-          "description": "A combination of date and time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]\n"
-        }
-      }
-    },
-    "required": [
-      "submitter_id",
-      "type",
-      "file_name",
-      "file_size",
-      "md5sum",
-      "data_category",
-      "data_type",
-      "data_format",
-      "assay_target"
-    ],
-    "submittable": true,
-    "systemProperties": [
-      "id",
-      "project_id",
-      "created_datetime",
-      "updated_datetime",
-      "state",
-      "file_state",
-      "error_type"
-    ],
-    "title": "Mass Cytometry Image",
     "type": "object",
     "uniqueKeys": [
       [
@@ -14870,14 +7642,7 @@
           },
           "subgroup": {
             "items": {
-              "oneOf": [
-                {
-                  "$ref": "#/definitions/link"
-                },
-                {
-                  "$ref": "#/definitions/link_subgroup"
-                }
-              ]
+              "$ref": "#/definitions/link"
             },
             "type": "array"
           }
@@ -14993,1133 +7758,6 @@
       "id"
     ],
     "title": "GDC JSON schema extension"
-  },
-  "molecular_tagging_workflow": {
-    "$schema": "http://json-schema.org/draft-04/schema#",
-    "additionalProperties": false,
-    "category": "analysis",
-    "description": "A description of the specific bioinformatics workflow or pipeline used for molecular tagging of sequenced reads.\n",
-    "id": "molecular_tagging_workflow",
-    "links": [
-      {
-        "exclusive": true,
-        "required": true,
-        "subgroup": [
-          {
-            "backref": "associated_molecular_tagging_workflows_aligned",
-            "label": "performed_on",
-            "multiplicity": "many_to_many",
-            "name": "input_submitted_aligned_reads_files",
-            "required": false,
-            "target_type": "submitted_aligned_reads"
-          },
-          {
-            "backref": "associated_molecular_tagging_workflows_unaligned",
-            "label": "performed_on",
-            "multiplicity": "many_to_many",
-            "name": "input_submitted_unaligned_reads_files",
-            "required": false,
-            "target_type": "submitted_unaligned_reads"
-          }
-        ]
-      },
-      {
-        "backref": "molecular_tagging_workflows",
-        "label": "generate",
-        "multiplicity": "one_to_one",
-        "name": "output_submitted_aligned_reads_files",
-        "required": true,
-        "target_type": "submitted_aligned_reads"
-      }
-    ],
-    "namespace": "https://www.bloodpac.org",
-    "program": "*",
-    "project": "*",
-    "properties": {
-      "created_datetime": {
-        "oneOf": [
-          {
-            "format": "date-time",
-            "type": "string"
-          },
-          {
-            "type": "null"
-          }
-        ],
-        "term": {
-          "description": "A combination of date and time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]\n"
-        }
-      },
-      "id": {
-        "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
-        "systemAlias": "node_id",
-        "term": {
-          "description": "A 128-bit identifier. Depending on the mechanism used to generate it, it is either guaranteed to be different from all other UUIDs/GUIDs generated until 3400 AD or extremely likely to be different. Its relatively small size lends itself well to sorting, ordering, and hashing of all sorts, storing in databases, simple allocation, and ease of programming in general.\n",
-          "termDef": {
-            "cde_id": "C54100",
-            "cde_version": null,
-            "source": "NCIt",
-            "term": "Universally Unique Identifier",
-            "term_url": "https://ncit.nci.nih.gov/ncitbrowser/ConceptReport.jsp?dictionary=NCI_Thesaurus&version=16.02d&ns=NCI_Thesaurus&code=C54100"
-          }
-        },
-        "type": "string"
-      },
-      "input_submitted_aligned_reads_files": {
-        "anyOf": [
-          {
-            "items": {
-              "additionalProperties": true,
-              "minItems": 1,
-              "properties": {
-                "id": {
-                  "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
-                  "term": {
-                    "description": "A 128-bit identifier. Depending on the mechanism used to generate it, it is either guaranteed to be different from all other UUIDs/GUIDs generated until 3400 AD or extremely likely to be different. Its relatively small size lends itself well to sorting, ordering, and hashing of all sorts, storing in databases, simple allocation, and ease of programming in general.\n",
-                    "termDef": {
-                      "cde_id": "C54100",
-                      "cde_version": null,
-                      "source": "NCIt",
-                      "term": "Universally Unique Identifier",
-                      "term_url": "https://ncit.nci.nih.gov/ncitbrowser/ConceptReport.jsp?dictionary=NCI_Thesaurus&version=16.02d&ns=NCI_Thesaurus&code=C54100"
-                    }
-                  },
-                  "type": "string"
-                },
-                "submitter_id": {
-                  "type": "string"
-                }
-              },
-              "type": "object"
-            },
-            "type": "array"
-          },
-          {
-            "additionalProperties": true,
-            "properties": {
-              "id": {
-                "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
-                "term": {
-                  "description": "A 128-bit identifier. Depending on the mechanism used to generate it, it is either guaranteed to be different from all other UUIDs/GUIDs generated until 3400 AD or extremely likely to be different. Its relatively small size lends itself well to sorting, ordering, and hashing of all sorts, storing in databases, simple allocation, and ease of programming in general.\n",
-                  "termDef": {
-                    "cde_id": "C54100",
-                    "cde_version": null,
-                    "source": "NCIt",
-                    "term": "Universally Unique Identifier",
-                    "term_url": "https://ncit.nci.nih.gov/ncitbrowser/ConceptReport.jsp?dictionary=NCI_Thesaurus&version=16.02d&ns=NCI_Thesaurus&code=C54100"
-                  }
-                },
-                "type": "string"
-              },
-              "submitter_id": {
-                "type": "string"
-              }
-            },
-            "type": "object"
-          }
-        ]
-      },
-      "input_submitted_unaligned_reads_files": {
-        "anyOf": [
-          {
-            "items": {
-              "additionalProperties": true,
-              "minItems": 1,
-              "properties": {
-                "id": {
-                  "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
-                  "term": {
-                    "description": "A 128-bit identifier. Depending on the mechanism used to generate it, it is either guaranteed to be different from all other UUIDs/GUIDs generated until 3400 AD or extremely likely to be different. Its relatively small size lends itself well to sorting, ordering, and hashing of all sorts, storing in databases, simple allocation, and ease of programming in general.\n",
-                    "termDef": {
-                      "cde_id": "C54100",
-                      "cde_version": null,
-                      "source": "NCIt",
-                      "term": "Universally Unique Identifier",
-                      "term_url": "https://ncit.nci.nih.gov/ncitbrowser/ConceptReport.jsp?dictionary=NCI_Thesaurus&version=16.02d&ns=NCI_Thesaurus&code=C54100"
-                    }
-                  },
-                  "type": "string"
-                },
-                "submitter_id": {
-                  "type": "string"
-                }
-              },
-              "type": "object"
-            },
-            "type": "array"
-          },
-          {
-            "additionalProperties": true,
-            "properties": {
-              "id": {
-                "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
-                "term": {
-                  "description": "A 128-bit identifier. Depending on the mechanism used to generate it, it is either guaranteed to be different from all other UUIDs/GUIDs generated until 3400 AD or extremely likely to be different. Its relatively small size lends itself well to sorting, ordering, and hashing of all sorts, storing in databases, simple allocation, and ease of programming in general.\n",
-                  "termDef": {
-                    "cde_id": "C54100",
-                    "cde_version": null,
-                    "source": "NCIt",
-                    "term": "Universally Unique Identifier",
-                    "term_url": "https://ncit.nci.nih.gov/ncitbrowser/ConceptReport.jsp?dictionary=NCI_Thesaurus&version=16.02d&ns=NCI_Thesaurus&code=C54100"
-                  }
-                },
-                "type": "string"
-              },
-              "submitter_id": {
-                "type": "string"
-              }
-            },
-            "type": "object"
-          }
-        ]
-      },
-      "output_submitted_aligned_reads_files": {
-        "anyOf": [
-          {
-            "items": {
-              "additionalProperties": true,
-              "maxItems": 1,
-              "minItems": 1,
-              "properties": {
-                "id": {
-                  "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
-                  "term": {
-                    "description": "A 128-bit identifier. Depending on the mechanism used to generate it, it is either guaranteed to be different from all other UUIDs/GUIDs generated until 3400 AD or extremely likely to be different. Its relatively small size lends itself well to sorting, ordering, and hashing of all sorts, storing in databases, simple allocation, and ease of programming in general.\n",
-                    "termDef": {
-                      "cde_id": "C54100",
-                      "cde_version": null,
-                      "source": "NCIt",
-                      "term": "Universally Unique Identifier",
-                      "term_url": "https://ncit.nci.nih.gov/ncitbrowser/ConceptReport.jsp?dictionary=NCI_Thesaurus&version=16.02d&ns=NCI_Thesaurus&code=C54100"
-                    }
-                  },
-                  "type": "string"
-                },
-                "submitter_id": {
-                  "type": "string"
-                }
-              },
-              "type": "object"
-            },
-            "type": "array"
-          },
-          {
-            "additionalProperties": true,
-            "properties": {
-              "id": {
-                "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
-                "term": {
-                  "description": "A 128-bit identifier. Depending on the mechanism used to generate it, it is either guaranteed to be different from all other UUIDs/GUIDs generated until 3400 AD or extremely likely to be different. Its relatively small size lends itself well to sorting, ordering, and hashing of all sorts, storing in databases, simple allocation, and ease of programming in general.\n",
-                  "termDef": {
-                    "cde_id": "C54100",
-                    "cde_version": null,
-                    "source": "NCIt",
-                    "term": "Universally Unique Identifier",
-                    "term_url": "https://ncit.nci.nih.gov/ncitbrowser/ConceptReport.jsp?dictionary=NCI_Thesaurus&version=16.02d&ns=NCI_Thesaurus&code=C54100"
-                  }
-                },
-                "type": "string"
-              },
-              "submitter_id": {
-                "type": "string"
-              }
-            },
-            "type": "object"
-          }
-        ]
-      },
-      "project_id": {
-        "term": {
-          "description": "Unique ID for any specific defined piece of work that is undertaken or attempted to meet a single requirement.\n"
-        },
-        "type": "string"
-      },
-      "state": {
-        "default": "validated",
-        "downloadable": [
-          "uploaded",
-          "md5summed",
-          "validating",
-          "validated",
-          "error",
-          "invalid",
-          "released"
-        ],
-        "oneOf": [
-          {
-            "enum": [
-              "uploading",
-              "uploaded",
-              "md5summing",
-              "md5summed",
-              "validating",
-              "error",
-              "invalid",
-              "suppressed",
-              "redacted",
-              "live"
-            ]
-          },
-          {
-            "enum": [
-              "validated",
-              "submitted",
-              "released"
-            ]
-          }
-        ],
-        "public": [
-          "live"
-        ],
-        "term": {
-          "description": "The current state of the object.\n"
-        }
-      },
-      "submitter_id": {
-        "description": "A project-specific identifier for a node. This property is the calling card/nickname/alias for a unit of submission. It can be used in place of the UUID for identifying or recalling a node.\n",
-        "type": [
-          "string"
-        ]
-      },
-      "type": {
-        "type": "string"
-      },
-      "updated_datetime": {
-        "oneOf": [
-          {
-            "format": "date-time",
-            "type": "string"
-          },
-          {
-            "type": "null"
-          }
-        ],
-        "term": {
-          "description": "A combination of date and time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]\n"
-        }
-      },
-      "workflow_description": {
-        "description": "A brief description of the workflow or pipeline used to generate the data.",
-        "type": "string"
-      },
-      "workflow_end_datetime": {
-        "oneOf": [
-          {
-            "format": "date-time",
-            "type": "string"
-          },
-          {
-            "type": "null"
-          }
-        ],
-        "term": {
-          "description": "A combination of date and time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]\n"
-        }
-      },
-      "workflow_link": {
-        "description": "Link to Github hash for the CWL workflow used.",
-        "type": "string"
-      },
-      "workflow_name": {
-        "description": "The name of an encapsulated bioinformatics workflow or pipeline.",
-        "type": "string"
-      },
-      "workflow_start_datetime": {
-        "oneOf": [
-          {
-            "format": "date-time",
-            "type": "string"
-          },
-          {
-            "type": "null"
-          }
-        ],
-        "term": {
-          "description": "A combination of date and time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]\n"
-        }
-      },
-      "workflow_version": {
-        "description": "Major version for a GDC workflow.",
-        "type": "string"
-      }
-    },
-    "required": [
-      "submitter_id",
-      "type",
-      "workflow_name",
-      "workflow_version",
-      "workflow_description"
-    ],
-    "submittable": true,
-    "systemProperties": [
-      "id",
-      "project_id",
-      "created_datetime",
-      "updated_datetime",
-      "state",
-      "file_state",
-      "error_type"
-    ],
-    "title": "Molecular Tagging Workflow",
-    "type": "object",
-    "uniqueKeys": [
-      [
-        "id"
-      ],
-      [
-        "project_id",
-        "submitter_id"
-      ]
-    ],
-    "validators": null
-  },
-  "pcr_assay": {
-    "$schema": "http://json-schema.org/draft-04/schema#",
-    "additionalProperties": false,
-    "category": "notation",
-    "description": "Information pertaining to processed results obtained from a PCR assay.\n",
-    "id": "pcr_assay",
-    "links": [
-      {
-        "backref": "pcr_assays",
-        "label": "data_from",
-        "multiplicity": "many_to_one",
-        "name": "analytes",
-        "required": true,
-        "target_type": "analyte"
-      }
-    ],
-    "namespace": "https://www.bloodpac.org",
-    "program": "*",
-    "project": "*",
-    "properties": {
-      "analytes": {
-        "anyOf": [
-          {
-            "items": {
-              "additionalProperties": true,
-              "maxItems": 1,
-              "minItems": 1,
-              "properties": {
-                "id": {
-                  "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
-                  "term": {
-                    "description": "A 128-bit identifier. Depending on the mechanism used to generate it, it is either guaranteed to be different from all other UUIDs/GUIDs generated until 3400 AD or extremely likely to be different. Its relatively small size lends itself well to sorting, ordering, and hashing of all sorts, storing in databases, simple allocation, and ease of programming in general.\n",
-                    "termDef": {
-                      "cde_id": "C54100",
-                      "cde_version": null,
-                      "source": "NCIt",
-                      "term": "Universally Unique Identifier",
-                      "term_url": "https://ncit.nci.nih.gov/ncitbrowser/ConceptReport.jsp?dictionary=NCI_Thesaurus&version=16.02d&ns=NCI_Thesaurus&code=C54100"
-                    }
-                  },
-                  "type": "string"
-                },
-                "submitter_id": {
-                  "type": "string"
-                }
-              },
-              "type": "object"
-            },
-            "type": "array"
-          },
-          {
-            "additionalProperties": true,
-            "properties": {
-              "id": {
-                "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
-                "term": {
-                  "description": "A 128-bit identifier. Depending on the mechanism used to generate it, it is either guaranteed to be different from all other UUIDs/GUIDs generated until 3400 AD or extremely likely to be different. Its relatively small size lends itself well to sorting, ordering, and hashing of all sorts, storing in databases, simple allocation, and ease of programming in general.\n",
-                  "termDef": {
-                    "cde_id": "C54100",
-                    "cde_version": null,
-                    "source": "NCIt",
-                    "term": "Universally Unique Identifier",
-                    "term_url": "https://ncit.nci.nih.gov/ncitbrowser/ConceptReport.jsp?dictionary=NCI_Thesaurus&version=16.02d&ns=NCI_Thesaurus&code=C54100"
-                  }
-                },
-                "type": "string"
-              },
-              "submitter_id": {
-                "type": "string"
-              }
-            },
-            "type": "object"
-          }
-        ]
-      },
-      "assay_instrument": {
-        "description": "The specific instrument type used to perform the assay.",
-        "enum": [
-          "BD Flow Cytometer",
-          "Bio-Rad",
-          "QuantStudio",
-          "Qiagen Rotor-Gene Q"
-        ]
-      },
-      "assay_instrument_model": {
-        "description": "The specific model of instrument used to perform the assay.",
-        "enum": [
-          "BD Accuri C6 Flow Cytometer",
-          "Bio-Rad QX100",
-          "Bio-Rad QX200",
-          "QuantStudio Dx",
-          "Qiagen Rotor-Gene Q 5plex HRM"
-        ]
-      },
-      "assay_kit_name": {
-        "description": "Name of the assay kit used.",
-        "type": "string"
-      },
-      "assay_kit_vendor": {
-        "description": "Vendor that provided the assay kit.",
-        "type": "string"
-      },
-      "assay_kit_version": {
-        "description": "Version of the assay kit used.",
-        "type": "string"
-      },
-      "assay_method": {
-        "description": "General methodology used to perform the assay (e.g. PCR, Sequencing).",
-        "enum": [
-          "Amplification-Refactory Mutation System",
-          "BEAMing Digital",
-          "Digital Droplet",
-          "TaqMan"
-        ]
-      },
-      "assay_target": {
-        "description": "Target for the assay: can be a gene, protein, or otherwise.",
-        "type": "string"
-      },
-      "created_datetime": {
-        "oneOf": [
-          {
-            "format": "date-time",
-            "type": "string"
-          },
-          {
-            "type": "null"
-          }
-        ],
-        "term": {
-          "description": "A combination of date and time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]\n"
-        }
-      },
-      "id": {
-        "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
-        "systemAlias": "node_id",
-        "term": {
-          "description": "A 128-bit identifier. Depending on the mechanism used to generate it, it is either guaranteed to be different from all other UUIDs/GUIDs generated until 3400 AD or extremely likely to be different. Its relatively small size lends itself well to sorting, ordering, and hashing of all sorts, storing in databases, simple allocation, and ease of programming in general.\n",
-          "termDef": {
-            "cde_id": "C54100",
-            "cde_version": null,
-            "source": "NCIt",
-            "term": "Universally Unique Identifier",
-            "term_url": "https://ncit.nci.nih.gov/ncitbrowser/ConceptReport.jsp?dictionary=NCI_Thesaurus&version=16.02d&ns=NCI_Thesaurus&code=C54100"
-          }
-        },
-        "type": "string"
-      },
-      "mutant_copies": {
-        "description": "Mutant DNA absolute copies in the ctDNA. Requires copies_unit.",
-        "type": "integer"
-      },
-      "mutant_fraction_percent": {
-        "description": "Percent of the target that is identified as mutant.",
-        "type": "number"
-      },
-      "mutation_result": {
-        "description": "Observed mutation type.",
-        "enum": [
-          "Missense",
-          "Nonsense",
-          "Insertion",
-          "Deleteion",
-          "Deletion",
-          "Duplication",
-          "Frameshift",
-          "Unspecified",
-          "No Mutation Detected"
-        ]
-      },
-      "project_id": {
-        "term": {
-          "description": "Unique ID for any specific defined piece of work that is undertaken or attempted to meet a single requirement.\n"
-        },
-        "type": "string"
-      },
-      "state": {
-        "default": "validated",
-        "downloadable": [
-          "uploaded",
-          "md5summed",
-          "validating",
-          "validated",
-          "error",
-          "invalid",
-          "released"
-        ],
-        "oneOf": [
-          {
-            "enum": [
-              "uploading",
-              "uploaded",
-              "md5summing",
-              "md5summed",
-              "validating",
-              "error",
-              "invalid",
-              "suppressed",
-              "redacted",
-              "live"
-            ]
-          },
-          {
-            "enum": [
-              "validated",
-              "submitted",
-              "released"
-            ]
-          }
-        ],
-        "public": [
-          "live"
-        ],
-        "term": {
-          "description": "The current state of the object.\n"
-        }
-      },
-      "submitter_id": {
-        "description": "A project-specific identifier for a node. This property is the calling card/nickname/alias for a unit of submission. It can be used in place of the UUID for identifying or recalling a node.\n",
-        "type": [
-          "string"
-        ]
-      },
-      "target_alt": {
-        "description": "The observed alternate sequence for the genomic region being investigated.",
-        "type": "string"
-      },
-      "target_chromosome": {
-        "description": "The chromosome on which the gene of interest is located.",
-        "enum": [
-          "1",
-          "2",
-          "3",
-          "4",
-          "5",
-          "6",
-          "7",
-          "8",
-          "9",
-          "10",
-          "11",
-          "12",
-          "13",
-          "14",
-          "15",
-          "16",
-          "17",
-          "18",
-          "19",
-          "20",
-          "21",
-          "22",
-          "X",
-          "Y"
-        ]
-      },
-      "target_position": {
-        "description": "The position on the chromosome on which the gene of interest is located.",
-        "type": "integer"
-      },
-      "target_ref": {
-        "description": "The reference sequence for the genomic region that is being investigated.",
-        "type": "string"
-      },
-      "type": {
-        "type": "string"
-      },
-      "updated_datetime": {
-        "oneOf": [
-          {
-            "format": "date-time",
-            "type": "string"
-          },
-          {
-            "type": "null"
-          }
-        ],
-        "term": {
-          "description": "A combination of date and time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]\n"
-        }
-      }
-    },
-    "required": [
-      "submitter_id",
-      "type",
-      "assay_instrument",
-      "assay_instrument_model",
-      "assay_method",
-      "analytes"
-    ],
-    "submittable": true,
-    "systemProperties": [
-      "id",
-      "project_id",
-      "created_datetime",
-      "updated_datetime",
-      "state"
-    ],
-    "title": "PCR Assay",
-    "type": "object",
-    "uniqueKeys": [
-      [
-        "id"
-      ],
-      [
-        "project_id",
-        "submitter_id"
-      ]
-    ],
-    "validators": null
-  },
-  "pcr_assay_file": {
-    "$schema": "http://json-schema.org/draft-04/schema#",
-    "additionalProperties": false,
-    "category": "data_file",
-    "description": "A data file containing the results of a PCR assay\n",
-    "id": "pcr_assay_file",
-    "links": [
-      {
-        "exclusive": false,
-        "required": true,
-        "subgroup": [
-          {
-            "backref": "pcr_assay_files",
-            "label": "data_from",
-            "multiplicity": "one_to_one",
-            "name": "core_metadata_collections",
-            "required": false,
-            "target_type": "core_metadata_collection"
-          },
-          {
-            "backref": "pcr_assay_files",
-            "label": "data_from",
-            "multiplicity": "many_to_many",
-            "name": "pcr_assays",
-            "required": false,
-            "target_type": "pcr_assay"
-          },
-          {
-            "backref": "pcr_assay_files",
-            "label": "data_from",
-            "multiplicity": "many_to_many",
-            "name": "analytes",
-            "required": false,
-            "target_type": "analyte"
-          }
-        ]
-      }
-    ],
-    "namespace": "https://www.bloodpac.org",
-    "program": "*",
-    "project": "*",
-    "properties": {
-      "analysis_software": {
-        "description": "The software used to process PCR assay raw data.\n",
-        "enum": [
-          "BD Accuri C6",
-          "Q-Rex",
-          "QuantaSoft",
-          "QuantStudio Dx"
-        ]
-      },
-      "analytes": {
-        "anyOf": [
-          {
-            "items": {
-              "additionalProperties": true,
-              "maxItems": 1,
-              "minItems": 1,
-              "properties": {
-                "id": {
-                  "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
-                  "term": {
-                    "description": "A 128-bit identifier. Depending on the mechanism used to generate it, it is either guaranteed to be different from all other UUIDs/GUIDs generated until 3400 AD or extremely likely to be different. Its relatively small size lends itself well to sorting, ordering, and hashing of all sorts, storing in databases, simple allocation, and ease of programming in general.\n",
-                    "termDef": {
-                      "cde_id": "C54100",
-                      "cde_version": null,
-                      "source": "NCIt",
-                      "term": "Universally Unique Identifier",
-                      "term_url": "https://ncit.nci.nih.gov/ncitbrowser/ConceptReport.jsp?dictionary=NCI_Thesaurus&version=16.02d&ns=NCI_Thesaurus&code=C54100"
-                    }
-                  },
-                  "type": "string"
-                },
-                "submitter_id": {
-                  "type": "string"
-                }
-              },
-              "type": "object"
-            },
-            "type": "array"
-          },
-          {
-            "additionalProperties": true,
-            "properties": {
-              "id": {
-                "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
-                "term": {
-                  "description": "A 128-bit identifier. Depending on the mechanism used to generate it, it is either guaranteed to be different from all other UUIDs/GUIDs generated until 3400 AD or extremely likely to be different. Its relatively small size lends itself well to sorting, ordering, and hashing of all sorts, storing in databases, simple allocation, and ease of programming in general.\n",
-                  "termDef": {
-                    "cde_id": "C54100",
-                    "cde_version": null,
-                    "source": "NCIt",
-                    "term": "Universally Unique Identifier",
-                    "term_url": "https://ncit.nci.nih.gov/ncitbrowser/ConceptReport.jsp?dictionary=NCI_Thesaurus&version=16.02d&ns=NCI_Thesaurus&code=C54100"
-                  }
-                },
-                "type": "string"
-              },
-              "submitter_id": {
-                "type": "string"
-              }
-            },
-            "type": "object"
-          }
-        ]
-      },
-      "core_metadata_collections": {
-        "anyOf": [
-          {
-            "items": {
-              "additionalProperties": true,
-              "maxItems": 1,
-              "minItems": 1,
-              "properties": {
-                "id": {
-                  "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
-                  "term": {
-                    "description": "A 128-bit identifier. Depending on the mechanism used to generate it, it is either guaranteed to be different from all other UUIDs/GUIDs generated until 3400 AD or extremely likely to be different. Its relatively small size lends itself well to sorting, ordering, and hashing of all sorts, storing in databases, simple allocation, and ease of programming in general.\n",
-                    "termDef": {
-                      "cde_id": "C54100",
-                      "cde_version": null,
-                      "source": "NCIt",
-                      "term": "Universally Unique Identifier",
-                      "term_url": "https://ncit.nci.nih.gov/ncitbrowser/ConceptReport.jsp?dictionary=NCI_Thesaurus&version=16.02d&ns=NCI_Thesaurus&code=C54100"
-                    }
-                  },
-                  "type": "string"
-                },
-                "submitter_id": {
-                  "type": "string"
-                }
-              },
-              "type": "object"
-            },
-            "type": "array"
-          },
-          {
-            "additionalProperties": true,
-            "properties": {
-              "id": {
-                "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
-                "term": {
-                  "description": "A 128-bit identifier. Depending on the mechanism used to generate it, it is either guaranteed to be different from all other UUIDs/GUIDs generated until 3400 AD or extremely likely to be different. Its relatively small size lends itself well to sorting, ordering, and hashing of all sorts, storing in databases, simple allocation, and ease of programming in general.\n",
-                  "termDef": {
-                    "cde_id": "C54100",
-                    "cde_version": null,
-                    "source": "NCIt",
-                    "term": "Universally Unique Identifier",
-                    "term_url": "https://ncit.nci.nih.gov/ncitbrowser/ConceptReport.jsp?dictionary=NCI_Thesaurus&version=16.02d&ns=NCI_Thesaurus&code=C54100"
-                  }
-                },
-                "type": "string"
-              },
-              "submitter_id": {
-                "type": "string"
-              }
-            },
-            "type": "object"
-          }
-        ]
-      },
-      "created_datetime": {
-        "oneOf": [
-          {
-            "format": "date-time",
-            "type": "string"
-          },
-          {
-            "type": "null"
-          }
-        ],
-        "term": {
-          "description": "A combination of date and time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]\n"
-        }
-      },
-      "data_category": {
-        "enum": [
-          "Mutant Allele Fractions"
-        ],
-        "term": {
-          "description": "Broad categorization of the contents of the data file.\n"
-        }
-      },
-      "data_format": {
-        "enum": [
-          "CSV",
-          "QLB",
-          "QLT",
-          "QLP",
-          "TSV"
-        ],
-        "term": {
-          "description": "Format of the data files.\n"
-        }
-      },
-      "data_type": {
-        "enum": [
-          "Processed Data",
-          "Tabulated Results",
-          "Template",
-          "Unprocessed Data"
-        ],
-        "term": {
-          "description": "Specific content type of the data file.\n"
-        }
-      },
-      "error_type": {
-        "enum": [
-          "file_size",
-          "file_format",
-          "md5sum"
-        ],
-        "term": {
-          "description": "Type of error for the data file object.\n"
-        }
-      },
-      "experimental_strategy": {
-        "enum": [
-          "ddPCR"
-        ],
-        "term": {
-          "description": "The experimental strategy used to generate the data file.\n"
-        }
-      },
-      "file_name": {
-        "term": {
-          "description": "The name (or part of a name) of a file (of any type).\n"
-        },
-        "type": "string"
-      },
-      "file_size": {
-        "term": {
-          "description": "The size of the data file (object) in bytes.\n"
-        },
-        "type": "integer"
-      },
-      "file_state": {
-        "default": "registered",
-        "enum": [
-          "registered",
-          "uploading",
-          "uploaded",
-          "validating",
-          "validated",
-          "submitted",
-          "processing",
-          "processed",
-          "released",
-          "error"
-        ],
-        "term": {
-          "description": "The current state of the data file object.\n"
-        }
-      },
-      "id": {
-        "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
-        "systemAlias": "node_id",
-        "term": {
-          "description": "A 128-bit identifier. Depending on the mechanism used to generate it, it is either guaranteed to be different from all other UUIDs/GUIDs generated until 3400 AD or extremely likely to be different. Its relatively small size lends itself well to sorting, ordering, and hashing of all sorts, storing in databases, simple allocation, and ease of programming in general.\n",
-          "termDef": {
-            "cde_id": "C54100",
-            "cde_version": null,
-            "source": "NCIt",
-            "term": "Universally Unique Identifier",
-            "term_url": "https://ncit.nci.nih.gov/ncitbrowser/ConceptReport.jsp?dictionary=NCI_Thesaurus&version=16.02d&ns=NCI_Thesaurus&code=C54100"
-          }
-        },
-        "type": "string"
-      },
-      "md5sum": {
-        "term": {
-          "description": "The 128-bit hash value expressed as a 32 digit hexadecimal number used as a file's digital fingerprint.\n"
-        },
-        "type": "string"
-      },
-      "object_id": {
-        "description": "The GUID of the object in the index service.",
-        "type": "string"
-      },
-      "pcr_assays": {
-        "anyOf": [
-          {
-            "items": {
-              "additionalProperties": true,
-              "maxItems": 1,
-              "minItems": 1,
-              "properties": {
-                "id": {
-                  "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
-                  "term": {
-                    "description": "A 128-bit identifier. Depending on the mechanism used to generate it, it is either guaranteed to be different from all other UUIDs/GUIDs generated until 3400 AD or extremely likely to be different. Its relatively small size lends itself well to sorting, ordering, and hashing of all sorts, storing in databases, simple allocation, and ease of programming in general.\n",
-                    "termDef": {
-                      "cde_id": "C54100",
-                      "cde_version": null,
-                      "source": "NCIt",
-                      "term": "Universally Unique Identifier",
-                      "term_url": "https://ncit.nci.nih.gov/ncitbrowser/ConceptReport.jsp?dictionary=NCI_Thesaurus&version=16.02d&ns=NCI_Thesaurus&code=C54100"
-                    }
-                  },
-                  "type": "string"
-                },
-                "submitter_id": {
-                  "type": "string"
-                }
-              },
-              "type": "object"
-            },
-            "type": "array"
-          },
-          {
-            "additionalProperties": true,
-            "properties": {
-              "id": {
-                "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
-                "term": {
-                  "description": "A 128-bit identifier. Depending on the mechanism used to generate it, it is either guaranteed to be different from all other UUIDs/GUIDs generated until 3400 AD or extremely likely to be different. Its relatively small size lends itself well to sorting, ordering, and hashing of all sorts, storing in databases, simple allocation, and ease of programming in general.\n",
-                  "termDef": {
-                    "cde_id": "C54100",
-                    "cde_version": null,
-                    "source": "NCIt",
-                    "term": "Universally Unique Identifier",
-                    "term_url": "https://ncit.nci.nih.gov/ncitbrowser/ConceptReport.jsp?dictionary=NCI_Thesaurus&version=16.02d&ns=NCI_Thesaurus&code=C54100"
-                  }
-                },
-                "type": "string"
-              },
-              "submitter_id": {
-                "type": "string"
-              }
-            },
-            "type": "object"
-          }
-        ]
-      },
-      "project_id": {
-        "term": {
-          "description": "Unique ID for any specific defined piece of work that is undertaken or attempted to meet a single requirement.\n"
-        },
-        "type": "string"
-      },
-      "state": {
-        "default": "validated",
-        "downloadable": [
-          "uploaded",
-          "md5summed",
-          "validating",
-          "validated",
-          "error",
-          "invalid",
-          "released"
-        ],
-        "oneOf": [
-          {
-            "enum": [
-              "uploading",
-              "uploaded",
-              "md5summing",
-              "md5summed",
-              "validating",
-              "error",
-              "invalid",
-              "suppressed",
-              "redacted",
-              "live"
-            ]
-          },
-          {
-            "enum": [
-              "validated",
-              "submitted",
-              "released"
-            ]
-          }
-        ],
-        "public": [
-          "live"
-        ],
-        "term": {
-          "description": "The current state of the object.\n"
-        }
-      },
-      "submitter_id": {
-        "description": "A project-specific identifier for a node. This property is the calling card/nickname/alias for a unit of submission. It can be used in place of the UUID for identifying or recalling a node.\n",
-        "type": [
-          "string"
-        ]
-      },
-      "type": {
-        "type": "string"
-      },
-      "updated_datetime": {
-        "oneOf": [
-          {
-            "format": "date-time",
-            "type": "string"
-          },
-          {
-            "type": "null"
-          }
-        ],
-        "term": {
-          "description": "A combination of date and time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]\n"
-        }
-      }
-    },
-    "required": [
-      "submitter_id",
-      "type",
-      "file_name",
-      "file_size",
-      "data_format",
-      "md5sum",
-      "data_category",
-      "data_type",
-      "experimental_strategy"
-    ],
-    "submittable": true,
-    "systemProperties": [
-      "id",
-      "project_id",
-      "created_datetime",
-      "updated_datetime",
-      "state"
-    ],
-    "title": "PCR Assay File",
-    "type": "object",
-    "uniqueKeys": [
-      [
-        "id"
-      ],
-      [
-        "project_id",
-        "submitter_id"
-      ]
-    ],
-    "validators": null
   },
   "program": {
     "$schema": "http://json-schema.org/draft-04/schema#",
@@ -16347,8 +7985,7 @@
     "required": [
       "code",
       "name",
-      "programs",
-      "dbgap_accession_number"
+      "programs"
     ],
     "submittable": true,
     "systemProperties": [
@@ -16370,359 +8007,6 @@
     ],
     "validators": null
   },
-  "protocol": {
-    "$schema": "http://json-schema.org/draft-04/schema#",
-    "additionalProperties": false,
-    "category": "metadata_file",
-    "description": "Data file containing the metadata for the study performed. A space for protocols, panel data, or any data related to the study design.\n",
-    "id": "protocol",
-    "links": [
-      {
-        "exclusive": false,
-        "required": true,
-        "subgroup": [
-          {
-            "backref": "study_metadata_files",
-            "label": "derived_from",
-            "multiplicity": "many_to_many",
-            "name": "studies",
-            "required": false,
-            "target_type": "study"
-          },
-          {
-            "backref": "study_metadata_files",
-            "label": "data_from",
-            "multiplicity": "many_to_one",
-            "name": "core_metadata_collections",
-            "required": false,
-            "target_type": "core_metadata_collection"
-          }
-        ]
-      }
-    ],
-    "namespace": "https://www.bloodpac.org",
-    "program": "*",
-    "project": "*",
-    "properties": {
-      "core_metadata_collections": {
-        "anyOf": [
-          {
-            "items": {
-              "additionalProperties": true,
-              "minItems": 1,
-              "properties": {
-                "id": {
-                  "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
-                  "term": {
-                    "description": "A 128-bit identifier. Depending on the mechanism used to generate it, it is either guaranteed to be different from all other UUIDs/GUIDs generated until 3400 AD or extremely likely to be different. Its relatively small size lends itself well to sorting, ordering, and hashing of all sorts, storing in databases, simple allocation, and ease of programming in general.\n",
-                    "termDef": {
-                      "cde_id": "C54100",
-                      "cde_version": null,
-                      "source": "NCIt",
-                      "term": "Universally Unique Identifier",
-                      "term_url": "https://ncit.nci.nih.gov/ncitbrowser/ConceptReport.jsp?dictionary=NCI_Thesaurus&version=16.02d&ns=NCI_Thesaurus&code=C54100"
-                    }
-                  },
-                  "type": "string"
-                },
-                "submitter_id": {
-                  "type": "string"
-                }
-              },
-              "type": "object"
-            },
-            "type": "array"
-          },
-          {
-            "additionalProperties": true,
-            "properties": {
-              "id": {
-                "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
-                "term": {
-                  "description": "A 128-bit identifier. Depending on the mechanism used to generate it, it is either guaranteed to be different from all other UUIDs/GUIDs generated until 3400 AD or extremely likely to be different. Its relatively small size lends itself well to sorting, ordering, and hashing of all sorts, storing in databases, simple allocation, and ease of programming in general.\n",
-                  "termDef": {
-                    "cde_id": "C54100",
-                    "cde_version": null,
-                    "source": "NCIt",
-                    "term": "Universally Unique Identifier",
-                    "term_url": "https://ncit.nci.nih.gov/ncitbrowser/ConceptReport.jsp?dictionary=NCI_Thesaurus&version=16.02d&ns=NCI_Thesaurus&code=C54100"
-                  }
-                },
-                "type": "string"
-              },
-              "submitter_id": {
-                "type": "string"
-              }
-            },
-            "type": "object"
-          }
-        ]
-      },
-      "created_datetime": {
-        "oneOf": [
-          {
-            "format": "date-time",
-            "type": "string"
-          },
-          {
-            "type": "null"
-          }
-        ],
-        "term": {
-          "description": "A combination of date and time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]\n"
-        }
-      },
-      "data_category": {
-        "enum": [
-          "Experimental Metadata",
-          "Biospecimen Metadata"
-        ],
-        "term": {
-          "description": "Broad categorization of the contents of the data file.\n"
-        }
-      },
-      "data_format": {
-        "enum": [
-          "EXCEL",
-          "PDF",
-          "TXT"
-        ],
-        "term": {
-          "description": "Format of the data files.\n"
-        }
-      },
-      "data_type": {
-        "enum": [
-          "Collection and Shipping SOP",
-          "Testing Protocol",
-          "Testing Kit/Panel Information",
-          "Sample Preparation SOP"
-        ],
-        "term": {
-          "description": "Specific content type of the data file.\n"
-        }
-      },
-      "error_type": {
-        "enum": [
-          "file_size",
-          "file_format",
-          "md5sum"
-        ],
-        "term": {
-          "description": "Type of error for the data file object.\n"
-        }
-      },
-      "file_name": {
-        "term": {
-          "description": "The name (or part of a name) of a file (of any type).\n"
-        },
-        "type": "string"
-      },
-      "file_size": {
-        "term": {
-          "description": "The size of the data file (object) in bytes.\n"
-        },
-        "type": "integer"
-      },
-      "file_state": {
-        "default": "registered",
-        "enum": [
-          "registered",
-          "uploading",
-          "uploaded",
-          "validating",
-          "validated",
-          "submitted",
-          "processing",
-          "processed",
-          "released",
-          "error"
-        ],
-        "term": {
-          "description": "The current state of the data file object.\n"
-        }
-      },
-      "id": {
-        "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
-        "systemAlias": "node_id",
-        "term": {
-          "description": "A 128-bit identifier. Depending on the mechanism used to generate it, it is either guaranteed to be different from all other UUIDs/GUIDs generated until 3400 AD or extremely likely to be different. Its relatively small size lends itself well to sorting, ordering, and hashing of all sorts, storing in databases, simple allocation, and ease of programming in general.\n",
-          "termDef": {
-            "cde_id": "C54100",
-            "cde_version": null,
-            "source": "NCIt",
-            "term": "Universally Unique Identifier",
-            "term_url": "https://ncit.nci.nih.gov/ncitbrowser/ConceptReport.jsp?dictionary=NCI_Thesaurus&version=16.02d&ns=NCI_Thesaurus&code=C54100"
-          }
-        },
-        "type": "string"
-      },
-      "md5sum": {
-        "term": {
-          "description": "The 128-bit hash value expressed as a 32 digit hexadecimal number used as a file's digital fingerprint.\n"
-        },
-        "type": "string"
-      },
-      "object_id": {
-        "description": "The GUID of the object in the index service.",
-        "type": "string"
-      },
-      "project_id": {
-        "term": {
-          "description": "Unique ID for any specific defined piece of work that is undertaken or attempted to meet a single requirement.\n"
-        },
-        "type": "string"
-      },
-      "state": {
-        "default": "validated",
-        "downloadable": [
-          "uploaded",
-          "md5summed",
-          "validating",
-          "validated",
-          "error",
-          "invalid",
-          "released"
-        ],
-        "oneOf": [
-          {
-            "enum": [
-              "uploading",
-              "uploaded",
-              "md5summing",
-              "md5summed",
-              "validating",
-              "error",
-              "invalid",
-              "suppressed",
-              "redacted",
-              "live"
-            ]
-          },
-          {
-            "enum": [
-              "validated",
-              "submitted",
-              "released"
-            ]
-          }
-        ],
-        "public": [
-          "live"
-        ],
-        "term": {
-          "description": "The current state of the object.\n"
-        }
-      },
-      "studies": {
-        "anyOf": [
-          {
-            "items": {
-              "additionalProperties": true,
-              "minItems": 1,
-              "properties": {
-                "id": {
-                  "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
-                  "term": {
-                    "description": "A 128-bit identifier. Depending on the mechanism used to generate it, it is either guaranteed to be different from all other UUIDs/GUIDs generated until 3400 AD or extremely likely to be different. Its relatively small size lends itself well to sorting, ordering, and hashing of all sorts, storing in databases, simple allocation, and ease of programming in general.\n",
-                    "termDef": {
-                      "cde_id": "C54100",
-                      "cde_version": null,
-                      "source": "NCIt",
-                      "term": "Universally Unique Identifier",
-                      "term_url": "https://ncit.nci.nih.gov/ncitbrowser/ConceptReport.jsp?dictionary=NCI_Thesaurus&version=16.02d&ns=NCI_Thesaurus&code=C54100"
-                    }
-                  },
-                  "type": "string"
-                },
-                "submitter_id": {
-                  "type": "string"
-                }
-              },
-              "type": "object"
-            },
-            "type": "array"
-          },
-          {
-            "additionalProperties": true,
-            "properties": {
-              "id": {
-                "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
-                "term": {
-                  "description": "A 128-bit identifier. Depending on the mechanism used to generate it, it is either guaranteed to be different from all other UUIDs/GUIDs generated until 3400 AD or extremely likely to be different. Its relatively small size lends itself well to sorting, ordering, and hashing of all sorts, storing in databases, simple allocation, and ease of programming in general.\n",
-                  "termDef": {
-                    "cde_id": "C54100",
-                    "cde_version": null,
-                    "source": "NCIt",
-                    "term": "Universally Unique Identifier",
-                    "term_url": "https://ncit.nci.nih.gov/ncitbrowser/ConceptReport.jsp?dictionary=NCI_Thesaurus&version=16.02d&ns=NCI_Thesaurus&code=C54100"
-                  }
-                },
-                "type": "string"
-              },
-              "submitter_id": {
-                "type": "string"
-              }
-            },
-            "type": "object"
-          }
-        ]
-      },
-      "submitter_id": {
-        "description": "A project-specific identifier for a node. This property is the calling card/nickname/alias for a unit of submission. It can be used in place of the UUID for identifying or recalling a node.\n",
-        "type": [
-          "string"
-        ]
-      },
-      "type": {
-        "type": "string"
-      },
-      "updated_datetime": {
-        "oneOf": [
-          {
-            "format": "date-time",
-            "type": "string"
-          },
-          {
-            "type": "null"
-          }
-        ],
-        "term": {
-          "description": "A combination of date and time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]\n"
-        }
-      }
-    },
-    "required": [
-      "submitter_id",
-      "type",
-      "file_name",
-      "data_category",
-      "data_type",
-      "data_format"
-    ],
-    "submittable": true,
-    "systemProperties": [
-      "id",
-      "project_id",
-      "created_datetime",
-      "updated_datetime",
-      "state",
-      "file_state",
-      "error_type"
-    ],
-    "title": "Protocol",
-    "type": "object",
-    "uniqueKeys": [
-      [
-        "id"
-      ],
-      [
-        "project_id",
-        "submitter_id"
-      ]
-    ],
-    "validators": null
-  },
   "publication": {
     "$schema": "http://json-schema.org/draft-04/schema#",
     "additionalProperties": false,
@@ -16739,7 +8023,7 @@
         "target_type": "project"
       }
     ],
-    "namespace": "https://www.bloodpac.org",
+    "namespace": "http://gdc.nci.nih.gov",
     "program": "*",
     "project": "*",
     "properties": {
@@ -16779,9 +8063,6 @@
         "type": "string"
       },
       "project_id": {
-        "term": {
-          "description": "Unique ID for any specific defined piece of work that is undertaken or attempted to meet a single requirement.\n"
-        },
         "type": "string"
       },
       "projects": {
@@ -16791,9 +8072,6 @@
               "additionalProperties": true,
               "minItems": 1,
               "properties": {
-                "code": {
-                  "type": "string"
-                },
                 "id": {
                   "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
                   "term": {
@@ -16807,6 +8085,9 @@
                     }
                   },
                   "type": "string"
+                },
+                "submitter_id": {
+                  "type": "string"
                 }
               },
               "type": "object"
@@ -16816,9 +8097,6 @@
           {
             "additionalProperties": true,
             "properties": {
-              "code": {
-                "type": "string"
-              },
               "id": {
                 "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
                 "term": {
@@ -16831,6 +8109,9 @@
                     "term_url": "https://ncit.nci.nih.gov/ncitbrowser/ConceptReport.jsp?dictionary=NCI_Thesaurus&version=16.02d&ns=NCI_Thesaurus&code=C54100"
                   }
                 },
+                "type": "string"
+              },
+              "submitter_id": {
                 "type": "string"
               }
             },
@@ -16880,13 +8161,15 @@
         }
       },
       "submitter_id": {
-        "description": "A project-specific identifier for a node. This property is the calling card/nickname/alias for a unit of submission. It can be used in place of the UUID for identifying or recalling a node.\n",
         "type": [
-          "string"
+          "string",
+          "null"
         ]
       },
       "type": {
-        "type": "string"
+        "enum": [
+          "publication"
+        ]
       },
       "updated_datetime": {
         "oneOf": [
@@ -16905,7 +8188,6 @@
     },
     "required": [
       "submitter_id",
-      "type",
       "projects"
     ],
     "submittable": true,
@@ -16929,850 +8211,6 @@
     ],
     "validators": null
   },
-  "quantification_assay": {
-    "$schema": "http://json-schema.org/draft-04/schema#",
-    "additionalProperties": false,
-    "category": "notation",
-    "description": "Information pertaining to processed results obtained from a quantification assay.\n",
-    "id": "quantification_assay",
-    "links": [
-      {
-        "backref": "quantification_assays",
-        "label": "data_from",
-        "multiplicity": "many_to_one",
-        "name": "analytes",
-        "required": true,
-        "target_type": "analyte"
-      }
-    ],
-    "namespace": "https://www.bloodpac.org",
-    "program": "*",
-    "project": "*",
-    "properties": {
-      "analytes": {
-        "anyOf": [
-          {
-            "items": {
-              "additionalProperties": true,
-              "maxItems": 1,
-              "minItems": 1,
-              "properties": {
-                "id": {
-                  "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
-                  "term": {
-                    "description": "A 128-bit identifier. Depending on the mechanism used to generate it, it is either guaranteed to be different from all other UUIDs/GUIDs generated until 3400 AD or extremely likely to be different. Its relatively small size lends itself well to sorting, ordering, and hashing of all sorts, storing in databases, simple allocation, and ease of programming in general.\n",
-                    "termDef": {
-                      "cde_id": "C54100",
-                      "cde_version": null,
-                      "source": "NCIt",
-                      "term": "Universally Unique Identifier",
-                      "term_url": "https://ncit.nci.nih.gov/ncitbrowser/ConceptReport.jsp?dictionary=NCI_Thesaurus&version=16.02d&ns=NCI_Thesaurus&code=C54100"
-                    }
-                  },
-                  "type": "string"
-                },
-                "submitter_id": {
-                  "type": "string"
-                }
-              },
-              "type": "object"
-            },
-            "type": "array"
-          },
-          {
-            "additionalProperties": true,
-            "properties": {
-              "id": {
-                "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
-                "term": {
-                  "description": "A 128-bit identifier. Depending on the mechanism used to generate it, it is either guaranteed to be different from all other UUIDs/GUIDs generated until 3400 AD or extremely likely to be different. Its relatively small size lends itself well to sorting, ordering, and hashing of all sorts, storing in databases, simple allocation, and ease of programming in general.\n",
-                  "termDef": {
-                    "cde_id": "C54100",
-                    "cde_version": null,
-                    "source": "NCIt",
-                    "term": "Universally Unique Identifier",
-                    "term_url": "https://ncit.nci.nih.gov/ncitbrowser/ConceptReport.jsp?dictionary=NCI_Thesaurus&version=16.02d&ns=NCI_Thesaurus&code=C54100"
-                  }
-                },
-                "type": "string"
-              },
-              "submitter_id": {
-                "type": "string"
-              }
-            },
-            "type": "object"
-          }
-        ]
-      },
-      "assay_instrument": {
-        "description": "The specific instrument type used to perform the assay.",
-        "enum": [
-          "ABI QuantStudio",
-          "Agilent TapeStation",
-          "Applied Biosystems Real-Time PCR System",
-          "BioTek",
-          "CytoTrapNano CTC Platform",
-          "Epic Sciences CTC Platform",
-          "Fragment Analyzer",
-          "HD-SCA Platform",
-          "Molecular Devices SpectraMax",
-          "Qubit"
-        ]
-      },
-      "assay_instrument_mode": {
-        "description": "The specific mode an instrument was run in (e.g., High Sensitivity).",
-        "type": "string"
-      },
-      "assay_instrument_model": {
-        "description": "The specific model of instrument used to perform the assay.",
-        "enum": [
-          "ABI 7500 Fast Dx Real-Time PCR",
-          "ABI QuantStudio 5",
-          "Advanced Analytical Fragment Analyzer",
-          "Agilent 2200 TapeStation",
-          "Agilent 4200 TapeStation",
-          "Agilent Bioanalyzer 2100",
-          "BioTek Synergy 4",
-          "C88801-RU",
-          "ESRUO-01",
-          "Fluidigm Hyperion",
-          "HDSCA Enumeration",
-          "Molecular Devices SpectraMax M2",
-          "Qubit 3.0"
-        ]
-      },
-      "assay_kit_name": {
-        "description": "Name of the assay kit used.",
-        "type": "string"
-      },
-      "assay_kit_vendor": {
-        "description": "Vendor that provided the assay kit.",
-        "type": "string"
-      },
-      "assay_kit_version": {
-        "description": "Version of the assay kit used.",
-        "type": "string"
-      },
-      "assay_method": {
-        "description": "General methodology used to perform the assay (e.g. PCR, Sequencing).",
-        "enum": [
-          "DNA Electrophoresis",
-          "Fluorometer",
-          "Immunohistochemistry",
-          "qPCR"
-        ]
-      },
-      "cell_concentration": {
-        "description": "If the analyte is cell count, report the concentrations of the cells in the aliquot (counted cells per assay volume mL). Report the calculated concentration in cells per milliliters.\n",
-        "type": "number"
-      },
-      "cell_count": {
-        "description": "If the analyte is cell count, report total whole number of cells counted here.\n",
-        "type": "integer"
-      },
-      "created_datetime": {
-        "oneOf": [
-          {
-            "format": "date-time",
-            "type": "string"
-          },
-          {
-            "type": "null"
-          }
-        ],
-        "term": {
-          "description": "A combination of date and time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]\n"
-        }
-      },
-      "experimental_step": {
-        "description": "A description of the experimental purpose or step for which the assay was performed.",
-        "enum": [
-          "DNA Extraction",
-          "Library Building"
-        ]
-      },
-      "id": {
-        "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
-        "systemAlias": "node_id",
-        "term": {
-          "description": "A 128-bit identifier. Depending on the mechanism used to generate it, it is either guaranteed to be different from all other UUIDs/GUIDs generated until 3400 AD or extremely likely to be different. Its relatively small size lends itself well to sorting, ordering, and hashing of all sorts, storing in databases, simple allocation, and ease of programming in general.\n",
-          "termDef": {
-            "cde_id": "C54100",
-            "cde_version": null,
-            "source": "NCIt",
-            "term": "Universally Unique Identifier",
-            "term_url": "https://ncit.nci.nih.gov/ncitbrowser/ConceptReport.jsp?dictionary=NCI_Thesaurus&version=16.02d&ns=NCI_Thesaurus&code=C54100"
-          }
-        },
-        "type": "string"
-      },
-      "molecular_concentration": {
-        "description": "If the analyte is a molecule (e.g. DNA or RNA), report the observed concentration in nanograms per microliters.\n",
-        "type": "number"
-      },
-      "project_id": {
-        "term": {
-          "description": "Unique ID for any specific defined piece of work that is undertaken or attempted to meet a single requirement.\n"
-        },
-        "type": "string"
-      },
-      "state": {
-        "default": "validated",
-        "downloadable": [
-          "uploaded",
-          "md5summed",
-          "validating",
-          "validated",
-          "error",
-          "invalid",
-          "released"
-        ],
-        "oneOf": [
-          {
-            "enum": [
-              "uploading",
-              "uploaded",
-              "md5summing",
-              "md5summed",
-              "validating",
-              "error",
-              "invalid",
-              "suppressed",
-              "redacted",
-              "live"
-            ]
-          },
-          {
-            "enum": [
-              "validated",
-              "submitted",
-              "released"
-            ]
-          }
-        ],
-        "public": [
-          "live"
-        ],
-        "term": {
-          "description": "The current state of the object.\n"
-        }
-      },
-      "submitter_id": {
-        "description": "A project-specific identifier for a node. This property is the calling card/nickname/alias for a unit of submission. It can be used in place of the UUID for identifying or recalling a node.\n",
-        "type": [
-          "string"
-        ]
-      },
-      "type": {
-        "type": "string"
-      },
-      "updated_datetime": {
-        "oneOf": [
-          {
-            "format": "date-time",
-            "type": "string"
-          },
-          {
-            "type": "null"
-          }
-        ],
-        "term": {
-          "description": "A combination of date and time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]\n"
-        }
-      }
-    },
-    "required": [
-      "submitter_id",
-      "type",
-      "assay_instrument",
-      "assay_instrument_model",
-      "assay_method",
-      "analytes"
-    ],
-    "submittable": true,
-    "systemProperties": [
-      "id",
-      "project_id",
-      "created_datetime",
-      "updated_datetime",
-      "state"
-    ],
-    "title": "Quantification Assay",
-    "type": "object",
-    "uniqueKeys": [
-      [
-        "id"
-      ],
-      [
-        "project_id",
-        "submitter_id"
-      ]
-    ],
-    "validators": null
-  },
-  "quantification_assay_peak": {
-    "$schema": "http://json-schema.org/draft-04/schema#",
-    "additionalProperties": false,
-    "category": "notation",
-    "description": "The description of a peak in a quantification assay trace.\n",
-    "id": "quantification_assay_peak",
-    "links": [
-      {
-        "backref": "quantification_assay_peaks",
-        "label": "data_from",
-        "multiplicity": "many_to_one",
-        "name": "quantification_assay_qcs",
-        "required": true,
-        "target_type": "quantification_assay_qc"
-      }
-    ],
-    "namespace": "https://www.bloodpac.org",
-    "program": "*",
-    "project": "*",
-    "properties": {
-      "created_datetime": {
-        "oneOf": [
-          {
-            "format": "date-time",
-            "type": "string"
-          },
-          {
-            "type": "null"
-          }
-        ],
-        "term": {
-          "description": "A combination of date and time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]\n"
-        }
-      },
-      "id": {
-        "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
-        "systemAlias": "node_id",
-        "term": {
-          "description": "A 128-bit identifier. Depending on the mechanism used to generate it, it is either guaranteed to be different from all other UUIDs/GUIDs generated until 3400 AD or extremely likely to be different. Its relatively small size lends itself well to sorting, ordering, and hashing of all sorts, storing in databases, simple allocation, and ease of programming in general.\n",
-          "termDef": {
-            "cde_id": "C54100",
-            "cde_version": null,
-            "source": "NCIt",
-            "term": "Universally Unique Identifier",
-            "term_url": "https://ncit.nci.nih.gov/ncitbrowser/ConceptReport.jsp?dictionary=NCI_Thesaurus&version=16.02d&ns=NCI_Thesaurus&code=C54100"
-          }
-        },
-        "type": "string"
-      },
-      "kurtosis": {
-        "description": "Description of the kurtosis of a peak in a quantification assay trace.",
-        "type": "string"
-      },
-      "peak_center": {
-        "description": "The center of a peak in a quantification assay trace.",
-        "type": "string"
-      },
-      "peak_width": {
-        "description": "The width of a peak in a quantification assay trace.",
-        "type": "string"
-      },
-      "project_id": {
-        "term": {
-          "description": "Unique ID for any specific defined piece of work that is undertaken or attempted to meet a single requirement.\n"
-        },
-        "type": "string"
-      },
-      "quantification_assay_qcs": {
-        "anyOf": [
-          {
-            "items": {
-              "additionalProperties": true,
-              "maxItems": 1,
-              "minItems": 1,
-              "properties": {
-                "id": {
-                  "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
-                  "term": {
-                    "description": "A 128-bit identifier. Depending on the mechanism used to generate it, it is either guaranteed to be different from all other UUIDs/GUIDs generated until 3400 AD or extremely likely to be different. Its relatively small size lends itself well to sorting, ordering, and hashing of all sorts, storing in databases, simple allocation, and ease of programming in general.\n",
-                    "termDef": {
-                      "cde_id": "C54100",
-                      "cde_version": null,
-                      "source": "NCIt",
-                      "term": "Universally Unique Identifier",
-                      "term_url": "https://ncit.nci.nih.gov/ncitbrowser/ConceptReport.jsp?dictionary=NCI_Thesaurus&version=16.02d&ns=NCI_Thesaurus&code=C54100"
-                    }
-                  },
-                  "type": "string"
-                },
-                "submitter_id": {
-                  "type": "string"
-                }
-              },
-              "type": "object"
-            },
-            "type": "array"
-          },
-          {
-            "additionalProperties": true,
-            "properties": {
-              "id": {
-                "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
-                "term": {
-                  "description": "A 128-bit identifier. Depending on the mechanism used to generate it, it is either guaranteed to be different from all other UUIDs/GUIDs generated until 3400 AD or extremely likely to be different. Its relatively small size lends itself well to sorting, ordering, and hashing of all sorts, storing in databases, simple allocation, and ease of programming in general.\n",
-                  "termDef": {
-                    "cde_id": "C54100",
-                    "cde_version": null,
-                    "source": "NCIt",
-                    "term": "Universally Unique Identifier",
-                    "term_url": "https://ncit.nci.nih.gov/ncitbrowser/ConceptReport.jsp?dictionary=NCI_Thesaurus&version=16.02d&ns=NCI_Thesaurus&code=C54100"
-                  }
-                },
-                "type": "string"
-              },
-              "submitter_id": {
-                "type": "string"
-              }
-            },
-            "type": "object"
-          }
-        ]
-      },
-      "state": {
-        "default": "validated",
-        "downloadable": [
-          "uploaded",
-          "md5summed",
-          "validating",
-          "validated",
-          "error",
-          "invalid",
-          "released"
-        ],
-        "oneOf": [
-          {
-            "enum": [
-              "uploading",
-              "uploaded",
-              "md5summing",
-              "md5summed",
-              "validating",
-              "error",
-              "invalid",
-              "suppressed",
-              "redacted",
-              "live"
-            ]
-          },
-          {
-            "enum": [
-              "validated",
-              "submitted",
-              "released"
-            ]
-          }
-        ],
-        "public": [
-          "live"
-        ],
-        "term": {
-          "description": "The current state of the object.\n"
-        }
-      },
-      "submitter_id": {
-        "description": "A project-specific identifier for a node. This property is the calling card/nickname/alias for a unit of submission. It can be used in place of the UUID for identifying or recalling a node.\n",
-        "type": [
-          "string"
-        ]
-      },
-      "type": {
-        "type": "string"
-      },
-      "updated_datetime": {
-        "oneOf": [
-          {
-            "format": "date-time",
-            "type": "string"
-          },
-          {
-            "type": "null"
-          }
-        ],
-        "term": {
-          "description": "A combination of date and time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]\n"
-        }
-      }
-    },
-    "required": [
-      "submitter_id",
-      "type",
-      "quantification_assay_qcs"
-    ],
-    "submittable": true,
-    "systemProperties": [
-      "id",
-      "project_id",
-      "created_datetime",
-      "updated_datetime",
-      "state"
-    ],
-    "title": "Quantification Assay Peak",
-    "type": "object",
-    "uniqueKeys": [
-      [
-        "id"
-      ],
-      [
-        "project_id",
-        "submitter_id"
-      ]
-    ],
-    "validators": null
-  },
-  "quantification_assay_qc": {
-    "$schema": "http://json-schema.org/draft-04/schema#",
-    "additionalProperties": false,
-    "category": "data_file",
-    "description": "Data file containing the fragment analyzer or bioanalyzer trace from a quantification assay.\n",
-    "id": "quantification_assay_qc",
-    "links": [
-      {
-        "exclusive": false,
-        "required": true,
-        "subgroup": [
-          {
-            "backref": "quantification_assay_qcs",
-            "label": "data_from",
-            "multiplicity": "one_to_one",
-            "name": "core_metadata_collections",
-            "required": false,
-            "target_type": "core_metadata_collection"
-          },
-          {
-            "backref": "quantification_assay_qcs",
-            "label": "data_from",
-            "multiplicity": "many_to_one",
-            "name": "quantification_assays",
-            "required": false,
-            "target_type": "quantification_assay"
-          }
-        ]
-      }
-    ],
-    "namespace": "https://www.bloodpac.org",
-    "program": "*",
-    "project": "*",
-    "properties": {
-      "core_metadata_collections": {
-        "anyOf": [
-          {
-            "items": {
-              "additionalProperties": true,
-              "maxItems": 1,
-              "minItems": 1,
-              "properties": {
-                "id": {
-                  "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
-                  "term": {
-                    "description": "A 128-bit identifier. Depending on the mechanism used to generate it, it is either guaranteed to be different from all other UUIDs/GUIDs generated until 3400 AD or extremely likely to be different. Its relatively small size lends itself well to sorting, ordering, and hashing of all sorts, storing in databases, simple allocation, and ease of programming in general.\n",
-                    "termDef": {
-                      "cde_id": "C54100",
-                      "cde_version": null,
-                      "source": "NCIt",
-                      "term": "Universally Unique Identifier",
-                      "term_url": "https://ncit.nci.nih.gov/ncitbrowser/ConceptReport.jsp?dictionary=NCI_Thesaurus&version=16.02d&ns=NCI_Thesaurus&code=C54100"
-                    }
-                  },
-                  "type": "string"
-                },
-                "submitter_id": {
-                  "type": "string"
-                }
-              },
-              "type": "object"
-            },
-            "type": "array"
-          },
-          {
-            "additionalProperties": true,
-            "properties": {
-              "id": {
-                "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
-                "term": {
-                  "description": "A 128-bit identifier. Depending on the mechanism used to generate it, it is either guaranteed to be different from all other UUIDs/GUIDs generated until 3400 AD or extremely likely to be different. Its relatively small size lends itself well to sorting, ordering, and hashing of all sorts, storing in databases, simple allocation, and ease of programming in general.\n",
-                  "termDef": {
-                    "cde_id": "C54100",
-                    "cde_version": null,
-                    "source": "NCIt",
-                    "term": "Universally Unique Identifier",
-                    "term_url": "https://ncit.nci.nih.gov/ncitbrowser/ConceptReport.jsp?dictionary=NCI_Thesaurus&version=16.02d&ns=NCI_Thesaurus&code=C54100"
-                  }
-                },
-                "type": "string"
-              },
-              "submitter_id": {
-                "type": "string"
-              }
-            },
-            "type": "object"
-          }
-        ]
-      },
-      "created_datetime": {
-        "oneOf": [
-          {
-            "format": "date-time",
-            "type": "string"
-          },
-          {
-            "type": "null"
-          }
-        ],
-        "term": {
-          "description": "A combination of date and time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]\n"
-        }
-      },
-      "data_category": {
-        "enum": [
-          "Fragment Analyzer Trace",
-          "Bioanalyzer Trace"
-        ],
-        "term": {
-          "description": "Broad categorization of the contents of the data file.\n"
-        }
-      },
-      "data_format": {
-        "term": {
-          "description": "Format of the data files.\n"
-        },
-        "type": "string"
-      },
-      "data_type": {
-        "enum": [
-          "Quantification Assay Trace"
-        ],
-        "term": {
-          "description": "Specific content type of the data file.\n"
-        }
-      },
-      "error_type": {
-        "enum": [
-          "file_size",
-          "file_format",
-          "md5sum"
-        ],
-        "term": {
-          "description": "Type of error for the data file object.\n"
-        }
-      },
-      "file_name": {
-        "term": {
-          "description": "The name (or part of a name) of a file (of any type).\n"
-        },
-        "type": "string"
-      },
-      "file_size": {
-        "term": {
-          "description": "The size of the data file (object) in bytes.\n"
-        },
-        "type": "integer"
-      },
-      "file_state": {
-        "default": "registered",
-        "enum": [
-          "registered",
-          "uploading",
-          "uploaded",
-          "validating",
-          "validated",
-          "submitted",
-          "processing",
-          "processed",
-          "released",
-          "error"
-        ],
-        "term": {
-          "description": "The current state of the data file object.\n"
-        }
-      },
-      "id": {
-        "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
-        "systemAlias": "node_id",
-        "term": {
-          "description": "A 128-bit identifier. Depending on the mechanism used to generate it, it is either guaranteed to be different from all other UUIDs/GUIDs generated until 3400 AD or extremely likely to be different. Its relatively small size lends itself well to sorting, ordering, and hashing of all sorts, storing in databases, simple allocation, and ease of programming in general.\n",
-          "termDef": {
-            "cde_id": "C54100",
-            "cde_version": null,
-            "source": "NCIt",
-            "term": "Universally Unique Identifier",
-            "term_url": "https://ncit.nci.nih.gov/ncitbrowser/ConceptReport.jsp?dictionary=NCI_Thesaurus&version=16.02d&ns=NCI_Thesaurus&code=C54100"
-          }
-        },
-        "type": "string"
-      },
-      "md5sum": {
-        "term": {
-          "description": "The 128-bit hash value expressed as a 32 digit hexadecimal number used as a file's digital fingerprint.\n"
-        },
-        "type": "string"
-      },
-      "object_id": {
-        "description": "The GUID of the object in the index service.",
-        "type": "string"
-      },
-      "project_id": {
-        "term": {
-          "description": "Unique ID for any specific defined piece of work that is undertaken or attempted to meet a single requirement.\n"
-        },
-        "type": "string"
-      },
-      "quantification_assays": {
-        "anyOf": [
-          {
-            "items": {
-              "additionalProperties": true,
-              "maxItems": 1,
-              "minItems": 1,
-              "properties": {
-                "id": {
-                  "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
-                  "term": {
-                    "description": "A 128-bit identifier. Depending on the mechanism used to generate it, it is either guaranteed to be different from all other UUIDs/GUIDs generated until 3400 AD or extremely likely to be different. Its relatively small size lends itself well to sorting, ordering, and hashing of all sorts, storing in databases, simple allocation, and ease of programming in general.\n",
-                    "termDef": {
-                      "cde_id": "C54100",
-                      "cde_version": null,
-                      "source": "NCIt",
-                      "term": "Universally Unique Identifier",
-                      "term_url": "https://ncit.nci.nih.gov/ncitbrowser/ConceptReport.jsp?dictionary=NCI_Thesaurus&version=16.02d&ns=NCI_Thesaurus&code=C54100"
-                    }
-                  },
-                  "type": "string"
-                },
-                "submitter_id": {
-                  "type": "string"
-                }
-              },
-              "type": "object"
-            },
-            "type": "array"
-          },
-          {
-            "additionalProperties": true,
-            "properties": {
-              "id": {
-                "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
-                "term": {
-                  "description": "A 128-bit identifier. Depending on the mechanism used to generate it, it is either guaranteed to be different from all other UUIDs/GUIDs generated until 3400 AD or extremely likely to be different. Its relatively small size lends itself well to sorting, ordering, and hashing of all sorts, storing in databases, simple allocation, and ease of programming in general.\n",
-                  "termDef": {
-                    "cde_id": "C54100",
-                    "cde_version": null,
-                    "source": "NCIt",
-                    "term": "Universally Unique Identifier",
-                    "term_url": "https://ncit.nci.nih.gov/ncitbrowser/ConceptReport.jsp?dictionary=NCI_Thesaurus&version=16.02d&ns=NCI_Thesaurus&code=C54100"
-                  }
-                },
-                "type": "string"
-              },
-              "submitter_id": {
-                "type": "string"
-              }
-            },
-            "type": "object"
-          }
-        ]
-      },
-      "state": {
-        "default": "validated",
-        "downloadable": [
-          "uploaded",
-          "md5summed",
-          "validating",
-          "validated",
-          "error",
-          "invalid",
-          "released"
-        ],
-        "oneOf": [
-          {
-            "enum": [
-              "uploading",
-              "uploaded",
-              "md5summing",
-              "md5summed",
-              "validating",
-              "error",
-              "invalid",
-              "suppressed",
-              "redacted",
-              "live"
-            ]
-          },
-          {
-            "enum": [
-              "validated",
-              "submitted",
-              "released"
-            ]
-          }
-        ],
-        "public": [
-          "live"
-        ],
-        "term": {
-          "description": "The current state of the object.\n"
-        }
-      },
-      "submitter_id": {
-        "description": "A project-specific identifier for a node. This property is the calling card/nickname/alias for a unit of submission. It can be used in place of the UUID for identifying or recalling a node.\n",
-        "type": [
-          "string"
-        ]
-      },
-      "type": {
-        "type": "string"
-      },
-      "updated_datetime": {
-        "oneOf": [
-          {
-            "format": "date-time",
-            "type": "string"
-          },
-          {
-            "type": "null"
-          }
-        ],
-        "term": {
-          "description": "A combination of date and time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]\n"
-        }
-      }
-    },
-    "required": [
-      "submitter_id",
-      "type",
-      "file_name",
-      "file_size",
-      "md5sum",
-      "data_category",
-      "data_type",
-      "data_format"
-    ],
-    "submittable": true,
-    "systemProperties": [
-      "id",
-      "project_id",
-      "created_datetime",
-      "updated_datetime",
-      "state",
-      "file_state",
-      "error_type"
-    ],
-    "title": "Quantification Assay QC",
-    "type": "object",
-    "uniqueKeys": [
-      [
-        "id"
-      ],
-      [
-        "project_id",
-        "submitter_id"
-      ]
-    ],
-    "validators": null
-  },
   "read_group": {
     "$schema": "http://json-schema.org/draft-04/schema#",
     "additionalProperties": false,
@@ -17784,12 +8222,12 @@
         "backref": "read_groups",
         "label": "derived_from",
         "multiplicity": "many_to_one",
-        "name": "analytes",
+        "name": "aliquots",
         "required": true,
-        "target_type": "analyte"
+        "target_type": "aliquot"
       }
     ],
-    "namespace": "https://www.bloodpac.org",
+    "namespace": "http://gdc.nci.nih.gov",
     "program": "*",
     "project": "*",
     "properties": {
@@ -17806,13 +8244,19 @@
         },
         "type": "number"
       },
+      "adapter_name": {
+        "term": {
+          "description": "Name of the sequencing adapter.\n"
+        },
+        "type": "string"
+      },
       "adapter_sequence": {
         "term": {
           "description": "Base sequence of the sequencing adapter.\n"
         },
         "type": "string"
       },
-      "analytes": {
+      "aliquots": {
         "anyOf": [
           {
             "items": {
@@ -17871,8 +8315,16 @@
         "description": "True/False: was barcoding applied?",
         "type": "boolean"
       },
-      "coverage": {
-        "description": "Sequencing coverage used in the assay (e.g., 75 PE).",
+      "base_caller_name": {
+        "term": {
+          "description": "Name of the base caller.\n"
+        },
+        "type": "string"
+      },
+      "base_caller_version": {
+        "term": {
+          "description": "Version of the base caller.\n"
+        },
         "type": "string"
       },
       "created_datetime": {
@@ -17889,12 +8341,10 @@
           "description": "A combination of date and time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]\n"
         }
       },
-      "customization": {
-        "description": "A description of any special setup or customization not documented elsewhere.",
-        "type": "string"
-      },
-      "cycles": {
-        "description": "The number of cycles used in the assay (e.g., 50,000x per sample).",
+      "experiment_name": {
+        "term": {
+          "description": "Submitter-defined name for the experiment.\n"
+        },
         "type": "string"
       },
       "flow_cell_barcode": {
@@ -17905,7 +8355,6 @@
       },
       "id": {
         "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
-        "systemAlias": "node_id",
         "term": {
           "description": "A 128-bit identifier. Depending on the mechanism used to generate it, it is either guaranteed to be different from all other UUIDs/GUIDs generated until 3400 AD or extremely likely to be different. Its relatively small size lends itself well to sorting, ordering, and hashing of all sorts, storing in databases, simple allocation, and ease of programming in general.\n",
           "termDef": {
@@ -17917,6 +8366,12 @@
           }
         },
         "type": "string"
+      },
+      "includes_spike_ins": {
+        "term": {
+          "description": "Spike-in included?\n"
+        },
+        "type": "boolean"
       },
       "instrument_model": {
         "enum": [
@@ -17932,7 +8387,6 @@
           "Illumina HiSeq 2000",
           "Illumina HiSeq 2500",
           "Illumina HiSeq 4000",
-          "Illumina MiniSeq",
           "Illumina MiSeq",
           "Illumina NextSeq",
           "Ion Torrent PGM",
@@ -17990,13 +8444,11 @@
       },
       "library_selection": {
         "enum": [
-          "Amplicon",
-          "Hybrid Selection",
+          "Hybrid_Selection",
           "PCR",
-          "Affinity Enrichment",
-          "Poly-T Enrichment",
-          "RNA Depletion",
-          "Targeted Sequencing",
+          "Affinity_Enrichment",
+          "Poly-T_Enrichment",
+          "RNA_Depletion",
           "Other"
         ],
         "term": {
@@ -18006,8 +8458,8 @@
       "library_strand": {
         "enum": [
           "Unstranded",
-          "First Stranded",
-          "Second Stranded"
+          "First_Stranded",
+          "Second_Stranded"
         ],
         "term": {
           "description": "Library stranded-ness.\n"
@@ -18050,20 +8502,47 @@
         "type": "string"
       },
       "read_group_name": {
-        "description": "The name given to this read group. Should match what is provided in the headers of associated files.",
+        "description": "Read Group Name",
         "type": "string"
       },
-      "read_length_lower": {
-        "description": "The lower limit for the length of reads used in the sequencing experiment.",
-        "type": "integer"
-      },
-      "read_length_upper": {
-        "description": "The upper limit for the length of reads used in the sequencing experiment.",
+      "read_length": {
         "type": "integer"
       },
       "sequencing_center": {
         "term": {
           "description": "Name of the center that provided the sequence files.\n"
+        },
+        "type": "string"
+      },
+      "sequencing_date": {
+        "oneOf": [
+          {
+            "format": "date-time",
+            "type": "string"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "term": {
+          "description": "A combination of date and time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]\n"
+        }
+      },
+      "size_selection_range": {
+        "term": {
+          "description": "Range of size selection.\n"
+        },
+        "type": "string"
+      },
+      "spike_ins_concentration": {
+        "term": {
+          "description": "Spike in concentration.\n"
+        },
+        "type": "string"
+      },
+      "spike_ins_fasta": {
+        "term": {
+          "description": "Name of the FASTA file that contains the spike-in sequences.\n"
         },
         "type": "string"
       },
@@ -18109,10 +8588,7 @@
         }
       },
       "submitter_id": {
-        "description": "A project-specific identifier for a node. This property is the calling card/nickname/alias for a unit of submission. It can be used in place of the UUID for identifying or recalling a node.\n",
-        "type": [
-          "string"
-        ]
+        "type": "string"
       },
       "target_capture_kit_catalog_number": {
         "term": {
@@ -18144,12 +8620,16 @@
         },
         "type": "string"
       },
-      "type": {
-        "type": "string"
+      "to_trim_adapter_sequence": {
+        "term": {
+          "description": "Does the user suggest adapter trimming?\n"
+        },
+        "type": "boolean"
       },
-      "universal_molecular_identifier": {
-        "description": "Short sequences or barcodes added to each read for next generation sequencing protocols used to detect and quantify unique transcripts.",
-        "type": "string"
+      "type": {
+        "enum": [
+          "read_group"
+        ]
       },
       "updated_datetime": {
         "oneOf": [
@@ -18167,15 +8647,9 @@
       }
     },
     "required": [
-      "submitter_id",
       "type",
-      "platform",
-      "instrument_model",
-      "library_strategy",
-      "is_paired_end",
-      "read_length_lower",
-      "read_length_upper",
-      "analytes"
+      "submitter_id",
+      "aliquots"
     ],
     "submittable": true,
     "systemProperties": [
@@ -18236,7 +8710,7 @@
         "target_type": "read_group"
       }
     ],
-    "namespace": "https://www.bloodpac.org",
+    "namespace": "http://gdc.nci.nih.gov",
     "program": "*",
     "project": "*",
     "properties": {
@@ -18298,6 +8772,12 @@
             "term": "Encoding",
             "term_url": "http://www.bioinformatics.babraham.ac.uk/projects/fastqc/Help/3%20Analysis%20Modules/1%20Basic%20Statistics.html"
           }
+        },
+        "type": "string"
+      },
+      "fastq_name": {
+        "term": {
+          "description": "The name (or part of a name) of a file (of any type).\n"
         },
         "type": "string"
       },
@@ -18719,9 +9199,10 @@
         ]
       },
       "submitter_id": {
-        "description": "A project-specific identifier for a node. This property is the calling card/nickname/alias for a unit of submission. It can be used in place of the UUID for identifying or recalling a node.\n",
+        "description": "The file ID assigned by the submitter.",
         "type": [
-          "string"
+          "string",
+          "null"
         ]
       },
       "total_aligned_reads": {
@@ -18742,7 +9223,9 @@
         "type": "integer"
       },
       "type": {
-        "type": "string"
+        "enum": [
+          "read_group_qc"
+        ]
       },
       "updated_datetime": {
         "oneOf": [
@@ -18757,11 +9240,71 @@
         "term": {
           "description": "A combination of date and time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]\n"
         }
+      },
+      "workflow_end_datetime": {
+        "oneOf": [
+          {
+            "format": "date-time",
+            "type": "string"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "term": {
+          "description": "A combination of date and time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]\n"
+        }
+      },
+      "workflow_link": {
+        "description": "Link to Github hash for the CWL workflow used.",
+        "type": "string"
+      },
+      "workflow_start_datetime": {
+        "oneOf": [
+          {
+            "format": "date-time",
+            "type": "string"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "term": {
+          "description": "A combination of date and time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]\n"
+        }
+      },
+      "workflow_type": {
+        "enum": [
+          "Read Group Quality Control"
+        ],
+        "term": {
+          "description": "Generic name for the workflow used to analyze a data set.\n"
+        }
+      },
+      "workflow_version": {
+        "description": "Major version for a GDC workflow.",
+        "type": "string"
       }
     },
     "required": [
       "submitter_id",
+      "workflow_link",
       "type",
+      "percent_gc_content",
+      "encoding",
+      "total_sequences",
+      "basic_statistics",
+      "per_base_sequence_quality",
+      "per_tile_sequence_quality",
+      "per_sequence_quality_score",
+      "per_base_sequence_content",
+      "per_sequence_gc_content",
+      "per_base_n_content",
+      "sequence_length_distribution",
+      "sequence_duplication_levels",
+      "overrepresented_sequences",
+      "adapter_content",
+      "kmer_content",
       "read_groups"
     ],
     "submittable": false,
@@ -18791,9 +9334,7 @@
     "category": "internal",
     "constraints": null,
     "id": "root",
-    "links": [],
     "program": "*",
-    "project": "*",
     "properties": {
       "id": {
         "enum": [
@@ -18825,23 +9366,1297 @@
     "$schema": "http://json-schema.org/draft-04/schema#",
     "additionalProperties": false,
     "category": "biospecimen",
-    "description": "Any part of the biological whole of the biospecimen. In the case of solid tissue, this would be a particular set of cells. In the case of fluids, such as blood, this can refer to the plasma, peripheral blood components, or any combination therein.\n",
+    "description": "Any material sample taken from a biological entity for testing, diagnostic, propagation, treatment or research purposes, including a sample obtained from a living organism or taken from the biological object after halting of all its life functions. Biospecimen can contain one or more components including but not limited to cellular molecules, cells, tissues, organs, body fluids, embryos, and body excretory products.\n",
     "id": "sample",
     "links": [
       {
         "backref": "samples",
         "label": "derived_from",
-        "multiplicity": "many_to_many",
-        "name": "biospecimens",
+        "multiplicity": "many_to_one",
+        "name": "cases",
         "required": true,
-        "target_type": "biospecimen"
+        "target_type": "case"
+      },
+      {
+        "backref": "samples",
+        "label": "related_to",
+        "multiplicity": "many_to_one",
+        "name": "diagnoses",
+        "required": false,
+        "target_type": "diagnosis"
       }
     ],
-    "namespace": "https://www.bloodpac.org",
+    "namespace": "http://gdc.nci.nih.gov",
     "program": "*",
     "project": "*",
     "properties": {
-      "biospecimens": {
+      "biospecimen_anatomic_site": {
+        "enum": [
+          "Abdomen",
+          "Abdominal Wall",
+          "Acetabulum",
+          "Adenoid",
+          "Adipose",
+          "Adrenal",
+          "Alveolar Ridge",
+          "Amniotic Fluid",
+          "Ampulla Of Vater",
+          "Anal Sphincter",
+          "Ankle",
+          "Anorectum",
+          "Antecubital Fossa",
+          "Antrum",
+          "Anus",
+          "Aorta",
+          "Aortic Body",
+          "Appendix",
+          "Aqueous Fluid",
+          "Arm",
+          "Artery",
+          "Ascending Colon",
+          "Ascending Colon Hepatic Flexure",
+          "Auditory Canal",
+          "Autonomic Nervous System",
+          "Axilla",
+          "Back",
+          "Bile Duct",
+          "Bladder",
+          "Blood",
+          "Blood Vessel",
+          "Bone",
+          "Bone Marrow",
+          "Bowel",
+          "Brain",
+          "Brain Stem",
+          "Breast",
+          "Broad Ligament",
+          "Bronchiole",
+          "Bronchus",
+          "Brow",
+          "Buccal Cavity",
+          "Buccal Mucosa",
+          "Buttock",
+          "Calf",
+          "Capillary",
+          "Cardia",
+          "Carina",
+          "Carotid Artery",
+          "Carotid Body",
+          "Cartilage",
+          "Cecum",
+          "Cell-Line",
+          "Central Nervous System",
+          "Cerebellum",
+          "Cerebral Cortex",
+          "Cerebrospinal Fluid",
+          "Cerebrum",
+          "Cervical Spine",
+          "Cervix",
+          "Chest",
+          "Chest Wall",
+          "Chin",
+          "Clavicle",
+          "Clitoris",
+          "Colon",
+          "Colon - Mucosa Only",
+          "Common Duct",
+          "Conjunctiva",
+          "Connective Tissue",
+          "Dermal",
+          "Descending Colon",
+          "Diaphragm",
+          "Duodenum",
+          "Ear",
+          "Ear Canal",
+          "Ear, Pinna (External)",
+          "Effusion",
+          "Elbow",
+          "Endocrine Gland",
+          "Epididymis",
+          "Epidural Space",
+          "Esophagogastric Junction",
+          "Esophagus",
+          "Esophagus - Mucosa Only",
+          "Eye",
+          "Fallopian Tube",
+          "Femoral Artery",
+          "Femoral Vein",
+          "Femur",
+          "Fibroblasts",
+          "Fibula",
+          "Finger",
+          "Floor Of Mouth",
+          "Fluid",
+          "Foot",
+          "Forearm",
+          "Forehead",
+          "Foreskin",
+          "Frontal Cortex",
+          "Frontal Lobe",
+          "Fundus Of Stomach",
+          "Gallbladder",
+          "Ganglia",
+          "Gastroesophageal Junction",
+          "Gastrointestinal Tract",
+          "Groin",
+          "Gum",
+          "Hand",
+          "Hard Palate",
+          "Head & Neck",
+          "Head - Face Or Neck, Nos",
+          "Heart",
+          "Hepatic",
+          "Hepatic Duct",
+          "Hepatic Vein",
+          "Hip",
+          "Hippocampus",
+          "Humerus",
+          "Hypopharynx",
+          "Ileum",
+          "Ilium",
+          "Index Finger",
+          "Ischium",
+          "Islet Cells",
+          "Jaw",
+          "Jejunum",
+          "Joint",
+          "Kidney",
+          "Knee",
+          "Lacrimal Gland",
+          "Large Bowel",
+          "Laryngopharynx",
+          "Larynx",
+          "Leg",
+          "Leptomeninges",
+          "Ligament",
+          "Lip",
+          "Liver",
+          "Lumbar Spine",
+          "Lung",
+          "Lymph Node",
+          "Lymph Node(s) Axilla",
+          "Lymph Node(s) Cervical",
+          "Lymph Node(s) Distant",
+          "Lymph Node(s) Epitrochlear",
+          "Lymph Node(s) Femoral",
+          "Lymph Node(s) Hilar",
+          "Lymph Node(s) Iliac-Common",
+          "Lymph Node(s) Iliac-External",
+          "Lymph Node(s) Inguinal",
+          "Lymph Node(s) Internal Mammary",
+          "Lymph Node(s) Mammary",
+          "Lymph Node(s) Mesenteric",
+          "Lymph Node(s) Occipital",
+          "Lymph Node(s) Paraaortic",
+          "Lymph Node(s) Parotid",
+          "Lymph Node(s) Pelvic",
+          "Lymph Node(s) Popliteal",
+          "Lymph Node(s) Regional",
+          "Lymph Node(s) Retroperitoneal",
+          "Lymph Node(s) Scalene",
+          "Lymph Node(s) Splenic",
+          "Lymph Node(s) Subclavicular",
+          "Lymph Node(s) Submandibular",
+          "Lymph Node(s) Supraclavicular",
+          "Lymph Nodes(s) Mediastinal",
+          "Mandible",
+          "Maxilla",
+          "Mediastinal Soft Tissue",
+          "Mediastinum",
+          "Mesentery",
+          "Mesothelium",
+          "Middle Finger",
+          "Mitochondria",
+          "Muscle",
+          "Nails",
+          "Nasal Cavity",
+          "Nasal Soft Tissue",
+          "Nasopharynx",
+          "Neck",
+          "Nerve",
+          "Nerve(s) Cranial",
+          "Occipital Cortex",
+          "Ocular Orbits",
+          "Omentum",
+          "Oral Cavity",
+          "Oral Cavity - Mucosa Only",
+          "Oropharynx",
+          "Other",
+          "Ovary",
+          "Palate",
+          "Pancreas",
+          "Paraspinal Ganglion",
+          "Parathyroid",
+          "Parotid Gland",
+          "Patella",
+          "Pelvis",
+          "Penis",
+          "Pericardium",
+          "Periorbital Soft Tissue",
+          "Peritoneal Cavity",
+          "Peritoneum",
+          "Pharynx",
+          "Pineal",
+          "Pineal Gland",
+          "Pituitary Gland",
+          "Placenta",
+          "Pleura",
+          "Popliteal Fossa",
+          "Prostate",
+          "Pylorus",
+          "Rectosigmoid Junction",
+          "Rectum",
+          "Retina",
+          "Retro-Orbital Region",
+          "Retroperitoneum",
+          "Rib",
+          "Ring Finger",
+          "Round Ligament",
+          "Sacrum",
+          "Salivary Gland",
+          "Scalp",
+          "Scapula",
+          "Sciatic Nerve",
+          "Scrotum",
+          "Seminal Vesicle",
+          "Shoulder",
+          "Sigmoid Colon",
+          "Sinus",
+          "Sinus(es), Maxillary",
+          "Skeletal Muscle",
+          "Skin",
+          "Skull",
+          "Small Bowel",
+          "Small Bowel - Mucosa Only",
+          "Small Finger",
+          "Soft Tissue",
+          "Spinal Column",
+          "Spinal Cord",
+          "Spleen",
+          "Splenic Flexure",
+          "Sternum",
+          "Stomach",
+          "Stomach - Mucosa Only",
+          "Subcutaneous Tissue",
+          "Synovium",
+          "Temporal Cortex",
+          "Tendon",
+          "Testis",
+          "Thigh",
+          "Thoracic Spine",
+          "Thorax",
+          "Throat",
+          "Thumb",
+          "Thymus",
+          "Thyroid",
+          "Tibia",
+          "Tongue",
+          "Tonsil",
+          "Tonsil (Pharyngeal)",
+          "Trachea / Major Bronchi",
+          "Transverse Colon",
+          "Trunk",
+          "Umbilical Cord",
+          "Ureter",
+          "Urethra",
+          "Urinary Tract",
+          "Uterus",
+          "Uvula",
+          "Vagina",
+          "Vas Deferens",
+          "Vein",
+          "Venous",
+          "Vertebra",
+          "Vulva",
+          "White Blood Cells",
+          "Wrist",
+          "Unknown",
+          "Not Reported",
+          "Not Allowed To Collect"
+        ],
+        "term": {
+          "description": "Text term that represents the name of the primary disease site of the submitted tumor sample.\n",
+          "termDef": {
+            "cde_id": 4742851,
+            "cde_version": 1,
+            "source": "caDSR",
+            "term": "Submitted Tumor Sample Primary Anatomic Site",
+            "term_url": "https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=4742851&version=1.0"
+          }
+        }
+      },
+      "cases": {
+        "anyOf": [
+          {
+            "items": {
+              "additionalProperties": true,
+              "maxItems": 1,
+              "minItems": 1,
+              "properties": {
+                "id": {
+                  "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
+                  "term": {
+                    "description": "A 128-bit identifier. Depending on the mechanism used to generate it, it is either guaranteed to be different from all other UUIDs/GUIDs generated until 3400 AD or extremely likely to be different. Its relatively small size lends itself well to sorting, ordering, and hashing of all sorts, storing in databases, simple allocation, and ease of programming in general.\n",
+                    "termDef": {
+                      "cde_id": "C54100",
+                      "cde_version": null,
+                      "source": "NCIt",
+                      "term": "Universally Unique Identifier",
+                      "term_url": "https://ncit.nci.nih.gov/ncitbrowser/ConceptReport.jsp?dictionary=NCI_Thesaurus&version=16.02d&ns=NCI_Thesaurus&code=C54100"
+                    }
+                  },
+                  "type": "string"
+                },
+                "submitter_id": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "type": "array"
+          },
+          {
+            "additionalProperties": true,
+            "properties": {
+              "id": {
+                "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
+                "term": {
+                  "description": "A 128-bit identifier. Depending on the mechanism used to generate it, it is either guaranteed to be different from all other UUIDs/GUIDs generated until 3400 AD or extremely likely to be different. Its relatively small size lends itself well to sorting, ordering, and hashing of all sorts, storing in databases, simple allocation, and ease of programming in general.\n",
+                  "termDef": {
+                    "cde_id": "C54100",
+                    "cde_version": null,
+                    "source": "NCIt",
+                    "term": "Universally Unique Identifier",
+                    "term_url": "https://ncit.nci.nih.gov/ncitbrowser/ConceptReport.jsp?dictionary=NCI_Thesaurus&version=16.02d&ns=NCI_Thesaurus&code=C54100"
+                  }
+                },
+                "type": "string"
+              },
+              "submitter_id": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          }
+        ]
+      },
+      "composition": {
+        "enum": [
+          "Buccal Cells",
+          "Buffy Coat",
+          "Bone Marrow Components",
+          "Bone Marrow Components NOS",
+          "Control Analyte",
+          "Cell",
+          "Circulating Tumor Cell (CTC)",
+          "Derived Cell Line",
+          "EBV Immortalized",
+          "Fibroblasts from Bone Marrow Normal",
+          "Granulocytes",
+          "Human Original Cells",
+          "Lymphocytes",
+          "Mononuclear Cells from Bone Marrow Normal",
+          "Peripheral Blood Components NOS",
+          "Peripheral Blood Nucleated Cells",
+          "Pleural Effusion",
+          "Plasma",
+          "Peripheral Whole Blood",
+          "Serum",
+          "Saliva",
+          "Sputum",
+          "Solid Tissue",
+          "Whole Bone Marrow",
+          "Unknown",
+          "Not Reported",
+          "Not Allowed To Collect"
+        ],
+        "term": {
+          "description": "Text term that represents the cellular composition of the sample.\n",
+          "termDef": {
+            "cde_id": 5432591,
+            "cde_version": 1,
+            "source": "caDSR",
+            "term": "Biospecimen Cellular Composition Type",
+            "term_url": "https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=5432591&version=1.0"
+          }
+        }
+      },
+      "created_datetime": {
+        "oneOf": [
+          {
+            "format": "date-time",
+            "type": "string"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "term": {
+          "description": "A combination of date and time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]\n"
+        }
+      },
+      "current_weight": {
+        "term": {
+          "description": "Numeric value that represents the current weight of the sample, measured  in milligrams.\n",
+          "termDef": {
+            "cde_id": 5432606,
+            "cde_version": 1,
+            "source": "caDSR",
+            "term": "Tissue Sample Current Weight Milligram Value",
+            "term_url": "https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=5432606&version=1.0"
+          }
+        },
+        "type": "number"
+      },
+      "days_to_collection": {
+        "term": {
+          "description": "Time interval from the date of biospecimen collection to the date of initial pathologic diagnosis, represented as a calculated number of days.\n",
+          "termDef": {
+            "cde_id": 3008340,
+            "cde_version": 1,
+            "source": "caDSR",
+            "term": "Biospecimen Collection Date Less Initial Pathologic Diagnosis Date Calculated Day Value",
+            "term_url": "https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=3008340&version=1.0"
+          }
+        },
+        "type": "integer"
+      },
+      "days_to_sample_procurement": {
+        "term": {
+          "description": "The number of days from the date the patient was diagnosed to the date of the procedure that produced the sample.\n"
+        },
+        "type": "integer"
+      },
+      "diagnoses": {
+        "anyOf": [
+          {
+            "items": {
+              "additionalProperties": true,
+              "maxItems": 1,
+              "minItems": 1,
+              "properties": {
+                "id": {
+                  "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
+                  "term": {
+                    "description": "A 128-bit identifier. Depending on the mechanism used to generate it, it is either guaranteed to be different from all other UUIDs/GUIDs generated until 3400 AD or extremely likely to be different. Its relatively small size lends itself well to sorting, ordering, and hashing of all sorts, storing in databases, simple allocation, and ease of programming in general.\n",
+                    "termDef": {
+                      "cde_id": "C54100",
+                      "cde_version": null,
+                      "source": "NCIt",
+                      "term": "Universally Unique Identifier",
+                      "term_url": "https://ncit.nci.nih.gov/ncitbrowser/ConceptReport.jsp?dictionary=NCI_Thesaurus&version=16.02d&ns=NCI_Thesaurus&code=C54100"
+                    }
+                  },
+                  "type": "string"
+                },
+                "submitter_id": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "type": "array"
+          },
+          {
+            "additionalProperties": true,
+            "properties": {
+              "id": {
+                "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
+                "term": {
+                  "description": "A 128-bit identifier. Depending on the mechanism used to generate it, it is either guaranteed to be different from all other UUIDs/GUIDs generated until 3400 AD or extremely likely to be different. Its relatively small size lends itself well to sorting, ordering, and hashing of all sorts, storing in databases, simple allocation, and ease of programming in general.\n",
+                  "termDef": {
+                    "cde_id": "C54100",
+                    "cde_version": null,
+                    "source": "NCIt",
+                    "term": "Universally Unique Identifier",
+                    "term_url": "https://ncit.nci.nih.gov/ncitbrowser/ConceptReport.jsp?dictionary=NCI_Thesaurus&version=16.02d&ns=NCI_Thesaurus&code=C54100"
+                  }
+                },
+                "type": "string"
+              },
+              "submitter_id": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          }
+        ]
+      },
+      "diagnosis_pathologically_confirmed": {
+        "enum": [
+          "Yes",
+          "No",
+          "Unknown"
+        ],
+        "term": {
+          "ref": "_terms.yaml#/diagnosis_pathologically_confirmed"
+        }
+      },
+      "freezing_method": {
+        "term": {
+          "description": "Text term that represents the method used for freezing the sample.\n",
+          "termDef": {
+            "cde_id": 5432607,
+            "cde_version": 1,
+            "source": "caDSR",
+            "term": "Tissue Sample Freezing Method Type",
+            "term_url": "https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=5432607&version=1.0"
+          }
+        },
+        "type": "string"
+      },
+      "id": {
+        "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
+        "systemAlias": "node_id",
+        "term": {
+          "description": "A 128-bit identifier. Depending on the mechanism used to generate it, it is either guaranteed to be different from all other UUIDs/GUIDs generated until 3400 AD or extremely likely to be different. Its relatively small size lends itself well to sorting, ordering, and hashing of all sorts, storing in databases, simple allocation, and ease of programming in general.\n",
+          "termDef": {
+            "cde_id": "C54100",
+            "cde_version": null,
+            "source": "NCIt",
+            "term": "Universally Unique Identifier",
+            "term_url": "https://ncit.nci.nih.gov/ncitbrowser/ConceptReport.jsp?dictionary=NCI_Thesaurus&version=16.02d&ns=NCI_Thesaurus&code=C54100"
+          }
+        },
+        "type": "string"
+      },
+      "initial_weight": {
+        "term": {
+          "description": "Numeric value that represents the initial weight of the sample, measured in milligrams.\n",
+          "termDef": {
+            "cde_id": 5432605,
+            "cde_version": 1,
+            "source": "caDSR",
+            "term": "Tissue Sample Initial Weight Milligram Value",
+            "term_url": "https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=5432605&version=1.0"
+          }
+        },
+        "type": "number"
+      },
+      "intermediate_dimension": {
+        "terms": {
+          "description": "Intermediate dimension of the sample, in millimeters.\n"
+        },
+        "type": "string"
+      },
+      "is_ffpe": {
+        "term": {
+          "description": "Indicator to signify whether or not the tissue sample was fixed in formalin and embedded in paraffin (FFPE).\n",
+          "termDef": {
+            "cde_id": 4170557,
+            "cde_version": 1,
+            "source": "caDSR",
+            "term": "Specimen Processing Formalin Fixed Paraffin Embedded Tissue Indicator",
+            "term_url": "https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=4170557&version=1.0"
+          }
+        },
+        "type": "boolean"
+      },
+      "longest_dimension": {
+        "terms": {
+          "description": "Numeric value that represents the longest dimension of the sample, measured in millimeters.\n",
+          "termDef": {
+            "cde_id": 5432602,
+            "cde_version": 1,
+            "source": "caDSR",
+            "term": "Tissue Sample Longest Dimension Millimeter Measurement",
+            "term_url": "https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=5432602&version=1.0"
+          }
+        },
+        "type": "string"
+      },
+      "method_of_sample_procurement": {
+        "enum": [
+          "Abdomino-perineal Resection of Rectum",
+          "Anterior Resection of Rectum",
+          "Aspirate",
+          "Biopsy",
+          "Blood Draw",
+          "Bone Marrow Aspirate",
+          "Core Biopsy",
+          "Cystectomy",
+          "Endo Rectal Tumor Resection",
+          "Endoscopic Biopsy",
+          "Endoscopic Mucosal Resection (EMR)",
+          "Enucleation",
+          "Excisional Biopsy",
+          "Fine Needle Aspiration",
+          "Full Hysterectomy",
+          "Gross Total Resection",
+          "Hand Assisted Laparoscopic Radical Nephrectomy",
+          "Hysterectomy NOS",
+          "Incisional Biopsy",
+          "Indeterminant",
+          "Laparoscopic Biopsy",
+          "Laparoscopic Partial Nephrectomy",
+          "Laparoscopic Radical Nephrectomy",
+          "Laparoscopic Radical Prostatectomy with Robotics",
+          "Laparoscopic Radical Prostatectomy without Robotics",
+          "Left Hemicolectomy",
+          "Lobectomy",
+          "Local Resection (Exoresection; wall resection)",
+          "Lumpectomy",
+          "Modified Radical Mastectomy",
+          "Needle Biopsy",
+          "Open Craniotomy",
+          "Open Partial Nephrectomy",
+          "Open Radical Nephrectomy",
+          "Open Radical Prostatectomy",
+          "Orchiectomy",
+          "Other",
+          "Other Surgical Resection",
+          "Pan-Procto Colectomy",
+          "Pneumonectomy",
+          "Right Hemicolectomy",
+          "Sigmoid Colectomy",
+          "Simple Mastectomy",
+          "Subtotal Resection",
+          "Surgical Resection",
+          "Thoracoscopic Biopsy",
+          "Total Colectomy",
+          "Total Mastectomy",
+          "Transplant",
+          "Transurethral resection (TURBT)",
+          "Transverse Colectomy",
+          "Tumor Resection",
+          "Wedge Resection",
+          "Unknown",
+          "Not Reported",
+          "Not Allowed To Collect"
+        ],
+        "term": {
+          "description": "The method used to procure the sample used to extract analyte(s).\n",
+          "termDef": {
+            "cde_id": null,
+            "cde_version": null,
+            "source": null,
+            "term": "Method of Sample Procurement",
+            "term_url": null
+          }
+        }
+      },
+      "oct_embedded": {
+        "term": {
+          "description": "Indicator of whether or not the sample was embedded in Optimal Cutting Temperature (OCT) compound.\n",
+          "termDef": {
+            "cde_id": 5432538,
+            "cde_version": 1,
+            "source": "caDSR",
+            "term": "Tissue Sample Optimal Cutting Temperature Compound Embedding Indicator",
+            "term_url": "https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=5432538&version=1.0"
+          }
+        },
+        "type": "string"
+      },
+      "preservation_method": {
+        "enum": [
+          "Cryopreserved",
+          "FFPE",
+          "Fresh",
+          "OCT",
+          "Snap Frozen",
+          "Frozen",
+          "Unknown",
+          "Not Reported",
+          "Not Allowed To Collect"
+        ],
+        "term": {
+          "description": "Text term that represents the method used to preserve the sample.\n",
+          "termDef": {
+            "cde_id": 5432521,
+            "cde_version": 1,
+            "source": "caDSR",
+            "term": "Tissue Sample Preservation Method Type",
+            "term_url": "https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=5432521&version=1.0"
+          }
+        }
+      },
+      "project_id": {
+        "type": "string"
+      },
+      "sample_type": {
+        "description": "Characterization of the sample as either clinical or contrived.",
+        "enum": [
+          "Additional Metastatic",
+          "Additional - New Primary",
+          "Blood Derived Cancer - Bone Marrow, Post-treatment",
+          "Blood Derived Cancer - Peripheral Blood, Post-treatment",
+          "Blood Derived Normal",
+          "Bone Marrow Normal",
+          "Buccal Cell Normal",
+          "Cell Line Derived Xenograft Tissue",
+          "Cell Lines",
+          "cfDNA",
+          "Circulating Tumor Cell (CTC)",
+          "Control Analyte",
+          "Clinical",
+          "Contrived",
+          "ctDNA",
+          "DNA",
+          "EBV Immortalized Normal",
+          "FFPE Recurrent",
+          "FFPE Scrolls",
+          "Fibroblasts from Bone Marrow Normal",
+          "GenomePlex (Rubicon) Amplified DNA",
+          "Granulocytes",
+          "Human Tumor Original Cells",
+          "Metastatic",
+          "Mononuclear Cells from Bone Marrow Normal",
+          "Primary Blood Derived Cancer - Peripheral Blood",
+          "Recurrent Blood Derived Cancer - Peripheral Blood",
+          "Pleural Effusion",
+          "Primary Blood Derived Cancer - Bone Marrow",
+          "Primary Tumor",
+          "Primary Xenograft Tissue",
+          "Post neo-adjuvant therapy",
+          "Recurrent Blood Derived Cancer - Bone Marrow",
+          "Recurrent Tumor",
+          "Repli-G (Qiagen) DNA",
+          "Repli-G X (Qiagen) DNA",
+          "RNA",
+          "Slides",
+          "Solid Tissue Normal",
+          "Total RNA",
+          "Xenograft Tissue",
+          "Unknown",
+          "Not Reported",
+          "Not Allowed To Collect"
+        ]
+      },
+      "sample_type_id": {
+        "enum": [
+          "01",
+          "02",
+          "03",
+          "04",
+          "05",
+          "06",
+          "07",
+          "08",
+          "09",
+          "10",
+          "11",
+          "12",
+          "13",
+          "14",
+          "15",
+          "16",
+          "20",
+          "40",
+          "41",
+          "42",
+          "50",
+          "60",
+          "61",
+          "99"
+        ],
+        "term": {
+          "description": "The accompanying sample type id for the sample type.\n"
+        }
+      },
+      "sample_volume": {
+        "description": "The volume of the sample in mL.",
+        "type": "number"
+      },
+      "shortest_dimension": {
+        "term": {
+          "description": "Numeric value that represents the shortest dimension of the sample, measured in millimeters.\n",
+          "termDef": {
+            "cde_id": 5432603,
+            "cde_version": 1,
+            "source": "caDSR",
+            "term": "Tissue Sample Short Dimension Millimeter Measurement",
+            "term_url": "https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=5432603&version=1.0"
+          }
+        },
+        "type": "string"
+      },
+      "state": {
+        "default": "validated",
+        "downloadable": [
+          "uploaded",
+          "md5summed",
+          "validating",
+          "validated",
+          "error",
+          "invalid",
+          "released"
+        ],
+        "oneOf": [
+          {
+            "enum": [
+              "uploading",
+              "uploaded",
+              "md5summing",
+              "md5summed",
+              "validating",
+              "error",
+              "invalid",
+              "suppressed",
+              "redacted",
+              "live"
+            ]
+          },
+          {
+            "enum": [
+              "validated",
+              "submitted",
+              "released"
+            ]
+          }
+        ],
+        "public": [
+          "live"
+        ],
+        "term": {
+          "description": "The current state of the object.\n"
+        }
+      },
+      "submitter_id": {
+        "description": "The legacy barcode used before prior to the use UUIDs, varies by project. For TCGA this is bcrsamplebarcode.\n",
+        "type": [
+          "string",
+          "null"
+        ]
+      },
+      "time_between_clamping_and_freezing": {
+        "term": {
+          "description": "Numeric representation of the elapsed time between the surgical clamping of blood supply and freezing of the sample, measured in minutes.\n",
+          "termDef": {
+            "cde_id": 5432611,
+            "cde_version": 1,
+            "source": "caDSR",
+            "term": "Tissue Sample Clamping and Freezing Elapsed Minute Time",
+            "term_url": "https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=5432611&version=1.0"
+          }
+        },
+        "type": "string"
+      },
+      "time_between_excision_and_freezing": {
+        "term": {
+          "description": "Numeric representation of the elapsed time between the excision and freezing of the sample, measured in minutes.\n",
+          "termDef": {
+            "cde_id": 5432612,
+            "cde_version": 1,
+            "source": "caDSR",
+            "term": "Tissue Sample Excision and Freezing Elapsed Minute Time",
+            "term_url": "https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=5432612&version=1.0"
+          }
+        },
+        "type": "string"
+      },
+      "tissue_type": {
+        "enum": [
+          "Tumor",
+          "Normal",
+          "Abnormal",
+          "Peritumoral",
+          "Contrived",
+          "Unknown",
+          "Not Reported",
+          "Not Allowed To Collect"
+        ],
+        "term": {
+          "description": "Text term that represents a description of the kind of tissue collected with respect to disease status or proximity to tumor tissue.\n",
+          "termDef": {
+            "cde_id": 5432687,
+            "cde_version": 1,
+            "source": "caDSR",
+            "term": "Tissue Sample Description Type",
+            "term_url": "https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=5432687&version=1.0"
+          }
+        }
+      },
+      "tumor_code": {
+        "enum": [
+          "Non cancerous tissue",
+          "Diffuse Large B-Cell Lymphoma (DLBCL)",
+          "Lung Cancer (all types)",
+          "Lung Adenocarcinoma",
+          "Non-small Cell Lung Carcinoma (NSCLC)",
+          "Colon Cancer (all types)",
+          "Breast Cancer (all types)",
+          "Cervical Cancer (all types)",
+          "Anal Cancer (all types)",
+          "Acute lymphoblastic leukemia (ALL)",
+          "Acute myeloid leukemia (AML)",
+          "Induction Failure AML (AML-IF)",
+          "Neuroblastoma (NBL)",
+          "Osteosarcoma (OS)",
+          "Ewing sarcoma",
+          "Wilms tumor (WT)",
+          "Clear cell sarcoma of the kidney (CCSK)",
+          "Rhabdoid tumor (kidney) (RT)",
+          "CNS, ependymoma",
+          "CNS, glioblastoma (GBM)",
+          "CNS, rhabdoid tumor",
+          "CNS, low grade glioma (LGG)",
+          "CNS, medulloblastoma",
+          "CNS, other",
+          "NHL, anaplastic large cell lymphoma",
+          "NHL, Burkitt lymphoma (BL)",
+          "Rhabdomyosarcoma",
+          "Soft tissue sarcoma, non-rhabdomyosarcoma",
+          "Castration-Resistant Prostate Cancer (CRPC)",
+          "Prostate Cancer",
+          "Hepatocellular Carcinoma (HCC)"
+        ],
+        "term": {
+          "description": "Diagnostic tumor code of the tissue sample source.\n"
+        }
+      },
+      "tumor_code_id": {
+        "enum": [
+          "00",
+          "01",
+          "02",
+          "03",
+          "04",
+          "10",
+          "20",
+          "21",
+          "30",
+          "40",
+          "41",
+          "50",
+          "51",
+          "52",
+          "60",
+          "61",
+          "62",
+          "63",
+          "64",
+          "65",
+          "70",
+          "71",
+          "80",
+          "81"
+        ],
+        "term": {
+          "description": "BCR-defined id code for the tumor sample.\n"
+        }
+      },
+      "tumor_descriptor": {
+        "description": "A description of the tumor from which the sample was derived.",
+        "enum": [
+          "Metastatic",
+          "Not Applicable",
+          "Primary",
+          "Recurrence",
+          "Xenograft",
+          "NOS",
+          "Unknown",
+          "Not Reported",
+          "Not Allowed To Collect"
+        ],
+        "term": {
+          "description": "Text that describes the kind of disease present in the tumor specimen as related to a specific timepoint.\n",
+          "termDef": {
+            "cde_id": 3288124,
+            "cde_version": 1,
+            "source": "caDSR",
+            "term": "Tumor Tissue Disease Description Type",
+            "term_url": "https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=3288124&version=1.0"
+          }
+        }
+      },
+      "type": {
+        "type": "string"
+      },
+      "updated_datetime": {
+        "oneOf": [
+          {
+            "format": "date-time",
+            "type": "string"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "term": {
+          "description": "A combination of date and time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]\n"
+        }
+      }
+    },
+    "required": [
+      "submitter_id",
+      "cases"
+    ],
+    "submittable": true,
+    "systemProperties": [
+      "id",
+      "project_id",
+      "state",
+      "created_datetime",
+      "updated_datetime"
+    ],
+    "title": "Sample",
+    "type": "object",
+    "uniqueKeys": [
+      [
+        "id"
+      ],
+      [
+        "project_id",
+        "submitter_id"
+      ]
+    ],
+    "validators": null
+  },
+  "slide": {
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "additionalProperties": false,
+    "category": "biospecimen",
+    "description": "A digital image, microscopic or otherwise, of any sample, portion, or sub-part thereof. (GDC)\n",
+    "id": "slide",
+    "links": [
+      {
+        "backref": "slides",
+        "label": "derived_from",
+        "multiplicity": "many_to_many",
+        "name": "samples",
+        "required": true,
+        "target_type": "sample"
+      }
+    ],
+    "namespace": "http://gdc.nci.nih.gov",
+    "program": "*",
+    "project": "*",
+    "properties": {
+      "apoptotic_concentration": {
+        "description": "The concentration, in cells/mL, of apoptotic cells in the slide blood.",
+        "type": "number"
+      },
+      "created_datetime": {
+        "oneOf": [
+          {
+            "format": "date-time",
+            "type": "string"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "term": {
+          "description": "A combination of date and time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]\n"
+        }
+      },
+      "ctc_concentration": {
+        "description": "The concentration, in cells/mL, of traditional CTC cells (intact and enlarged cell and nucleus, cytokeratin positive, and CD45 negative) in the slide blood.",
+        "type": "number"
+      },
+      "ctc_low_concentration": {
+        "description": "The concentration, in cells/mL, of CTC-low cells (those with low cytokeratin levels compared to traditional CTCs) in the slide blood.",
+        "type": "number"
+      },
+      "ctc_small_concentration": {
+        "description": "The concentration, in cells/mL, of CTC-small cells (those with a small nuclear and cellular size relative to traditional CTCs) in the slide blood.",
+        "type": "number"
+      },
+      "id": {
+        "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
+        "systemAlias": "node_id",
+        "term": {
+          "description": "A 128-bit identifier. Depending on the mechanism used to generate it, it is either guaranteed to be different from all other UUIDs/GUIDs generated until 3400 AD or extremely likely to be different. Its relatively small size lends itself well to sorting, ordering, and hashing of all sorts, storing in databases, simple allocation, and ease of programming in general.\n",
+          "termDef": {
+            "cde_id": "C54100",
+            "cde_version": null,
+            "source": "NCIt",
+            "term": "Universally Unique Identifier",
+            "term_url": "https://ncit.nci.nih.gov/ncitbrowser/ConceptReport.jsp?dictionary=NCI_Thesaurus&version=16.02d&ns=NCI_Thesaurus&code=C54100"
+          }
+        },
+        "type": "string"
+      },
+      "methanol_added": {
+        "description": "True/False indicator for if methanol was used in the slide preparation process.",
+        "type": "boolean"
+      },
+      "number_nucleated_cells": {
+        "description": "The total number of nucleated cells identified on the slide.",
+        "type": "integer"
+      },
+      "number_proliferating_cells": {
+        "term": {
+          "description": "Numeric value that represents the count of proliferating cells determined during pathologic review of the sample slide(s).\n",
+          "termDef": {
+            "cde_id": 5432636,
+            "cde_version": 1,
+            "source": "caDSR",
+            "term": "Pathology Review Slide Proliferating Cell Count",
+            "term_url": "https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=5432636&version=1.0"
+          }
+        },
+        "type": "integer"
+      },
+      "percent_eosinophil_infiltration": {
+        "term": {
+          "description": "Numeric value to represent the percentage of infiltration by eosinophils in a tumor sample or specimen.\n",
+          "termDef": {
+            "cde_id": 2897700,
+            "cde_version": 2,
+            "source": "caDSR",
+            "term": "Specimen Eosinophilia Percentage Value",
+            "term_url": "https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=2897700&version=2.0"
+          }
+        },
+        "type": "number"
+      },
+      "percent_granulocyte_infiltration": {
+        "term": {
+          "description": "Numeric value to represent the percentage of infiltration by granulocytes in a tumor sample or specimen.\n",
+          "termDef": {
+            "cde_id": 2897705,
+            "cde_version": 2,
+            "source": "caDSR",
+            "term": "Specimen Granulocyte Infiltration Percentage Value",
+            "term_url": "https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=2897705&version=2.0"
+          }
+        },
+        "type": "number"
+      },
+      "percent_inflam_infiltration": {
+        "term": {
+          "description": "Numeric value to represent local response to cellular injury, marked by capillary dilatation, edema and leukocyte infiltration; clinically, inflammation is manifest by reddness, heat, pain, swelling and loss of function, with the need to heal damaged tissue.\n",
+          "termDef": {
+            "cde_id": 2897695,
+            "cde_version": 1,
+            "source": "caDSR",
+            "term": "Specimen Inflammation Change Percentage Value",
+            "term_url": "https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=2897695&version=1.0"
+          }
+        },
+        "type": "number"
+      },
+      "percent_lymphocyte_infiltration": {
+        "term": {
+          "description": "Numeric value to represent the percentage of infiltration by lymphocytes in a solid tissue normal sample or specimen.\n",
+          "termDef": {
+            "cde_id": 2897710,
+            "cde_version": 2,
+            "source": "caDSR",
+            "term": "Specimen Lymphocyte Infiltration Percentage Value",
+            "term_url": "https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=2897710&version=2.0"
+          }
+        },
+        "type": "number"
+      },
+      "percent_monocyte_infiltration": {
+        "term": {
+          "description": "Numeric value to represent the percentage of monocyte infiltration in a sample or specimen.\n",
+          "termDef": {
+            "cde_id": 5455535,
+            "cde_version": 1,
+            "source": "caDSR",
+            "term": "Specimen Monocyte Infiltration Percentage Value",
+            "term_url": "https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=5455535&version=1.0"
+          }
+        },
+        "type": "number"
+      },
+      "percent_necrosis": {
+        "term": {
+          "description": "Numeric value to represent the percentage of cell death in a malignant tumor sample or specimen.\n",
+          "termDef": {
+            "cde_id": 2841237,
+            "cde_version": 1,
+            "source": "caDSR",
+            "term": "Malignant Neoplasm Necrosis Percentage Value",
+            "term_url": "https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=2841237&version=1.0"
+          }
+        },
+        "type": "number"
+      },
+      "percent_neutrophil_infiltration": {
+        "term": {
+          "description": "Numeric value to represent the percentage of infiltration by neutrophils in a tumor sample or specimen.\n",
+          "termDef": {
+            "cde_id": 2841267,
+            "cde_version": 1,
+            "source": "caDSR",
+            "term": "Malignant Neoplasm Neutrophil Infiltration Percentage Cell Value",
+            "term_url": "https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=2841267&version=1.0"
+          }
+        },
+        "type": "number"
+      },
+      "percent_normal_cells": {
+        "term": {
+          "description": "Numeric value to represent the percentage of normal cell content in a malignant tumor sample or specimen.\n",
+          "termDef": {
+            "cde_id": 2841233,
+            "cde_version": 1,
+            "source": "caDSR",
+            "term": "Malignant Neoplasm Normal Cell Percentage Value",
+            "term_url": "https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=2841233&version=1.0"
+          }
+        },
+        "type": "number"
+      },
+      "percent_stromal_cells": {
+        "term": {
+          "description": "Numeric value to represent the percentage of reactive cells that are present in a malignant tumor sample or specimen but are not malignant such as fibroblasts, vascular structures, etc.\n",
+          "termDef": {
+            "cde_id": 2841241,
+            "cde_version": 1,
+            "source": "caDSR",
+            "term": "Malignant Neoplasm Stromal Cell Percentage Value",
+            "term_url": "https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=2841241&version=1.0"
+          }
+        },
+        "type": "number"
+      },
+      "percent_tumor_cells": {
+        "term": {
+          "description": "Numeric value that represents the percentage of infiltration by granulocytes in a sample.\n",
+          "termDef": {
+            "cde_id": 5432686,
+            "cde_version": 1,
+            "source": "caDSR",
+            "term": "Specimen Tumor Cell Percentage Value",
+            "term_url": "https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=5432686&version=1.0"
+          }
+        },
+        "type": "number"
+      },
+      "percent_tumor_nuclei": {
+        "term": {
+          "description": "Numeric value to represent the percentage of tumor nuclei in a malignant neoplasm sample or specimen.\n",
+          "termDef": {
+            "cde_id": 2841225,
+            "cde_version": 1,
+            "source": "caDSR",
+            "term": "Malignant Neoplasm Neoplasm Nucleus Percentage Cell Value",
+            "term_url": "https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=2841225&version=1.0"
+          }
+        },
+        "type": "number"
+      },
+      "project_id": {
+        "term": {
+          "description": "Unique ID for any specific defined piece of work that is undertaken or attempted to meet a single requirement.\n"
+        },
+        "type": "string"
+      },
+      "run_datetime": {
+        "oneOf": [
+          {
+            "format": "date-time",
+            "type": "string"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "term": {
+          "description": "A combination of date and time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]\n"
+        }
+      },
+      "run_name": {
+        "description": "Name, number, or other identifier given to this slide's run.",
+        "type": "string"
+      },
+      "samples": {
         "anyOf": [
           {
             "items": {
@@ -18895,127 +10710,15 @@
           }
         ]
       },
-      "blood_fractionation_method": {
-        "description": "The name or description of the method used to obtain the blood fraction sample. (e.g. Ficoll Method, Novartis Protocol #001, 2000 g centrifuge at 4C with gentle deceleration). Alternatively, if you have provided a detailed protocol, enter its file_name here.\n",
-        "type": "string"
-      },
-      "composition": {
-        "enum": [
-          "Buccal Cells",
-          "Buffy Coat",
-          "Bone Marrow Components",
-          "Bone Marrow Components NOS",
-          "Control Analyte",
-          "Cell",
-          "Circulating Tumor Cell (CTC)",
-          "Derived Cell Line",
-          "EBV Immortalized",
-          "Fibroblasts from Bone Marrow Normal",
-          "Granulocytes",
-          "Human Original Cells",
-          "Lymphocytes",
-          "Mononuclear Cells from Bone Marrow Normal",
-          "Peripheral Blood Components NOS",
-          "Peripheral Blood Nucleated Cells",
-          "Pleural Effusion",
-          "Plasma",
-          "Peripheral Whole Blood",
-          "Serum",
-          "Saliva",
-          "Sputum",
-          "Solid Tissue",
-          "Whole Bone Marrow",
-          "Unknown"
-        ],
+      "section_location": {
         "term": {
-          "description": "Text term that represents the cellular composition of the sample.\n",
-          "termDef": {
-            "cde_id": 5432591,
-            "cde_version": 1,
-            "source": "caDSR",
-            "term": "Biospecimen Cellular Composition Type",
-            "term_url": "https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=5432591&version=1.0"
-          }
-        }
-      },
-      "created_datetime": {
-        "oneOf": [
-          {
-            "format": "date-time",
-            "type": "string"
-          },
-          {
-            "type": "null"
-          }
-        ],
-        "term": {
-          "description": "A combination of date and time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]\n"
-        }
-      },
-      "hours_to_fractionation_lower": {
-        "description": "The lower limit on the amount of time, in hours, between the blood draw and the fractionation into its components. If the exact time is known, make this value equal to that of the upper limit. If the time is completely unknown, enter Unknown. If no fractionation was performed on this sample, enter Not Applicable.\n",
-        "oneOf": [
-          {
-            "enum": [
-              "Not Applicable",
-              "Unknown"
-            ]
-          },
-          {
-            "type": "number"
-          }
-        ],
-        "type": [
-          "number",
-          "string"
-        ]
-      },
-      "hours_to_fractionation_upper": {
-        "description": "The upper limit on the amount of time, in hours, between the blood draw and the fractionation into its components. If the exact time is known, make this value equal to that of the lower limit. If the time is completely unknown, enter Unknown. If no fractionation was performed on this sample, enter Not Applicable.\n",
-        "oneOf": [
-          {
-            "enum": [
-              "Not Applicable",
-              "Unknown"
-            ]
-          },
-          {
-            "type": "number"
-          }
-        ],
-        "type": [
-          "number",
-          "string"
-        ]
-      },
-      "id": {
-        "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
-        "systemAlias": "node_id",
-        "term": {
-          "description": "A 128-bit identifier. Depending on the mechanism used to generate it, it is either guaranteed to be different from all other UUIDs/GUIDs generated until 3400 AD or extremely likely to be different. Its relatively small size lends itself well to sorting, ordering, and hashing of all sorts, storing in databases, simple allocation, and ease of programming in general.\n",
-          "termDef": {
-            "cde_id": "C54100",
-            "cde_version": null,
-            "source": "NCIt",
-            "term": "Universally Unique Identifier",
-            "term_url": "https://ncit.nci.nih.gov/ncitbrowser/ConceptReport.jsp?dictionary=NCI_Thesaurus&version=16.02d&ns=NCI_Thesaurus&code=C54100"
-          }
+          "description": "Tissue source of the slide.\n"
         },
         "type": "string"
       },
-      "project_id": {
-        "term": {
-          "description": "Unique ID for any specific defined piece of work that is undertaken or attempted to meet a single requirement.\n"
-        },
+      "slide_identifier": {
+        "description": "Unique identifier given to the this slide.",
         "type": "string"
-      },
-      "sample_quantity": {
-        "description": "For solid samples, the mass of the sample in milligrams (mg).",
-        "type": "number"
-      },
-      "sample_volume": {
-        "description": "For liquid samples, the volume of the sample in millilitres (mL).",
-        "type": "number"
       },
       "state": {
         "default": "validated",
@@ -19058,22 +10761,10 @@
           "description": "The current state of the object.\n"
         }
       },
-      "storage_agitation": {
-        "description": "Indicate whether samples were agitated during storage.\n",
-        "enum": [
-          "Yes",
-          "No",
-          "Unknown"
-        ]
-      },
-      "storage_agitation_hours": {
-        "description": "The number of hours samples were agitated during storage; if a number is given here, also answer 'Yes' to 'storage_agitation'.\n",
-        "type": "number"
-      },
       "submitter_id": {
-        "description": "A project-specific identifier for a node. This property is the calling card/nickname/alias for a unit of submission. It can be used in place of the UUID for identifying or recalling a node.\n",
         "type": [
-          "string"
+          "string",
+          "null"
         ]
       },
       "type": {
@@ -19096,9 +10787,7 @@
     },
     "required": [
       "submitter_id",
-      "type",
-      "composition",
-      "biospecimens"
+      "samples"
     ],
     "submittable": true,
     "systemProperties": [
@@ -19108,7 +10797,7 @@
       "created_datetime",
       "updated_datetime"
     ],
-    "title": "Sample",
+    "title": "Slide",
     "type": "object",
     "uniqueKeys": [
       [
@@ -19121,48 +10810,45 @@
     ],
     "validators": null
   },
-  "sequencing_assay": {
+  "slide_count": {
     "$schema": "http://json-schema.org/draft-04/schema#",
     "additionalProperties": false,
     "category": "notation",
-    "description": "Information pertaining to processed results obtained from a sequencing assay.\n",
-    "id": "sequencing_assay",
+    "description": "Information pertaining to processed results obtained from slides; often in the form of counts.\n",
+    "id": "slide_count",
     "links": [
       {
-        "backref": "assay_results",
+        "backref": "slide_counts",
         "label": "data_from",
         "multiplicity": "many_to_many",
-        "name": "read_groups",
+        "name": "slides",
         "required": true,
-        "target_type": "read_group"
+        "target_type": "slide"
       }
     ],
-    "namespace": "https://www.bloodpac.org",
+    "namespace": "http://gdc.nci.nih.gov",
     "program": "*",
     "project": "*",
     "properties": {
-      "WT_copies": {
-        "description": "WT DNA absolute coppies in the ctDNA. Requires copies_unit.",
+      "biomarker_signal": {
+        "description": "Numeric quantification of the biomarker signal.",
+        "type": "number"
+      },
+      "cell_count": {
+        "description": "Raw count of a particular cell type.",
         "type": "integer"
       },
-      "assay_method": {
-        "description": "General name or description of the method used to characterize the analyte.",
-        "enum": [
-          "Targeted Sequencing",
-          "Copy Number Analysis"
-        ]
-      },
-      "assay_target": {
-        "description": "Gene of interest for the assay.",
+      "cell_identifier": {
+        "description": "An alternative identifier for a given cell type.",
         "type": "string"
       },
-      "assay_target_secondary": {
-        "description": "Secondary gene of interest for the assay.",
+      "cell_type": {
+        "description": "The type of cell being counted or measured.",
         "type": "string"
       },
-      "copies_unit": {
-        "description": "The units for the copies measured (e.g. copies/xxx uL plasma).",
-        "type": "string"
+      "ck_signal": {
+        "description": "Numeric quantification of the CK signal.",
+        "type": "number"
       },
       "created_datetime": {
         "oneOf": [
@@ -19176,6 +10862,774 @@
         ],
         "term": {
           "description": "A combination of date and time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]\n"
+        }
+      },
+      "er_localization": {
+        "description": "Cellular localization of the endoplasmic reticulum as determined by staining.",
+        "enum": [
+          "Nuclear",
+          "Cytoplasmic",
+          "Both",
+          "None",
+          "Not Determined"
+        ]
+      },
+      "frame_identifier": {
+        "description": "Name, number, or other identifier given to the frame of the slide from which this image was taken.",
+        "type": "string"
+      },
+      "id": {
+        "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
+        "systemAlias": "node_id",
+        "term": {
+          "description": "A 128-bit identifier. Depending on the mechanism used to generate it, it is either guaranteed to be different from all other UUIDs/GUIDs generated until 3400 AD or extremely likely to be different. Its relatively small size lends itself well to sorting, ordering, and hashing of all sorts, storing in databases, simple allocation, and ease of programming in general.\n",
+          "termDef": {
+            "cde_id": "C54100",
+            "cde_version": null,
+            "source": "NCIt",
+            "term": "Universally Unique Identifier",
+            "term_url": "https://ncit.nci.nih.gov/ncitbrowser/ConceptReport.jsp?dictionary=NCI_Thesaurus&version=16.02d&ns=NCI_Thesaurus&code=C54100"
+          }
+        },
+        "type": "string"
+      },
+      "project_id": {
+        "type": "string"
+      },
+      "relative_cytokeratin_intensity": {
+        "description": "The ratio of the single cell's cytokeratin staining intensity to the average of the surrounding cells.",
+        "type": "number"
+      },
+      "relative_er_intensity": {
+        "description": "The ratio of the single cell's endoplasmic reticulum staining intensity to the average of the surrounding cells.",
+        "type": "number"
+      },
+      "relative_nuclear_intensity": {
+        "description": "The ratio of the single cell's nuclear staining intensity to the average of the surrounding cells.",
+        "type": "number"
+      },
+      "relative_nuclear_size": {
+        "description": "The ratio of the single cell's nucleus size to the average of the surrounding cells.",
+        "type": "number"
+      },
+      "run_name": {
+        "description": "The name or identifier given to the run that was used to generate this slide count.",
+        "type": "string"
+      },
+      "slides": {
+        "anyOf": [
+          {
+            "items": {
+              "additionalProperties": true,
+              "minItems": 1,
+              "properties": {
+                "id": {
+                  "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
+                  "term": {
+                    "description": "A 128-bit identifier. Depending on the mechanism used to generate it, it is either guaranteed to be different from all other UUIDs/GUIDs generated until 3400 AD or extremely likely to be different. Its relatively small size lends itself well to sorting, ordering, and hashing of all sorts, storing in databases, simple allocation, and ease of programming in general.\n",
+                    "termDef": {
+                      "cde_id": "C54100",
+                      "cde_version": null,
+                      "source": "NCIt",
+                      "term": "Universally Unique Identifier",
+                      "term_url": "https://ncit.nci.nih.gov/ncitbrowser/ConceptReport.jsp?dictionary=NCI_Thesaurus&version=16.02d&ns=NCI_Thesaurus&code=C54100"
+                    }
+                  },
+                  "type": "string"
+                },
+                "submitter_id": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "type": "array"
+          },
+          {
+            "additionalProperties": true,
+            "properties": {
+              "id": {
+                "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
+                "term": {
+                  "description": "A 128-bit identifier. Depending on the mechanism used to generate it, it is either guaranteed to be different from all other UUIDs/GUIDs generated until 3400 AD or extremely likely to be different. Its relatively small size lends itself well to sorting, ordering, and hashing of all sorts, storing in databases, simple allocation, and ease of programming in general.\n",
+                  "termDef": {
+                    "cde_id": "C54100",
+                    "cde_version": null,
+                    "source": "NCIt",
+                    "term": "Universally Unique Identifier",
+                    "term_url": "https://ncit.nci.nih.gov/ncitbrowser/ConceptReport.jsp?dictionary=NCI_Thesaurus&version=16.02d&ns=NCI_Thesaurus&code=C54100"
+                  }
+                },
+                "type": "string"
+              },
+              "submitter_id": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          }
+        ]
+      },
+      "state": {
+        "default": "validated",
+        "downloadable": [
+          "uploaded",
+          "md5summed",
+          "validating",
+          "validated",
+          "error",
+          "invalid",
+          "released"
+        ],
+        "oneOf": [
+          {
+            "enum": [
+              "uploading",
+              "uploaded",
+              "md5summing",
+              "md5summed",
+              "validating",
+              "error",
+              "invalid",
+              "suppressed",
+              "redacted",
+              "live"
+            ]
+          },
+          {
+            "enum": [
+              "validated",
+              "submitted",
+              "released"
+            ]
+          }
+        ],
+        "public": [
+          "live"
+        ],
+        "term": {
+          "description": "The current state of the object.\n"
+        }
+      },
+      "submitter_id": {
+        "type": [
+          "string",
+          "null"
+        ]
+      },
+      "type": {
+        "enum": [
+          "slide_count"
+        ]
+      },
+      "updated_datetime": {
+        "oneOf": [
+          {
+            "format": "date-time",
+            "type": "string"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "term": {
+          "description": "A combination of date and time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]\n"
+        }
+      }
+    },
+    "required": [
+      "submitter_id",
+      "slides"
+    ],
+    "submittable": true,
+    "systemProperties": [
+      "id",
+      "project_id",
+      "created_datetime",
+      "updated_datetime",
+      "state"
+    ],
+    "title": "Slide Count",
+    "type": "object",
+    "uniqueKeys": [
+      [
+        "id"
+      ],
+      [
+        "project_id",
+        "submitter_id"
+      ]
+    ],
+    "validators": null
+  },
+  "slide_image": {
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "additionalProperties": false,
+    "category": "data_file",
+    "description": "Data file containing image of a slide.\n",
+    "id": "slide_image",
+    "links": [
+      {
+        "backref": "slide_images",
+        "label": "data_from",
+        "multiplicity": "many_to_one",
+        "name": "slides",
+        "required": true,
+        "target_type": "slide"
+      },
+      {
+        "backref": "slide_images",
+        "label": "data_from",
+        "multiplicity": "many_to_many",
+        "name": "core_metadata_collections",
+        "required": false,
+        "target_type": "core_metadata_collection"
+      }
+    ],
+    "namespace": "http://gdc.nci.nih.gov",
+    "program": "*",
+    "project": "*",
+    "properties": {
+      "cell_count": {
+        "description": "Count of the cell type being imaged or otherwise analysed.",
+        "type": "integer"
+      },
+      "cell_identifier": {
+        "description": "An alternative identifier for a given cell type.",
+        "type": "string"
+      },
+      "cell_type": {
+        "description": "The type of cell being imaged or otherwised analysed.",
+        "type": "string"
+      },
+      "core_metadata_collections": {
+        "anyOf": [
+          {
+            "items": {
+              "additionalProperties": true,
+              "minItems": 1,
+              "properties": {
+                "id": {
+                  "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
+                  "term": {
+                    "description": "A 128-bit identifier. Depending on the mechanism used to generate it, it is either guaranteed to be different from all other UUIDs/GUIDs generated until 3400 AD or extremely likely to be different. Its relatively small size lends itself well to sorting, ordering, and hashing of all sorts, storing in databases, simple allocation, and ease of programming in general.\n",
+                    "termDef": {
+                      "cde_id": "C54100",
+                      "cde_version": null,
+                      "source": "NCIt",
+                      "term": "Universally Unique Identifier",
+                      "term_url": "https://ncit.nci.nih.gov/ncitbrowser/ConceptReport.jsp?dictionary=NCI_Thesaurus&version=16.02d&ns=NCI_Thesaurus&code=C54100"
+                    }
+                  },
+                  "type": "string"
+                },
+                "submitter_id": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "type": "array"
+          },
+          {
+            "additionalProperties": true,
+            "properties": {
+              "id": {
+                "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
+                "term": {
+                  "description": "A 128-bit identifier. Depending on the mechanism used to generate it, it is either guaranteed to be different from all other UUIDs/GUIDs generated until 3400 AD or extremely likely to be different. Its relatively small size lends itself well to sorting, ordering, and hashing of all sorts, storing in databases, simple allocation, and ease of programming in general.\n",
+                  "termDef": {
+                    "cde_id": "C54100",
+                    "cde_version": null,
+                    "source": "NCIt",
+                    "term": "Universally Unique Identifier",
+                    "term_url": "https://ncit.nci.nih.gov/ncitbrowser/ConceptReport.jsp?dictionary=NCI_Thesaurus&version=16.02d&ns=NCI_Thesaurus&code=C54100"
+                  }
+                },
+                "type": "string"
+              },
+              "submitter_id": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          }
+        ]
+      },
+      "created_datetime": {
+        "oneOf": [
+          {
+            "format": "date-time",
+            "type": "string"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "term": {
+          "description": "A combination of date and time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]\n"
+        }
+      },
+      "data_category": {
+        "enum": [
+          "Biospecimen",
+          "Slide Image",
+          "Mass Cytometry"
+        ],
+        "term": {
+          "description": "Broad categorization of the contents of the data file.\n"
+        }
+      },
+      "data_format": {
+        "term": {
+          "description": "Format of the data files.\n"
+        },
+        "type": "string"
+      },
+      "data_type": {
+        "enum": [
+          "image",
+          "Single Cell Image",
+          "Raw IMC Data",
+          "Single Channel IMC Image",
+          "Antibody Panel Added"
+        ],
+        "term": {
+          "description": "Specific content type of the data file.\n"
+        }
+      },
+      "error_type": {
+        "enum": [
+          "file_size",
+          "file_format",
+          "md5sum"
+        ],
+        "term": {
+          "description": "Type of error for the data file object.\n"
+        }
+      },
+      "experimental_strategy": {
+        "description": "Classification of the slide type with respect to its experimental use.",
+        "enum": [
+          "Diagnostic Slide",
+          "Tissue Slide"
+        ]
+      },
+      "file_name": {
+        "term": {
+          "description": "The name (or part of a name) of a file (of any type).\n"
+        },
+        "type": "string"
+      },
+      "file_size": {
+        "term": {
+          "description": "The size of the data file (object) in bytes.\n"
+        },
+        "type": "integer"
+      },
+      "file_state": {
+        "default": "registered",
+        "enum": [
+          "registered",
+          "uploading",
+          "uploaded",
+          "validating",
+          "validated",
+          "submitted",
+          "processing",
+          "processed",
+          "released",
+          "error"
+        ],
+        "term": {
+          "description": "The current state of the data file object.\n"
+        }
+      },
+      "frame_identifier": {
+        "description": "Name, number, or other identifier given to the frame of the slide from which this image was taken.",
+        "type": "string"
+      },
+      "id": {
+        "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
+        "systemAlias": "node_id",
+        "term": {
+          "description": "A 128-bit identifier. Depending on the mechanism used to generate it, it is either guaranteed to be different from all other UUIDs/GUIDs generated until 3400 AD or extremely likely to be different. Its relatively small size lends itself well to sorting, ordering, and hashing of all sorts, storing in databases, simple allocation, and ease of programming in general.\n",
+          "termDef": {
+            "cde_id": "C54100",
+            "cde_version": null,
+            "source": "NCIt",
+            "term": "Universally Unique Identifier",
+            "term_url": "https://ncit.nci.nih.gov/ncitbrowser/ConceptReport.jsp?dictionary=NCI_Thesaurus&version=16.02d&ns=NCI_Thesaurus&code=C54100"
+          }
+        },
+        "type": "string"
+      },
+      "md5sum": {
+        "pattern": "^[a-f0-9]{32}$",
+        "term": {
+          "description": "The 128-bit hash value expressed as a 32 digit hexadecimal number used as a file's digital fingerprint.\n"
+        },
+        "type": "string"
+      },
+      "object_id": {
+        "description": "The GUID of the object in the index service.",
+        "type": "string"
+      },
+      "panel_used": {
+        "description": "Name or other identifier given to the panel used during an IMC run.",
+        "type": "string"
+      },
+      "project_id": {
+        "term": {
+          "description": "Unique ID for any specific defined piece of work that is undertaken or attempted to meet a single requirement.\n"
+        },
+        "type": "string"
+      },
+      "protocol_used": {
+        "description": "Name or other identifier given to the protocol used during an IMC run.",
+        "type": "string"
+      },
+      "run_name": {
+        "description": "Name, number, or other identifier given to the run that generated this slide image.",
+        "type": "string"
+      },
+      "slides": {
+        "anyOf": [
+          {
+            "items": {
+              "additionalProperties": true,
+              "maxItems": 1,
+              "minItems": 1,
+              "properties": {
+                "id": {
+                  "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
+                  "term": {
+                    "description": "A 128-bit identifier. Depending on the mechanism used to generate it, it is either guaranteed to be different from all other UUIDs/GUIDs generated until 3400 AD or extremely likely to be different. Its relatively small size lends itself well to sorting, ordering, and hashing of all sorts, storing in databases, simple allocation, and ease of programming in general.\n",
+                    "termDef": {
+                      "cde_id": "C54100",
+                      "cde_version": null,
+                      "source": "NCIt",
+                      "term": "Universally Unique Identifier",
+                      "term_url": "https://ncit.nci.nih.gov/ncitbrowser/ConceptReport.jsp?dictionary=NCI_Thesaurus&version=16.02d&ns=NCI_Thesaurus&code=C54100"
+                    }
+                  },
+                  "type": "string"
+                },
+                "submitter_id": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "type": "array"
+          },
+          {
+            "additionalProperties": true,
+            "properties": {
+              "id": {
+                "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
+                "term": {
+                  "description": "A 128-bit identifier. Depending on the mechanism used to generate it, it is either guaranteed to be different from all other UUIDs/GUIDs generated until 3400 AD or extremely likely to be different. Its relatively small size lends itself well to sorting, ordering, and hashing of all sorts, storing in databases, simple allocation, and ease of programming in general.\n",
+                  "termDef": {
+                    "cde_id": "C54100",
+                    "cde_version": null,
+                    "source": "NCIt",
+                    "term": "Universally Unique Identifier",
+                    "term_url": "https://ncit.nci.nih.gov/ncitbrowser/ConceptReport.jsp?dictionary=NCI_Thesaurus&version=16.02d&ns=NCI_Thesaurus&code=C54100"
+                  }
+                },
+                "type": "string"
+              },
+              "submitter_id": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          }
+        ]
+      },
+      "state": {
+        "default": "validated",
+        "downloadable": [
+          "uploaded",
+          "md5summed",
+          "validating",
+          "validated",
+          "error",
+          "invalid",
+          "released"
+        ],
+        "oneOf": [
+          {
+            "enum": [
+              "uploading",
+              "uploaded",
+              "md5summing",
+              "md5summed",
+              "validating",
+              "error",
+              "invalid",
+              "suppressed",
+              "redacted",
+              "live"
+            ]
+          },
+          {
+            "enum": [
+              "validated",
+              "submitted",
+              "released"
+            ]
+          }
+        ],
+        "public": [
+          "live"
+        ],
+        "term": {
+          "description": "The current state of the object.\n"
+        }
+      },
+      "state_comment": {
+        "description": "Optional comment about why the file is in the current state, mainly for invalid state.\n",
+        "type": "string"
+      },
+      "submitter_id": {
+        "description": "The file ID assigned by the submitter.",
+        "type": [
+          "string",
+          "null"
+        ]
+      },
+      "type": {
+        "enum": [
+          "slide_image"
+        ]
+      },
+      "updated_datetime": {
+        "oneOf": [
+          {
+            "format": "date-time",
+            "type": "string"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "term": {
+          "description": "A combination of date and time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]\n"
+        }
+      }
+    },
+    "required": [
+      "submitter_id",
+      "file_name",
+      "file_size",
+      "md5sum",
+      "data_category",
+      "data_type",
+      "data_format",
+      "slides"
+    ],
+    "submittable": true,
+    "systemProperties": [
+      "id",
+      "project_id",
+      "created_datetime",
+      "updated_datetime",
+      "state",
+      "file_state",
+      "error_type"
+    ],
+    "title": "Slide Image",
+    "type": "object",
+    "uniqueKeys": [
+      [
+        "id"
+      ],
+      [
+        "project_id",
+        "submitter_id"
+      ]
+    ],
+    "validators": null
+  },
+  "submitted_aligned_reads": {
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "additionalProperties": false,
+    "category": "data_file",
+    "description": "Data file containing aligned reads that are used as input to GDC workflows.\n",
+    "id": "submitted_aligned_reads",
+    "links": [
+      {
+        "backref": "submitted_aligned_reads_files",
+        "label": "data_from",
+        "multiplicity": "one_to_many",
+        "name": "read_groups",
+        "required": true,
+        "target_type": "read_group"
+      },
+      {
+        "backref": "submitted_aligned_reads_files",
+        "label": "data_from",
+        "multiplicity": "many_to_many",
+        "name": "core_metadata_collections",
+        "required": false,
+        "target_type": "core_metadata_collection"
+      }
+    ],
+    "namespace": "http://gdc.nci.nih.gov",
+    "program": "*",
+    "project": "*",
+    "properties": {
+      "core_metadata_collections": {
+        "anyOf": [
+          {
+            "items": {
+              "additionalProperties": true,
+              "minItems": 1,
+              "properties": {
+                "id": {
+                  "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
+                  "term": {
+                    "description": "A 128-bit identifier. Depending on the mechanism used to generate it, it is either guaranteed to be different from all other UUIDs/GUIDs generated until 3400 AD or extremely likely to be different. Its relatively small size lends itself well to sorting, ordering, and hashing of all sorts, storing in databases, simple allocation, and ease of programming in general.\n",
+                    "termDef": {
+                      "cde_id": "C54100",
+                      "cde_version": null,
+                      "source": "NCIt",
+                      "term": "Universally Unique Identifier",
+                      "term_url": "https://ncit.nci.nih.gov/ncitbrowser/ConceptReport.jsp?dictionary=NCI_Thesaurus&version=16.02d&ns=NCI_Thesaurus&code=C54100"
+                    }
+                  },
+                  "type": "string"
+                },
+                "submitter_id": {
+                  "type": "string"
+                }
+              },
+              "type": "object"
+            },
+            "type": "array"
+          },
+          {
+            "additionalProperties": true,
+            "properties": {
+              "id": {
+                "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
+                "term": {
+                  "description": "A 128-bit identifier. Depending on the mechanism used to generate it, it is either guaranteed to be different from all other UUIDs/GUIDs generated until 3400 AD or extremely likely to be different. Its relatively small size lends itself well to sorting, ordering, and hashing of all sorts, storing in databases, simple allocation, and ease of programming in general.\n",
+                  "termDef": {
+                    "cde_id": "C54100",
+                    "cde_version": null,
+                    "source": "NCIt",
+                    "term": "Universally Unique Identifier",
+                    "term_url": "https://ncit.nci.nih.gov/ncitbrowser/ConceptReport.jsp?dictionary=NCI_Thesaurus&version=16.02d&ns=NCI_Thesaurus&code=C54100"
+                  }
+                },
+                "type": "string"
+              },
+              "submitter_id": {
+                "type": "string"
+              }
+            },
+            "type": "object"
+          }
+        ]
+      },
+      "created_datetime": {
+        "oneOf": [
+          {
+            "format": "date-time",
+            "type": "string"
+          },
+          {
+            "type": "null"
+          }
+        ],
+        "term": {
+          "description": "A combination of date and time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]\n"
+        }
+      },
+      "data_category": {
+        "enum": [
+          "Sequencing Data",
+          "Sequencing Reads",
+          "Raw Sequencing Data"
+        ],
+        "term": {
+          "description": "Broad categorization of the contents of the data file.\n"
+        }
+      },
+      "data_format": {
+        "enum": [
+          "BAM",
+          "BED"
+        ],
+        "term": {
+          "description": "Format of the data files.\n"
+        }
+      },
+      "data_type": {
+        "enum": [
+          "Aligned Reads",
+          "Alignment Coordinates"
+        ],
+        "term": {
+          "description": "Specific content type of the data file.\n"
+        }
+      },
+      "error_type": {
+        "enum": [
+          "file_size",
+          "file_format",
+          "md5sum"
+        ],
+        "term": {
+          "description": "Type of error for the data file object.\n"
+        }
+      },
+      "experimental_strategy": {
+        "enum": [
+          "WGS",
+          "WXS",
+          "Low Pass WGS",
+          "Validation",
+          "RNA-Seq",
+          "miRNA-Seq",
+          "Total RNA-Seq",
+          "DNA Panel"
+        ],
+        "term": {
+          "description": "The sequencing strategy used to generate the data file.\n"
+        }
+      },
+      "file_name": {
+        "term": {
+          "description": "The name (or part of a name) of a file (of any type).\n"
+        },
+        "type": "string"
+      },
+      "file_size": {
+        "term": {
+          "description": "The size of the data file (object) in bytes.\n"
+        },
+        "type": "integer"
+      },
+      "file_state": {
+        "default": "registered",
+        "enum": [
+          "registered",
+          "uploading",
+          "uploaded",
+          "validating",
+          "validated",
+          "submitted",
+          "processing",
+          "processed",
+          "released",
+          "error"
+        ],
+        "term": {
+          "description": "The current state of the data file object.\n"
         }
       },
       "id": {
@@ -19193,40 +11647,22 @@
         },
         "type": "string"
       },
-      "mutant_copies": {
-        "description": "Mutant DNA absolute copies in the ctDNA. Requires copies_unit.",
-        "type": "integer"
+      "md5sum": {
+        "pattern": "^[a-f0-9]{32}$",
+        "term": {
+          "description": "The 128-bit hash value expressed as a 32 digit hexadecimal number used as a file's digital fingerprint.\n"
+        },
+        "type": "string"
       },
-      "mutant_fraction_percent": {
-        "description": "Percent of the target that is identified as mutant.",
-        "type": "number"
-      },
-      "mutation_result": {
-        "description": "Observed mutation type.",
-        "enum": [
-          "Copy Number Amplification",
-          "Copy Number Deletion",
-          "Frameshift",
-          "Missense",
-          "Nonsense",
-          "Nonstart",
-          "Nonstop",
-          "Nonframeshift Insertion",
-          "Nonframeshift Deletion",
-          "Splice Site",
-          "Unspecified",
-          "No Mutation Detected"
-        ]
+      "object_id": {
+        "description": "The GUID of the object in the index service.",
+        "type": "string"
       },
       "project_id": {
         "term": {
           "description": "Unique ID for any specific defined piece of work that is undertaken or attempted to meet a single requirement.\n"
         },
         "type": "string"
-      },
-      "read_depth": {
-        "description": "The read depth of the assay.",
-        "type": "integer"
       },
       "read_groups": {
         "anyOf": [
@@ -19323,88 +11759,21 @@
           "description": "The current state of the object.\n"
         }
       },
+      "state_comment": {
+        "description": "Optional comment about why the file is in the current state, mainly for invalid state.\n",
+        "type": "string"
+      },
       "submitter_id": {
-        "description": "A project-specific identifier for a node. This property is the calling card/nickname/alias for a unit of submission. It can be used in place of the UUID for identifying or recalling a node.\n",
+        "description": "The file ID assigned by the submitter.",
         "type": [
-          "string"
+          "string",
+          "null"
         ]
-      },
-      "target_alt": {
-        "description": "The observed alternate sequence for the genomic region being investigated.",
-        "type": "string"
-      },
-      "target_chromosome": {
-        "description": "The chromosome on which the gene of interest is located.",
-        "enum": [
-          "1",
-          "2",
-          "3",
-          "4",
-          "5",
-          "6",
-          "7",
-          "8",
-          "9",
-          "10",
-          "11",
-          "12",
-          "13",
-          "14",
-          "15",
-          "16",
-          "17",
-          "18",
-          "19",
-          "20",
-          "21",
-          "22",
-          "X",
-          "Y"
-        ]
-      },
-      "target_chromosome_secondary": {
-        "description": "The chromosome on which the secondary gene of interest is located.",
-        "enum": [
-          "1",
-          "2",
-          "3",
-          "4",
-          "5",
-          "6",
-          "7",
-          "8",
-          "9",
-          "10",
-          "11",
-          "12",
-          "13",
-          "14",
-          "15",
-          "16",
-          "17",
-          "18",
-          "19",
-          "20",
-          "21",
-          "22",
-          "X",
-          "Y"
-        ]
-      },
-      "target_position": {
-        "description": "The position on the chromosome on which the gene of interest is located.",
-        "type": "integer"
-      },
-      "target_position_secondary": {
-        "description": "The position on the chromosome on which the secondary gene of interest is located.",
-        "type": "integer"
-      },
-      "target_ref": {
-        "description": "The reference sequence for the genomic region that is being investigated.",
-        "type": "string"
       },
       "type": {
-        "type": "string"
+        "enum": [
+          "submitted_aligned_reads"
+        ]
       },
       "updated_datetime": {
         "oneOf": [
@@ -19423,7 +11792,13 @@
     },
     "required": [
       "submitter_id",
-      "type",
+      "file_name",
+      "file_size",
+      "data_format",
+      "md5sum",
+      "data_category",
+      "data_type",
+      "experimental_strategy",
       "read_groups"
     ],
     "submittable": true,
@@ -19432,9 +11807,11 @@
       "project_id",
       "created_datetime",
       "updated_datetime",
-      "state"
+      "state",
+      "file_state",
+      "error_type"
     ],
-    "title": "Sequencing Assay",
+    "title": "Submitted Aligned Reads",
     "type": "object",
     "uniqueKeys": [
       [
@@ -19447,37 +11824,37 @@
     ],
     "validators": null
   },
-  "slide_image": {
+  "submitted_copy_number": {
     "$schema": "http://json-schema.org/draft-04/schema#",
     "additionalProperties": false,
     "category": "data_file",
-    "description": "Data file containing image of a slide.\n",
-    "id": "slide_image",
+    "description": "Data file containing normalized copy number information from an aliquot.\n",
+    "id": "submitted_copy_number",
     "links": [
       {
-        "exclusive": false,
+        "exclusive": true,
         "required": true,
         "subgroup": [
           {
-            "backref": "slide_images",
-            "label": "data_from",
+            "backref": "submitted_copy_number_files",
+            "label": "derived_from",
             "multiplicity": "one_to_one",
-            "name": "core_metadata_collections",
-            "required": false,
-            "target_type": "core_metadata_collection"
-          },
-          {
-            "backref": "slide_images",
-            "label": "data_from",
-            "multiplicity": "many_to_one",
             "name": "aliquots",
             "required": false,
             "target_type": "aliquot"
+          },
+          {
+            "backref": "submitted_copy_number_files",
+            "label": "derived_from",
+            "multiplicity": "many_to_many",
+            "name": "read_groups",
+            "required": false,
+            "target_type": "read_group"
           }
         ]
       }
     ],
-    "namespace": "https://www.bloodpac.org",
+    "namespace": "http://gdc.nci.nih.gov",
     "program": "*",
     "project": "*",
     "properties": {
@@ -19536,61 +11913,6 @@
           }
         ]
       },
-      "core_metadata_collections": {
-        "anyOf": [
-          {
-            "items": {
-              "additionalProperties": true,
-              "maxItems": 1,
-              "minItems": 1,
-              "properties": {
-                "id": {
-                  "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
-                  "term": {
-                    "description": "A 128-bit identifier. Depending on the mechanism used to generate it, it is either guaranteed to be different from all other UUIDs/GUIDs generated until 3400 AD or extremely likely to be different. Its relatively small size lends itself well to sorting, ordering, and hashing of all sorts, storing in databases, simple allocation, and ease of programming in general.\n",
-                    "termDef": {
-                      "cde_id": "C54100",
-                      "cde_version": null,
-                      "source": "NCIt",
-                      "term": "Universally Unique Identifier",
-                      "term_url": "https://ncit.nci.nih.gov/ncitbrowser/ConceptReport.jsp?dictionary=NCI_Thesaurus&version=16.02d&ns=NCI_Thesaurus&code=C54100"
-                    }
-                  },
-                  "type": "string"
-                },
-                "submitter_id": {
-                  "type": "string"
-                }
-              },
-              "type": "object"
-            },
-            "type": "array"
-          },
-          {
-            "additionalProperties": true,
-            "properties": {
-              "id": {
-                "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
-                "term": {
-                  "description": "A 128-bit identifier. Depending on the mechanism used to generate it, it is either guaranteed to be different from all other UUIDs/GUIDs generated until 3400 AD or extremely likely to be different. Its relatively small size lends itself well to sorting, ordering, and hashing of all sorts, storing in databases, simple allocation, and ease of programming in general.\n",
-                  "termDef": {
-                    "cde_id": "C54100",
-                    "cde_version": null,
-                    "source": "NCIt",
-                    "term": "Universally Unique Identifier",
-                    "term_url": "https://ncit.nci.nih.gov/ncitbrowser/ConceptReport.jsp?dictionary=NCI_Thesaurus&version=16.02d&ns=NCI_Thesaurus&code=C54100"
-                  }
-                },
-                "type": "string"
-              },
-              "submitter_id": {
-                "type": "string"
-              }
-            },
-            "type": "object"
-          }
-        ]
-      },
       "created_datetime": {
         "oneOf": [
           {
@@ -19606,12 +11928,10 @@
         }
       },
       "data_category": {
-        "enum": [
-          "Slide Image"
-        ],
         "term": {
           "description": "Broad categorization of the contents of the data file.\n"
-        }
+        },
+        "type": "string"
       },
       "data_format": {
         "term": {
@@ -19620,561 +11940,10 @@
         "type": "string"
       },
       "data_type": {
-        "enum": [
-          "Diagnostic Slide Image",
-          "Tissue Slide Image",
-          "Blood Slide Image"
-        ],
         "term": {
           "description": "Specific content type of the data file.\n"
-        }
-      },
-      "error_type": {
-        "enum": [
-          "file_size",
-          "file_format",
-          "md5sum"
-        ],
-        "term": {
-          "description": "Type of error for the data file object.\n"
-        }
-      },
-      "file_name": {
-        "term": {
-          "description": "The name (or part of a name) of a file (of any type).\n"
         },
         "type": "string"
-      },
-      "file_size": {
-        "term": {
-          "description": "The size of the data file (object) in bytes.\n"
-        },
-        "type": "integer"
-      },
-      "file_state": {
-        "default": "registered",
-        "enum": [
-          "registered",
-          "uploading",
-          "uploaded",
-          "validating",
-          "validated",
-          "submitted",
-          "processing",
-          "processed",
-          "released",
-          "error"
-        ],
-        "term": {
-          "description": "The current state of the data file object.\n"
-        }
-      },
-      "id": {
-        "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
-        "systemAlias": "node_id",
-        "term": {
-          "description": "A 128-bit identifier. Depending on the mechanism used to generate it, it is either guaranteed to be different from all other UUIDs/GUIDs generated until 3400 AD or extremely likely to be different. Its relatively small size lends itself well to sorting, ordering, and hashing of all sorts, storing in databases, simple allocation, and ease of programming in general.\n",
-          "termDef": {
-            "cde_id": "C54100",
-            "cde_version": null,
-            "source": "NCIt",
-            "term": "Universally Unique Identifier",
-            "term_url": "https://ncit.nci.nih.gov/ncitbrowser/ConceptReport.jsp?dictionary=NCI_Thesaurus&version=16.02d&ns=NCI_Thesaurus&code=C54100"
-          }
-        },
-        "type": "string"
-      },
-      "md5sum": {
-        "term": {
-          "description": "The 128-bit hash value expressed as a 32 digit hexadecimal number used as a file's digital fingerprint.\n"
-        },
-        "type": "string"
-      },
-      "object_id": {
-        "description": "The GUID of the object in the index service.",
-        "type": "string"
-      },
-      "project_id": {
-        "term": {
-          "description": "Unique ID for any specific defined piece of work that is undertaken or attempted to meet a single requirement.\n"
-        },
-        "type": "string"
-      },
-      "state": {
-        "default": "validated",
-        "downloadable": [
-          "uploaded",
-          "md5summed",
-          "validating",
-          "validated",
-          "error",
-          "invalid",
-          "released"
-        ],
-        "oneOf": [
-          {
-            "enum": [
-              "uploading",
-              "uploaded",
-              "md5summing",
-              "md5summed",
-              "validating",
-              "error",
-              "invalid",
-              "suppressed",
-              "redacted",
-              "live"
-            ]
-          },
-          {
-            "enum": [
-              "validated",
-              "submitted",
-              "released"
-            ]
-          }
-        ],
-        "public": [
-          "live"
-        ],
-        "term": {
-          "description": "The current state of the object.\n"
-        }
-      },
-      "submitter_id": {
-        "description": "A project-specific identifier for a node. This property is the calling card/nickname/alias for a unit of submission. It can be used in place of the UUID for identifying or recalling a node.\n",
-        "type": [
-          "string"
-        ]
-      },
-      "type": {
-        "type": "string"
-      },
-      "updated_datetime": {
-        "oneOf": [
-          {
-            "format": "date-time",
-            "type": "string"
-          },
-          {
-            "type": "null"
-          }
-        ],
-        "term": {
-          "description": "A combination of date and time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]\n"
-        }
-      }
-    },
-    "required": [
-      "submitter_id",
-      "type",
-      "file_name",
-      "file_size",
-      "md5sum",
-      "data_category",
-      "data_type",
-      "data_format"
-    ],
-    "submittable": true,
-    "systemProperties": [
-      "id",
-      "project_id",
-      "created_datetime",
-      "updated_datetime",
-      "state",
-      "file_state",
-      "error_type"
-    ],
-    "title": "Slide Image",
-    "type": "object",
-    "uniqueKeys": [
-      [
-        "id"
-      ],
-      [
-        "project_id",
-        "submitter_id"
-      ]
-    ],
-    "validators": null
-  },
-  "study": {
-    "$schema": "http://json-schema.org/draft-04/schema#",
-    "additionalProperties": false,
-    "category": "administrative",
-    "description": "A coordinated set of actions and observations designed to generate data, with the ultimate goal of discovery or hypothesis testing.\n",
-    "id": "study",
-    "links": [
-      {
-        "backref": "studies",
-        "label": "performed_for",
-        "multiplicity": "many_to_one",
-        "name": "projects",
-        "required": true,
-        "target_type": "project"
-      }
-    ],
-    "namespace": "https://www.bloodpac.org",
-    "program": "*",
-    "project": "*",
-    "properties": {
-      "associated_study": {
-        "description": "The submitter_id for any study with which this study is associated, paired, or matched.",
-        "type": "string"
-      },
-      "created_datetime": {
-        "oneOf": [
-          {
-            "format": "date-time",
-            "type": "string"
-          },
-          {
-            "type": "null"
-          }
-        ],
-        "term": {
-          "description": "A combination of date and time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]\n"
-        }
-      },
-      "data_description": {
-        "description": "Brief description of the data being provided for this study. Free text",
-        "type": "string"
-      },
-      "id": {
-        "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
-        "systemAlias": "node_id",
-        "term": {
-          "description": "A 128-bit identifier. Depending on the mechanism used to generate it, it is either guaranteed to be different from all other UUIDs/GUIDs generated until 3400 AD or extremely likely to be different. Its relatively small size lends itself well to sorting, ordering, and hashing of all sorts, storing in databases, simple allocation, and ease of programming in general.\n",
-          "termDef": {
-            "cde_id": "C54100",
-            "cde_version": null,
-            "source": "NCIt",
-            "term": "Universally Unique Identifier",
-            "term_url": "https://ncit.nci.nih.gov/ncitbrowser/ConceptReport.jsp?dictionary=NCI_Thesaurus&version=16.02d&ns=NCI_Thesaurus&code=C54100"
-          }
-        },
-        "type": "string"
-      },
-      "project_id": {
-        "term": {
-          "description": "Unique ID for any specific defined piece of work that is undertaken or attempted to meet a single requirement.\n"
-        },
-        "type": "string"
-      },
-      "projects": {
-        "anyOf": [
-          {
-            "items": {
-              "additionalProperties": true,
-              "maxItems": 1,
-              "minItems": 1,
-              "properties": {
-                "code": {
-                  "type": "string"
-                },
-                "id": {
-                  "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
-                  "term": {
-                    "description": "A 128-bit identifier. Depending on the mechanism used to generate it, it is either guaranteed to be different from all other UUIDs/GUIDs generated until 3400 AD or extremely likely to be different. Its relatively small size lends itself well to sorting, ordering, and hashing of all sorts, storing in databases, simple allocation, and ease of programming in general.\n",
-                    "termDef": {
-                      "cde_id": "C54100",
-                      "cde_version": null,
-                      "source": "NCIt",
-                      "term": "Universally Unique Identifier",
-                      "term_url": "https://ncit.nci.nih.gov/ncitbrowser/ConceptReport.jsp?dictionary=NCI_Thesaurus&version=16.02d&ns=NCI_Thesaurus&code=C54100"
-                    }
-                  },
-                  "type": "string"
-                }
-              },
-              "type": "object"
-            },
-            "type": "array"
-          },
-          {
-            "additionalProperties": true,
-            "properties": {
-              "code": {
-                "type": "string"
-              },
-              "id": {
-                "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
-                "term": {
-                  "description": "A 128-bit identifier. Depending on the mechanism used to generate it, it is either guaranteed to be different from all other UUIDs/GUIDs generated until 3400 AD or extremely likely to be different. Its relatively small size lends itself well to sorting, ordering, and hashing of all sorts, storing in databases, simple allocation, and ease of programming in general.\n",
-                  "termDef": {
-                    "cde_id": "C54100",
-                    "cde_version": null,
-                    "source": "NCIt",
-                    "term": "Universally Unique Identifier",
-                    "term_url": "https://ncit.nci.nih.gov/ncitbrowser/ConceptReport.jsp?dictionary=NCI_Thesaurus&version=16.02d&ns=NCI_Thesaurus&code=C54100"
-                  }
-                },
-                "type": "string"
-              }
-            },
-            "type": "object"
-          }
-        ]
-      },
-      "state": {
-        "default": "validated",
-        "downloadable": [
-          "uploaded",
-          "md5summed",
-          "validating",
-          "validated",
-          "error",
-          "invalid",
-          "released"
-        ],
-        "oneOf": [
-          {
-            "enum": [
-              "uploading",
-              "uploaded",
-              "md5summing",
-              "md5summed",
-              "validating",
-              "error",
-              "invalid",
-              "suppressed",
-              "redacted",
-              "live"
-            ]
-          },
-          {
-            "enum": [
-              "validated",
-              "submitted",
-              "released"
-            ]
-          }
-        ],
-        "public": [
-          "live"
-        ],
-        "term": {
-          "description": "The current state of the object.\n"
-        }
-      },
-      "study_description": {
-        "description": "A brief description of the study being performed. Free text",
-        "type": "string"
-      },
-      "study_design": {
-        "description": "Summary of the goals the study is designed to discover. General description of the study's place in relation to a clinical application.\n",
-        "enum": [
-          "Research/Early Development",
-          "Pre-Analytical",
-          "Analytical",
-          "Clinical",
-          "Clinical Assay",
-          "Clinical Utility"
-        ]
-      },
-      "study_objective": {
-        "description": "The general objective of the study. What the study hopes to discover or determine through testing.\n",
-        "enum": [
-          "Accuracy",
-          "Clinical Detection",
-          "Interference",
-          "Limit of Detection",
-          "Precision (Repeatability)",
-          "Precision (Reproducibility)",
-          "Specificity/Sensitivity",
-          "Stability"
-        ]
-      },
-      "study_setup": {
-        "description": "A high level description of the setup used to achieve the study objectives.\n",
-        "enum": [
-          "Detection/Enumeration/Isolation",
-          "Genetic Analysis"
-        ]
-      },
-      "submitter_id": {
-        "description": "A project-specific identifier for a node. This property is the calling card/nickname/alias for a unit of submission. It can be used in place of the UUID for identifying or recalling a node.\n",
-        "type": [
-          "string"
-        ]
-      },
-      "type": {
-        "type": "string"
-      },
-      "updated_datetime": {
-        "oneOf": [
-          {
-            "format": "date-time",
-            "type": "string"
-          },
-          {
-            "type": "null"
-          }
-        ],
-        "term": {
-          "description": "A combination of date and time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]\n"
-        }
-      }
-    },
-    "required": [
-      "submitter_id",
-      "type",
-      "data_description",
-      "study_description",
-      "study_design",
-      "study_objective",
-      "study_setup",
-      "projects"
-    ],
-    "submittable": true,
-    "systemProperties": [
-      "id",
-      "project_id",
-      "created_datetime",
-      "updated_datetime",
-      "state"
-    ],
-    "title": "Study",
-    "type": "object",
-    "uniqueKeys": [
-      [
-        "id"
-      ],
-      [
-        "project_id",
-        "submitter_id"
-      ]
-    ],
-    "validators": null
-  },
-  "submitted_aligned_reads": {
-    "$schema": "http://json-schema.org/draft-04/schema#",
-    "additionalProperties": false,
-    "category": "data_file",
-    "description": "Data file containing aligned reads that are used as input to GDC workflows.\n",
-    "id": "submitted_aligned_reads",
-    "links": [
-      {
-        "exclusive": false,
-        "required": true,
-        "subgroup": [
-          {
-            "backref": "submitted_aligned_reads_files",
-            "label": "data_from",
-            "multiplicity": "one_to_one",
-            "name": "core_metadata_collections",
-            "required": false,
-            "target_type": "core_metadata_collection"
-          },
-          {
-            "backref": "submitted_aligned_reads_files",
-            "label": "data_from",
-            "multiplicity": "one_to_many",
-            "name": "read_groups",
-            "required": false,
-            "target_type": "read_group"
-          }
-        ]
-      }
-    ],
-    "namespace": "https://www.bloodpac.org",
-    "program": "*",
-    "project": "*",
-    "properties": {
-      "core_metadata_collections": {
-        "anyOf": [
-          {
-            "items": {
-              "additionalProperties": true,
-              "maxItems": 1,
-              "minItems": 1,
-              "properties": {
-                "id": {
-                  "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
-                  "term": {
-                    "description": "A 128-bit identifier. Depending on the mechanism used to generate it, it is either guaranteed to be different from all other UUIDs/GUIDs generated until 3400 AD or extremely likely to be different. Its relatively small size lends itself well to sorting, ordering, and hashing of all sorts, storing in databases, simple allocation, and ease of programming in general.\n",
-                    "termDef": {
-                      "cde_id": "C54100",
-                      "cde_version": null,
-                      "source": "NCIt",
-                      "term": "Universally Unique Identifier",
-                      "term_url": "https://ncit.nci.nih.gov/ncitbrowser/ConceptReport.jsp?dictionary=NCI_Thesaurus&version=16.02d&ns=NCI_Thesaurus&code=C54100"
-                    }
-                  },
-                  "type": "string"
-                },
-                "submitter_id": {
-                  "type": "string"
-                }
-              },
-              "type": "object"
-            },
-            "type": "array"
-          },
-          {
-            "additionalProperties": true,
-            "properties": {
-              "id": {
-                "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
-                "term": {
-                  "description": "A 128-bit identifier. Depending on the mechanism used to generate it, it is either guaranteed to be different from all other UUIDs/GUIDs generated until 3400 AD or extremely likely to be different. Its relatively small size lends itself well to sorting, ordering, and hashing of all sorts, storing in databases, simple allocation, and ease of programming in general.\n",
-                  "termDef": {
-                    "cde_id": "C54100",
-                    "cde_version": null,
-                    "source": "NCIt",
-                    "term": "Universally Unique Identifier",
-                    "term_url": "https://ncit.nci.nih.gov/ncitbrowser/ConceptReport.jsp?dictionary=NCI_Thesaurus&version=16.02d&ns=NCI_Thesaurus&code=C54100"
-                  }
-                },
-                "type": "string"
-              },
-              "submitter_id": {
-                "type": "string"
-              }
-            },
-            "type": "object"
-          }
-        ]
-      },
-      "created_datetime": {
-        "oneOf": [
-          {
-            "format": "date-time",
-            "type": "string"
-          },
-          {
-            "type": "null"
-          }
-        ],
-        "term": {
-          "description": "A combination of date and time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]\n"
-        }
-      },
-      "data_category": {
-        "enum": [
-          "Sequencing Reads"
-        ],
-        "term": {
-          "description": "Broad categorization of the contents of the data file.\n"
-        }
-      },
-      "data_format": {
-        "enum": [
-          "BAM",
-          "BED"
-        ],
-        "term": {
-          "description": "Format of the data files.\n"
-        }
-      },
-      "data_type": {
-        "enum": [
-          "Aligned Reads",
-          "Alignment Coordinates"
-        ],
-        "term": {
-          "description": "Specific content type of the data file.\n"
-        }
       },
       "error_type": {
         "enum": [
@@ -20187,19 +11956,10 @@
         }
       },
       "experimental_strategy": {
-        "enum": [
-          "WGS",
-          "WXS",
-          "Low Pass WGS",
-          "Validation",
-          "RNA-Seq",
-          "miRNA-Seq",
-          "Total RNA-Seq",
-          "DNA Panel"
-        ],
         "term": {
-          "description": "The experimental strategy used to generate the data file.\n"
-        }
+          "description": "The sequencing strategy used to generate the data file.\n"
+        },
+        "type": "string"
       },
       "file_name": {
         "term": {
@@ -20247,6 +12007,7 @@
         "type": "string"
       },
       "md5sum": {
+        "pattern": "^[a-f0-9]{32}$",
         "term": {
           "description": "The 128-bit hash value expressed as a 32 digit hexadecimal number used as a file's digital fingerprint.\n"
         },
@@ -20357,14 +12118,21 @@
           "description": "The current state of the object.\n"
         }
       },
+      "state_comment": {
+        "description": "Optional comment about why the file is in the current state, mainly for invalid state.\n",
+        "type": "string"
+      },
       "submitter_id": {
-        "description": "A project-specific identifier for a node. This property is the calling card/nickname/alias for a unit of submission. It can be used in place of the UUID for identifying or recalling a node.\n",
+        "description": "The file ID assigned by the submitter.",
         "type": [
-          "string"
+          "string",
+          "null"
         ]
       },
       "type": {
-        "type": "string"
+        "enum": [
+          "submitted_copy_number"
+        ]
       },
       "updated_datetime": {
         "oneOf": [
@@ -20383,358 +12151,6 @@
     },
     "required": [
       "submitter_id",
-      "type",
-      "file_name",
-      "file_size",
-      "data_format",
-      "md5sum",
-      "data_category",
-      "data_type",
-      "experimental_strategy"
-    ],
-    "submittable": true,
-    "systemProperties": [
-      "id",
-      "project_id",
-      "created_datetime",
-      "updated_datetime",
-      "state",
-      "file_state",
-      "error_type"
-    ],
-    "title": "Submitted Aligned Reads",
-    "type": "object",
-    "uniqueKeys": [
-      [
-        "id"
-      ],
-      [
-        "project_id",
-        "submitter_id"
-      ]
-    ],
-    "validators": null
-  },
-  "submitted_copy_number": {
-    "$schema": "http://json-schema.org/draft-04/schema#",
-    "additionalProperties": false,
-    "category": "data_file",
-    "description": "Data file containing normalized copy number information from an aliquot.\n",
-    "id": "submitted_copy_number",
-    "links": [
-      {
-        "exclusive": false,
-        "required": true,
-        "subgroup": [
-          {
-            "backref": "submitted_copy_number_files",
-            "label": "data_from",
-            "multiplicity": "one_to_one",
-            "name": "core_metadata_collections",
-            "required": false,
-            "target_type": "core_metadata_collection"
-          },
-          {
-            "backref": "submitted_copy_number_files",
-            "label": "derived_from",
-            "multiplicity": "many_to_many",
-            "name": "read_groups",
-            "required": false,
-            "target_type": "read_group"
-          }
-        ]
-      }
-    ],
-    "namespace": "https://www.bloodpac.org",
-    "program": "*",
-    "project": "*",
-    "properties": {
-      "core_metadata_collections": {
-        "anyOf": [
-          {
-            "items": {
-              "additionalProperties": true,
-              "maxItems": 1,
-              "minItems": 1,
-              "properties": {
-                "id": {
-                  "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
-                  "term": {
-                    "description": "A 128-bit identifier. Depending on the mechanism used to generate it, it is either guaranteed to be different from all other UUIDs/GUIDs generated until 3400 AD or extremely likely to be different. Its relatively small size lends itself well to sorting, ordering, and hashing of all sorts, storing in databases, simple allocation, and ease of programming in general.\n",
-                    "termDef": {
-                      "cde_id": "C54100",
-                      "cde_version": null,
-                      "source": "NCIt",
-                      "term": "Universally Unique Identifier",
-                      "term_url": "https://ncit.nci.nih.gov/ncitbrowser/ConceptReport.jsp?dictionary=NCI_Thesaurus&version=16.02d&ns=NCI_Thesaurus&code=C54100"
-                    }
-                  },
-                  "type": "string"
-                },
-                "submitter_id": {
-                  "type": "string"
-                }
-              },
-              "type": "object"
-            },
-            "type": "array"
-          },
-          {
-            "additionalProperties": true,
-            "properties": {
-              "id": {
-                "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
-                "term": {
-                  "description": "A 128-bit identifier. Depending on the mechanism used to generate it, it is either guaranteed to be different from all other UUIDs/GUIDs generated until 3400 AD or extremely likely to be different. Its relatively small size lends itself well to sorting, ordering, and hashing of all sorts, storing in databases, simple allocation, and ease of programming in general.\n",
-                  "termDef": {
-                    "cde_id": "C54100",
-                    "cde_version": null,
-                    "source": "NCIt",
-                    "term": "Universally Unique Identifier",
-                    "term_url": "https://ncit.nci.nih.gov/ncitbrowser/ConceptReport.jsp?dictionary=NCI_Thesaurus&version=16.02d&ns=NCI_Thesaurus&code=C54100"
-                  }
-                },
-                "type": "string"
-              },
-              "submitter_id": {
-                "type": "string"
-              }
-            },
-            "type": "object"
-          }
-        ]
-      },
-      "created_datetime": {
-        "oneOf": [
-          {
-            "format": "date-time",
-            "type": "string"
-          },
-          {
-            "type": "null"
-          }
-        ],
-        "term": {
-          "description": "A combination of date and time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]\n"
-        }
-      },
-      "data_category": {
-        "term": {
-          "description": "Broad categorization of the contents of the data file.\n"
-        },
-        "type": "string"
-      },
-      "data_format": {
-        "term": {
-          "description": "Format of the data files.\n"
-        },
-        "type": "string"
-      },
-      "data_type": {
-        "term": {
-          "description": "Specific content type of the data file.\n"
-        },
-        "type": "string"
-      },
-      "error_type": {
-        "enum": [
-          "file_size",
-          "file_format",
-          "md5sum"
-        ],
-        "term": {
-          "description": "Type of error for the data file object.\n"
-        }
-      },
-      "experimental_strategy": {
-        "term": {
-          "description": "The experimental strategy used to generate the data file.\n"
-        },
-        "type": "string"
-      },
-      "file_name": {
-        "term": {
-          "description": "The name (or part of a name) of a file (of any type).\n"
-        },
-        "type": "string"
-      },
-      "file_size": {
-        "term": {
-          "description": "The size of the data file (object) in bytes.\n"
-        },
-        "type": "integer"
-      },
-      "file_state": {
-        "default": "registered",
-        "enum": [
-          "registered",
-          "uploading",
-          "uploaded",
-          "validating",
-          "validated",
-          "submitted",
-          "processing",
-          "processed",
-          "released",
-          "error"
-        ],
-        "term": {
-          "description": "The current state of the data file object.\n"
-        }
-      },
-      "id": {
-        "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
-        "systemAlias": "node_id",
-        "term": {
-          "description": "A 128-bit identifier. Depending on the mechanism used to generate it, it is either guaranteed to be different from all other UUIDs/GUIDs generated until 3400 AD or extremely likely to be different. Its relatively small size lends itself well to sorting, ordering, and hashing of all sorts, storing in databases, simple allocation, and ease of programming in general.\n",
-          "termDef": {
-            "cde_id": "C54100",
-            "cde_version": null,
-            "source": "NCIt",
-            "term": "Universally Unique Identifier",
-            "term_url": "https://ncit.nci.nih.gov/ncitbrowser/ConceptReport.jsp?dictionary=NCI_Thesaurus&version=16.02d&ns=NCI_Thesaurus&code=C54100"
-          }
-        },
-        "type": "string"
-      },
-      "md5sum": {
-        "term": {
-          "description": "The 128-bit hash value expressed as a 32 digit hexadecimal number used as a file's digital fingerprint.\n"
-        },
-        "type": "string"
-      },
-      "object_id": {
-        "description": "The GUID of the object in the index service.",
-        "type": "string"
-      },
-      "project_id": {
-        "term": {
-          "description": "Unique ID for any specific defined piece of work that is undertaken or attempted to meet a single requirement.\n"
-        },
-        "type": "string"
-      },
-      "read_groups": {
-        "anyOf": [
-          {
-            "items": {
-              "additionalProperties": true,
-              "minItems": 1,
-              "properties": {
-                "id": {
-                  "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
-                  "term": {
-                    "description": "A 128-bit identifier. Depending on the mechanism used to generate it, it is either guaranteed to be different from all other UUIDs/GUIDs generated until 3400 AD or extremely likely to be different. Its relatively small size lends itself well to sorting, ordering, and hashing of all sorts, storing in databases, simple allocation, and ease of programming in general.\n",
-                    "termDef": {
-                      "cde_id": "C54100",
-                      "cde_version": null,
-                      "source": "NCIt",
-                      "term": "Universally Unique Identifier",
-                      "term_url": "https://ncit.nci.nih.gov/ncitbrowser/ConceptReport.jsp?dictionary=NCI_Thesaurus&version=16.02d&ns=NCI_Thesaurus&code=C54100"
-                    }
-                  },
-                  "type": "string"
-                },
-                "submitter_id": {
-                  "type": "string"
-                }
-              },
-              "type": "object"
-            },
-            "type": "array"
-          },
-          {
-            "additionalProperties": true,
-            "properties": {
-              "id": {
-                "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
-                "term": {
-                  "description": "A 128-bit identifier. Depending on the mechanism used to generate it, it is either guaranteed to be different from all other UUIDs/GUIDs generated until 3400 AD or extremely likely to be different. Its relatively small size lends itself well to sorting, ordering, and hashing of all sorts, storing in databases, simple allocation, and ease of programming in general.\n",
-                  "termDef": {
-                    "cde_id": "C54100",
-                    "cde_version": null,
-                    "source": "NCIt",
-                    "term": "Universally Unique Identifier",
-                    "term_url": "https://ncit.nci.nih.gov/ncitbrowser/ConceptReport.jsp?dictionary=NCI_Thesaurus&version=16.02d&ns=NCI_Thesaurus&code=C54100"
-                  }
-                },
-                "type": "string"
-              },
-              "submitter_id": {
-                "type": "string"
-              }
-            },
-            "type": "object"
-          }
-        ]
-      },
-      "state": {
-        "default": "validated",
-        "downloadable": [
-          "uploaded",
-          "md5summed",
-          "validating",
-          "validated",
-          "error",
-          "invalid",
-          "released"
-        ],
-        "oneOf": [
-          {
-            "enum": [
-              "uploading",
-              "uploaded",
-              "md5summing",
-              "md5summed",
-              "validating",
-              "error",
-              "invalid",
-              "suppressed",
-              "redacted",
-              "live"
-            ]
-          },
-          {
-            "enum": [
-              "validated",
-              "submitted",
-              "released"
-            ]
-          }
-        ],
-        "public": [
-          "live"
-        ],
-        "term": {
-          "description": "The current state of the object.\n"
-        }
-      },
-      "submitter_id": {
-        "description": "A project-specific identifier for a node. This property is the calling card/nickname/alias for a unit of submission. It can be used in place of the UUID for identifying or recalling a node.\n",
-        "type": [
-          "string"
-        ]
-      },
-      "type": {
-        "type": "string"
-      },
-      "updated_datetime": {
-        "oneOf": [
-          {
-            "format": "date-time",
-            "type": "string"
-          },
-          {
-            "type": "null"
-          }
-        ],
-        "term": {
-          "description": "A combination of date and time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]\n"
-        }
-      }
-    },
-    "required": [
-      "submitter_id",
-      "type",
       "file_name",
       "file_size",
       "data_format",
@@ -20774,33 +12190,19 @@
     "id": "submitted_methylation",
     "links": [
       {
-        "exclusive": false,
+        "backref": "submitted_methylation_files",
+        "label": "data_from",
+        "multiplicity": "many_to_one",
+        "name": "aliquots",
         "required": true,
-        "subgroup": [
-          {
-            "backref": "submitted_methylation_files",
-            "label": "data_from",
-            "multiplicity": "one_to_one",
-            "name": "core_metadata_collections",
-            "required": false,
-            "target_type": "core_metadata_collection"
-          },
-          {
-            "backref": "submitted_methylation_files",
-            "label": "data_from",
-            "multiplicity": "one_to_one",
-            "name": "analytes",
-            "required": false,
-            "target_type": "analyte"
-          }
-        ]
+        "target_type": "aliquot"
       }
     ],
     "namespace": "https://www.bloodpac.org/",
     "program": "*",
     "project": "*",
     "properties": {
-      "analytes": {
+      "aliquots": {
         "anyOf": [
           {
             "items": {
@@ -20869,61 +12271,6 @@
       "assay_method": {
         "enum": [
           "Methylation Array"
-        ]
-      },
-      "core_metadata_collections": {
-        "anyOf": [
-          {
-            "items": {
-              "additionalProperties": true,
-              "maxItems": 1,
-              "minItems": 1,
-              "properties": {
-                "id": {
-                  "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
-                  "term": {
-                    "description": "A 128-bit identifier. Depending on the mechanism used to generate it, it is either guaranteed to be different from all other UUIDs/GUIDs generated until 3400 AD or extremely likely to be different. Its relatively small size lends itself well to sorting, ordering, and hashing of all sorts, storing in databases, simple allocation, and ease of programming in general.\n",
-                    "termDef": {
-                      "cde_id": "C54100",
-                      "cde_version": null,
-                      "source": "NCIt",
-                      "term": "Universally Unique Identifier",
-                      "term_url": "https://ncit.nci.nih.gov/ncitbrowser/ConceptReport.jsp?dictionary=NCI_Thesaurus&version=16.02d&ns=NCI_Thesaurus&code=C54100"
-                    }
-                  },
-                  "type": "string"
-                },
-                "submitter_id": {
-                  "type": "string"
-                }
-              },
-              "type": "object"
-            },
-            "type": "array"
-          },
-          {
-            "additionalProperties": true,
-            "properties": {
-              "id": {
-                "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
-                "term": {
-                  "description": "A 128-bit identifier. Depending on the mechanism used to generate it, it is either guaranteed to be different from all other UUIDs/GUIDs generated until 3400 AD or extremely likely to be different. Its relatively small size lends itself well to sorting, ordering, and hashing of all sorts, storing in databases, simple allocation, and ease of programming in general.\n",
-                  "termDef": {
-                    "cde_id": "C54100",
-                    "cde_version": null,
-                    "source": "NCIt",
-                    "term": "Universally Unique Identifier",
-                    "term_url": "https://ncit.nci.nih.gov/ncitbrowser/ConceptReport.jsp?dictionary=NCI_Thesaurus&version=16.02d&ns=NCI_Thesaurus&code=C54100"
-                  }
-                },
-                "type": "string"
-              },
-              "submitter_id": {
-                "type": "string"
-              }
-            },
-            "type": "object"
-          }
         ]
       },
       "created_datetime": {
@@ -21020,6 +12367,7 @@
         "type": "string"
       },
       "md5sum": {
+        "pattern": "^[a-f0-9]{32}$",
         "term": {
           "description": "The 128-bit hash value expressed as a 32 digit hexadecimal number used as a file's digital fingerprint.\n"
         },
@@ -21076,14 +12424,21 @@
           "description": "The current state of the object.\n"
         }
       },
+      "state_comment": {
+        "description": "Optional comment about why the file is in the current state, mainly for invalid state.\n",
+        "type": "string"
+      },
       "submitter_id": {
-        "description": "A project-specific identifier for a node. This property is the calling card/nickname/alias for a unit of submission. It can be used in place of the UUID for identifying or recalling a node.\n",
+        "description": "The file ID assigned by the submitter.",
         "type": [
-          "string"
+          "string",
+          "null"
         ]
       },
       "type": {
-        "type": "string"
+        "enum": [
+          "submitted_methylation"
+        ]
       },
       "updated_datetime": {
         "oneOf": [
@@ -21102,16 +12457,13 @@
     },
     "required": [
       "submitter_id",
-      "type",
       "file_name",
       "file_size",
       "md5sum",
       "data_category",
       "data_type",
       "data_format",
-      "assay_method",
-      "assay_instrument",
-      "assay_instrument_model"
+      "aliquots"
     ],
     "submittable": true,
     "systemProperties": [
@@ -21144,87 +12496,18 @@
     "id": "submitted_somatic_mutation",
     "links": [
       {
-        "exclusive": false,
+        "backref": "submitted_somatic_mutations",
+        "label": "derived_from",
+        "multiplicity": "many_to_many",
+        "name": "read_groups",
         "required": true,
-        "subgroup": [
-          {
-            "backref": "submitted_somatic_mutations",
-            "label": "data_from",
-            "multiplicity": "one_to_one",
-            "name": "core_metadata_collections",
-            "required": false,
-            "target_type": "core_metadata_collection"
-          },
-          {
-            "backref": "submitted_somatic_mutations",
-            "label": "derived_from",
-            "multiplicity": "many_to_many",
-            "name": "read_groups",
-            "required": false,
-            "target_type": "read_group"
-          }
-        ]
+        "target_type": "read_group"
       }
     ],
-    "namespace": "https://www.bloodpac.org",
+    "namespace": "http://gdc.nci.nih.gov",
     "program": "*",
     "project": "*",
     "properties": {
-      "core_metadata_collections": {
-        "anyOf": [
-          {
-            "items": {
-              "additionalProperties": true,
-              "maxItems": 1,
-              "minItems": 1,
-              "properties": {
-                "id": {
-                  "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
-                  "term": {
-                    "description": "A 128-bit identifier. Depending on the mechanism used to generate it, it is either guaranteed to be different from all other UUIDs/GUIDs generated until 3400 AD or extremely likely to be different. Its relatively small size lends itself well to sorting, ordering, and hashing of all sorts, storing in databases, simple allocation, and ease of programming in general.\n",
-                    "termDef": {
-                      "cde_id": "C54100",
-                      "cde_version": null,
-                      "source": "NCIt",
-                      "term": "Universally Unique Identifier",
-                      "term_url": "https://ncit.nci.nih.gov/ncitbrowser/ConceptReport.jsp?dictionary=NCI_Thesaurus&version=16.02d&ns=NCI_Thesaurus&code=C54100"
-                    }
-                  },
-                  "type": "string"
-                },
-                "submitter_id": {
-                  "type": "string"
-                }
-              },
-              "type": "object"
-            },
-            "type": "array"
-          },
-          {
-            "additionalProperties": true,
-            "properties": {
-              "id": {
-                "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
-                "term": {
-                  "description": "A 128-bit identifier. Depending on the mechanism used to generate it, it is either guaranteed to be different from all other UUIDs/GUIDs generated until 3400 AD or extremely likely to be different. Its relatively small size lends itself well to sorting, ordering, and hashing of all sorts, storing in databases, simple allocation, and ease of programming in general.\n",
-                  "termDef": {
-                    "cde_id": "C54100",
-                    "cde_version": null,
-                    "source": "NCIt",
-                    "term": "Universally Unique Identifier",
-                    "term_url": "https://ncit.nci.nih.gov/ncitbrowser/ConceptReport.jsp?dictionary=NCI_Thesaurus&version=16.02d&ns=NCI_Thesaurus&code=C54100"
-                  }
-                },
-                "type": "string"
-              },
-              "submitter_id": {
-                "type": "string"
-              }
-            },
-            "type": "object"
-          }
-        ]
-      },
       "created_datetime": {
         "oneOf": [
           {
@@ -21269,7 +12552,7 @@
       },
       "experimental_strategy": {
         "term": {
-          "description": "The experimental strategy used to generate the data file.\n"
+          "description": "The sequencing strategy used to generate the data file.\n"
         },
         "type": "string"
       },
@@ -21319,6 +12602,7 @@
         "type": "string"
       },
       "md5sum": {
+        "pattern": "^[a-f0-9]{32}$",
         "term": {
           "description": "The 128-bit hash value expressed as a 32 digit hexadecimal number used as a file's digital fingerprint.\n"
         },
@@ -21429,10 +12713,15 @@
           "description": "The current state of the object.\n"
         }
       },
+      "state_comment": {
+        "description": "Optional comment about why the file is in the current state, mainly for invalid state.\n",
+        "type": "string"
+      },
       "submitter_id": {
-        "description": "A project-specific identifier for a node. This property is the calling card/nickname/alias for a unit of submission. It can be used in place of the UUID for identifying or recalling a node.\n",
+        "description": "The file ID assigned by the submitter.",
         "type": [
-          "string"
+          "string",
+          "null"
         ]
       },
       "total_variants": {
@@ -21440,7 +12729,9 @@
         "type": "integer"
       },
       "type": {
-        "type": "string"
+        "enum": [
+          "submitted_somatic_mutation"
+        ]
       },
       "updated_datetime": {
         "oneOf": [
@@ -21459,14 +12750,14 @@
     },
     "required": [
       "submitter_id",
-      "type",
       "file_name",
       "file_size",
       "data_format",
       "md5sum",
       "data_category",
       "data_type",
-      "experimental_strategy"
+      "experimental_strategy",
+      "read_groups"
     ],
     "submittable": true,
     "systemProperties": [
@@ -21499,29 +12790,23 @@
     "id": "submitted_unaligned_reads",
     "links": [
       {
-        "exclusive": false,
+        "backref": "submitted_unaligned_reads_files",
+        "label": "data_from",
+        "multiplicity": "many_to_one",
+        "name": "read_groups",
         "required": true,
-        "subgroup": [
-          {
-            "backref": "submitted_unaligned_reads_files",
-            "label": "data_from",
-            "multiplicity": "one_to_one",
-            "name": "core_metadata_collections",
-            "required": false,
-            "target_type": "core_metadata_collection"
-          },
-          {
-            "backref": "submitted_unaligned_reads_files",
-            "label": "data_from",
-            "multiplicity": "many_to_one",
-            "name": "read_groups",
-            "required": false,
-            "target_type": "read_group"
-          }
-        ]
+        "target_type": "read_group"
+      },
+      {
+        "backref": "submitted_unaligned_reads_files",
+        "label": "data_from",
+        "multiplicity": "many_to_many",
+        "name": "core_metadata_collections",
+        "required": false,
+        "target_type": "core_metadata_collection"
       }
     ],
-    "namespace": "https://www.bloodpac.org",
+    "namespace": "http://gdc.nci.nih.gov",
     "program": "*",
     "project": "*",
     "properties": {
@@ -21530,7 +12815,6 @@
           {
             "items": {
               "additionalProperties": true,
-              "maxItems": 1,
               "minItems": 1,
               "properties": {
                 "id": {
@@ -21596,7 +12880,9 @@
       },
       "data_category": {
         "enum": [
-          "Sequencing Reads"
+          "Sequencing Data",
+          "Sequencing Reads",
+          "Raw Sequencing Data"
         ],
         "term": {
           "description": "Broad categorization of the contents of the data file.\n"
@@ -21641,7 +12927,7 @@
           "DNA Panel"
         ],
         "term": {
-          "description": "The experimental strategy used to generate the data file.\n"
+          "description": "The sequencing strategy used to generate the data file.\n"
         }
       },
       "file_name": {
@@ -21690,6 +12976,7 @@
         "type": "string"
       },
       "md5sum": {
+        "pattern": "^[a-f0-9]{32}$",
         "term": {
           "description": "The 128-bit hash value expressed as a 32 digit hexadecimal number used as a file's digital fingerprint.\n"
         },
@@ -21801,14 +13088,21 @@
           "description": "The current state of the object.\n"
         }
       },
+      "state_comment": {
+        "description": "Optional comment about why the file is in the current state, mainly for invalid state.\n",
+        "type": "string"
+      },
       "submitter_id": {
-        "description": "A project-specific identifier for a node. This property is the calling card/nickname/alias for a unit of submission. It can be used in place of the UUID for identifying or recalling a node.\n",
+        "description": "The file ID assigned by the submitter.",
         "type": [
-          "string"
+          "string",
+          "null"
         ]
       },
       "type": {
-        "type": "string"
+        "enum": [
+          "submitted_unaligned_reads"
+        ]
       },
       "updated_datetime": {
         "oneOf": [
@@ -21827,14 +13121,14 @@
     },
     "required": [
       "submitter_id",
-      "type",
       "file_name",
       "file_size",
       "md5sum",
       "data_category",
       "data_type",
       "data_format",
-      "experimental_strategy"
+      "experimental_strategy",
+      "read_groups"
     ],
     "submittable": true,
     "systemProperties": [
@@ -21863,99 +13157,22 @@
     "$schema": "http://json-schema.org/draft-04/schema#",
     "additionalProperties": false,
     "category": "clinical",
-    "description": "Any medication, treatment or procedure taken by, prescribed to, or administered to a patient, including cancer-directed treatments, palliative or supportive care, non-cancer-directed prescription medications, and over-the-counter agents.\n",
+    "description": "Record of the administration and intention of therapeutic agents provided to a patient to alter the course of a pathologic process.\n",
     "id": "treatment",
     "links": [
       {
-        "exclusive": false,
+        "backref": "treatments",
+        "label": "describes",
+        "multiplicity": "many_to_one",
+        "name": "diagnoses",
         "required": true,
-        "subgroup": [
-          {
-            "backref": "treatments",
-            "label": "describes",
-            "multiplicity": "many_to_one",
-            "name": "diagnoses",
-            "required": false,
-            "target_type": "diagnosis"
-          },
-          {
-            "backref": "treatments",
-            "label": "describes",
-            "multiplicity": "many_to_one",
-            "name": "cases",
-            "required": false,
-            "target_type": "case"
-          },
-          {
-            "backref": "treatments",
-            "label": "describes",
-            "multiplicity": "many_to_one",
-            "name": "followups",
-            "required": false,
-            "target_type": "followup"
-          }
-        ]
+        "target_type": "diagnosis"
       }
     ],
-    "namespace": "https://www.bloodpac.org",
+    "namespace": "http://gdc.nci.nih.gov",
     "program": "*",
     "project": "*",
     "properties": {
-      "cases": {
-        "anyOf": [
-          {
-            "items": {
-              "additionalProperties": true,
-              "maxItems": 1,
-              "minItems": 1,
-              "properties": {
-                "id": {
-                  "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
-                  "term": {
-                    "description": "A 128-bit identifier. Depending on the mechanism used to generate it, it is either guaranteed to be different from all other UUIDs/GUIDs generated until 3400 AD or extremely likely to be different. Its relatively small size lends itself well to sorting, ordering, and hashing of all sorts, storing in databases, simple allocation, and ease of programming in general.\n",
-                    "termDef": {
-                      "cde_id": "C54100",
-                      "cde_version": null,
-                      "source": "NCIt",
-                      "term": "Universally Unique Identifier",
-                      "term_url": "https://ncit.nci.nih.gov/ncitbrowser/ConceptReport.jsp?dictionary=NCI_Thesaurus&version=16.02d&ns=NCI_Thesaurus&code=C54100"
-                    }
-                  },
-                  "type": "string"
-                },
-                "submitter_id": {
-                  "type": "string"
-                }
-              },
-              "type": "object"
-            },
-            "type": "array"
-          },
-          {
-            "additionalProperties": true,
-            "properties": {
-              "id": {
-                "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
-                "term": {
-                  "description": "A 128-bit identifier. Depending on the mechanism used to generate it, it is either guaranteed to be different from all other UUIDs/GUIDs generated until 3400 AD or extremely likely to be different. Its relatively small size lends itself well to sorting, ordering, and hashing of all sorts, storing in databases, simple allocation, and ease of programming in general.\n",
-                  "termDef": {
-                    "cde_id": "C54100",
-                    "cde_version": null,
-                    "source": "NCIt",
-                    "term": "Universally Unique Identifier",
-                    "term_url": "https://ncit.nci.nih.gov/ncitbrowser/ConceptReport.jsp?dictionary=NCI_Thesaurus&version=16.02d&ns=NCI_Thesaurus&code=C54100"
-                  }
-                },
-                "type": "string"
-              },
-              "submitter_id": {
-                "type": "string"
-              }
-            },
-            "type": "object"
-          }
-        ]
-      },
       "created_datetime": {
         "oneOf": [
           {
@@ -21970,9 +13187,22 @@
           "description": "A combination of date and time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]\n"
         }
       },
+      "days_to_treatment": {
+        "term": {
+          "description": "Number of days from date of initial pathologic diagnosis that treatment began.\n",
+          "termDef": {
+            "cde_id": null,
+            "cde_version": null,
+            "source": null,
+            "term": "Days to Treatment Start",
+            "term_url": null
+          }
+        },
+        "type": "number"
+      },
       "days_to_treatment_end": {
         "term": {
-          "description": "Time interval from the date of the index to the date of treatment end, represented as a calculated number of days.\n",
+          "description": "Time interval from the date of the initial pathologic diagnosis to the date of treatment end, represented as a calculated number of days.\n",
           "termDef": {
             "cde_id": 5102431,
             "cde_version": 1,
@@ -21985,7 +13215,7 @@
       },
       "days_to_treatment_start": {
         "term": {
-          "description": "Time interval from the date of the index to the start of treatment, represented as a calculated number of days.\n",
+          "description": "Time interval from the date of the initial pathologic diagnosis to the start of treatment, represented as a calculated number of days.\n",
           "termDef": {
             "cde_id": 5102411,
             "cde_version": 1,
@@ -22051,69 +13281,6 @@
           }
         ]
       },
-      "dosage": {
-        "description": "The dosage of the medication; please also provide 'dosage_units'.\n",
-        "type": "number"
-      },
-      "dosage_units": {
-        "description": "The units corresponding to the dosage of the medication; please also provide 'dosage'.\n",
-        "type": "string"
-      },
-      "followups": {
-        "anyOf": [
-          {
-            "items": {
-              "additionalProperties": true,
-              "maxItems": 1,
-              "minItems": 1,
-              "properties": {
-                "id": {
-                  "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
-                  "term": {
-                    "description": "A 128-bit identifier. Depending on the mechanism used to generate it, it is either guaranteed to be different from all other UUIDs/GUIDs generated until 3400 AD or extremely likely to be different. Its relatively small size lends itself well to sorting, ordering, and hashing of all sorts, storing in databases, simple allocation, and ease of programming in general.\n",
-                    "termDef": {
-                      "cde_id": "C54100",
-                      "cde_version": null,
-                      "source": "NCIt",
-                      "term": "Universally Unique Identifier",
-                      "term_url": "https://ncit.nci.nih.gov/ncitbrowser/ConceptReport.jsp?dictionary=NCI_Thesaurus&version=16.02d&ns=NCI_Thesaurus&code=C54100"
-                    }
-                  },
-                  "type": "string"
-                },
-                "submitter_id": {
-                  "type": "string"
-                }
-              },
-              "type": "object"
-            },
-            "type": "array"
-          },
-          {
-            "additionalProperties": true,
-            "properties": {
-              "id": {
-                "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
-                "term": {
-                  "description": "A 128-bit identifier. Depending on the mechanism used to generate it, it is either guaranteed to be different from all other UUIDs/GUIDs generated until 3400 AD or extremely likely to be different. Its relatively small size lends itself well to sorting, ordering, and hashing of all sorts, storing in databases, simple allocation, and ease of programming in general.\n",
-                  "termDef": {
-                    "cde_id": "C54100",
-                    "cde_version": null,
-                    "source": "NCIt",
-                    "term": "Universally Unique Identifier",
-                    "term_url": "https://ncit.nci.nih.gov/ncitbrowser/ConceptReport.jsp?dictionary=NCI_Thesaurus&version=16.02d&ns=NCI_Thesaurus&code=C54100"
-                  }
-                },
-                "type": "string"
-              },
-              "submitter_id": {
-                "type": "string"
-              }
-            },
-            "type": "object"
-          }
-        ]
-      },
       "id": {
         "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
         "systemAlias": "node_id",
@@ -22133,10 +13300,6 @@
         "term": {
           "description": "Unique ID for any specific defined piece of work that is undertaken or attempted to meet a single requirement.\n"
         },
-        "type": "string"
-      },
-      "regimen_or_line_of_therapy": {
-        "description": "General name for a the group of treatments of which this treatment was a part. This reference name can be used to identify treatments involved in a certain outcome later one.\n",
         "type": "string"
       },
       "state": {
@@ -22181,9 +13344,9 @@
         }
       },
       "submitter_id": {
-        "description": "A project-specific identifier for a node. This property is the calling card/nickname/alias for a unit of submission. It can be used in place of the UUID for identifying or recalling a node.\n",
         "type": [
-          "string"
+          "string",
+          "null"
         ]
       },
       "therapeutic_agents": {
@@ -22275,7 +13438,9 @@
           "Supraclavicular/Axillary Level 3",
           "Thorax",
           "Trunk",
-          "Unknown"
+          "Unknown",
+          "Not Reported",
+          "Not Allowed To Collect"
         ],
         "term": {
           "description": "The anatomic site or field targeted by a treatment regimen or single agent therapy.\n",
@@ -22287,15 +13452,6 @@
             "term_url": null
           }
         }
-      },
-      "treatment_class": {
-        "description": "Indicate whether the treatment or therapeutic agent is cancer-directed, cancer-related supportive care, non-cancer-related prescription, or over-the-counter agent (not prescribed)\n",
-        "enum": [
-          "Cancer-directed",
-          "Cancer-related Supportive Care",
-          "Non-cancer-related Prescription",
-          "Over-the-counter Agent"
-        ]
       },
       "treatment_intent_type": {
         "term": {
@@ -22309,6 +13465,24 @@
           }
         },
         "type": "string"
+      },
+      "treatment_or_therapy": {
+        "enum": [
+          "yes",
+          "no",
+          "unknown",
+          "not reported"
+        ],
+        "term": {
+          "description": "A yes/no/unknown/not applicable indicator related to the administration of therapeutic agents received before the body specimen was collected.\n",
+          "termDef": {
+            "cde_id": 4231463,
+            "cde_version": 1,
+            "source": "caDSR",
+            "term": "Therapeutic Procedure Prior Specimen Collection Administered Yes No Unknown Not Applicable Indicator",
+            "term_url": "https://cdebrowser.nci.nih.gov/CDEBrowser/search?elementDetails=9&FirstTimer=0&PageId=ElementDetailsGroup&publicId=4231463&version=1.0"
+          }
+        }
       },
       "treatment_outcome": {
         "enum": [
@@ -22345,7 +13519,9 @@
           "Stem Cell Treatment",
           "Surgery",
           "Targeted Molecular Therapy",
-          "Unknown"
+          "Unknown",
+          "Not Reported",
+          "Not Allowed To Collect"
         ],
         "term": {
           "description": "Text term that describes the kind of treatment administered.\n",
@@ -22359,7 +13535,9 @@
         }
       },
       "type": {
-        "type": "string"
+        "enum": [
+          "treatment"
+        ]
       },
       "updated_datetime": {
         "oneOf": [
@@ -22376,12 +13554,6 @@
         }
       }
     },
-    "required": [
-      "submitter_id",
-      "type",
-      "therapeutic_agents",
-      "treatment_class"
-    ],
     "submittable": true,
     "systemProperties": [
       "id",
@@ -22391,317 +13563,6 @@
       "updated_datetime"
     ],
     "title": "Treatment",
-    "type": "object",
-    "uniqueKeys": [
-      [
-        "id"
-      ],
-      [
-        "project_id",
-        "submitter_id"
-      ]
-    ],
-    "validators": null
-  },
-  "variant_calling_workflow": {
-    "$schema": "http://json-schema.org/draft-04/schema#",
-    "additionalProperties": false,
-    "category": "analysis",
-    "description": "A description of the specific bioinformatics workflow or pipeline used for variant calling.\n",
-    "id": "variant_calling_workflow",
-    "links": [
-      {
-        "backref": "associated_variant_calling_workflows",
-        "label": "performed_on",
-        "multiplicity": "many_to_many",
-        "name": "input_submitted_aligned_reads_files",
-        "required": true,
-        "target_type": "submitted_aligned_reads"
-      },
-      {
-        "backref": "variant_calling_workflows",
-        "label": "generated",
-        "multiplicity": "one_to_one",
-        "name": "output_submitted_somatic_mutations",
-        "required": true,
-        "target_type": "submitted_somatic_mutation"
-      }
-    ],
-    "namespace": "https://www.bloodpac.org",
-    "program": "*",
-    "project": "*",
-    "properties": {
-      "created_datetime": {
-        "oneOf": [
-          {
-            "format": "date-time",
-            "type": "string"
-          },
-          {
-            "type": "null"
-          }
-        ],
-        "term": {
-          "description": "A combination of date and time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]\n"
-        }
-      },
-      "id": {
-        "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
-        "systemAlias": "node_id",
-        "term": {
-          "description": "A 128-bit identifier. Depending on the mechanism used to generate it, it is either guaranteed to be different from all other UUIDs/GUIDs generated until 3400 AD or extremely likely to be different. Its relatively small size lends itself well to sorting, ordering, and hashing of all sorts, storing in databases, simple allocation, and ease of programming in general.\n",
-          "termDef": {
-            "cde_id": "C54100",
-            "cde_version": null,
-            "source": "NCIt",
-            "term": "Universally Unique Identifier",
-            "term_url": "https://ncit.nci.nih.gov/ncitbrowser/ConceptReport.jsp?dictionary=NCI_Thesaurus&version=16.02d&ns=NCI_Thesaurus&code=C54100"
-          }
-        },
-        "type": "string"
-      },
-      "input_submitted_aligned_reads_files": {
-        "anyOf": [
-          {
-            "items": {
-              "additionalProperties": true,
-              "minItems": 1,
-              "properties": {
-                "id": {
-                  "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
-                  "term": {
-                    "description": "A 128-bit identifier. Depending on the mechanism used to generate it, it is either guaranteed to be different from all other UUIDs/GUIDs generated until 3400 AD or extremely likely to be different. Its relatively small size lends itself well to sorting, ordering, and hashing of all sorts, storing in databases, simple allocation, and ease of programming in general.\n",
-                    "termDef": {
-                      "cde_id": "C54100",
-                      "cde_version": null,
-                      "source": "NCIt",
-                      "term": "Universally Unique Identifier",
-                      "term_url": "https://ncit.nci.nih.gov/ncitbrowser/ConceptReport.jsp?dictionary=NCI_Thesaurus&version=16.02d&ns=NCI_Thesaurus&code=C54100"
-                    }
-                  },
-                  "type": "string"
-                },
-                "submitter_id": {
-                  "type": "string"
-                }
-              },
-              "type": "object"
-            },
-            "type": "array"
-          },
-          {
-            "additionalProperties": true,
-            "properties": {
-              "id": {
-                "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
-                "term": {
-                  "description": "A 128-bit identifier. Depending on the mechanism used to generate it, it is either guaranteed to be different from all other UUIDs/GUIDs generated until 3400 AD or extremely likely to be different. Its relatively small size lends itself well to sorting, ordering, and hashing of all sorts, storing in databases, simple allocation, and ease of programming in general.\n",
-                  "termDef": {
-                    "cde_id": "C54100",
-                    "cde_version": null,
-                    "source": "NCIt",
-                    "term": "Universally Unique Identifier",
-                    "term_url": "https://ncit.nci.nih.gov/ncitbrowser/ConceptReport.jsp?dictionary=NCI_Thesaurus&version=16.02d&ns=NCI_Thesaurus&code=C54100"
-                  }
-                },
-                "type": "string"
-              },
-              "submitter_id": {
-                "type": "string"
-              }
-            },
-            "type": "object"
-          }
-        ]
-      },
-      "output_submitted_somatic_mutations": {
-        "anyOf": [
-          {
-            "items": {
-              "additionalProperties": true,
-              "maxItems": 1,
-              "minItems": 1,
-              "properties": {
-                "id": {
-                  "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
-                  "term": {
-                    "description": "A 128-bit identifier. Depending on the mechanism used to generate it, it is either guaranteed to be different from all other UUIDs/GUIDs generated until 3400 AD or extremely likely to be different. Its relatively small size lends itself well to sorting, ordering, and hashing of all sorts, storing in databases, simple allocation, and ease of programming in general.\n",
-                    "termDef": {
-                      "cde_id": "C54100",
-                      "cde_version": null,
-                      "source": "NCIt",
-                      "term": "Universally Unique Identifier",
-                      "term_url": "https://ncit.nci.nih.gov/ncitbrowser/ConceptReport.jsp?dictionary=NCI_Thesaurus&version=16.02d&ns=NCI_Thesaurus&code=C54100"
-                    }
-                  },
-                  "type": "string"
-                },
-                "submitter_id": {
-                  "type": "string"
-                }
-              },
-              "type": "object"
-            },
-            "type": "array"
-          },
-          {
-            "additionalProperties": true,
-            "properties": {
-              "id": {
-                "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
-                "term": {
-                  "description": "A 128-bit identifier. Depending on the mechanism used to generate it, it is either guaranteed to be different from all other UUIDs/GUIDs generated until 3400 AD or extremely likely to be different. Its relatively small size lends itself well to sorting, ordering, and hashing of all sorts, storing in databases, simple allocation, and ease of programming in general.\n",
-                  "termDef": {
-                    "cde_id": "C54100",
-                    "cde_version": null,
-                    "source": "NCIt",
-                    "term": "Universally Unique Identifier",
-                    "term_url": "https://ncit.nci.nih.gov/ncitbrowser/ConceptReport.jsp?dictionary=NCI_Thesaurus&version=16.02d&ns=NCI_Thesaurus&code=C54100"
-                  }
-                },
-                "type": "string"
-              },
-              "submitter_id": {
-                "type": "string"
-              }
-            },
-            "type": "object"
-          }
-        ]
-      },
-      "project_id": {
-        "term": {
-          "description": "Unique ID for any specific defined piece of work that is undertaken or attempted to meet a single requirement.\n"
-        },
-        "type": "string"
-      },
-      "state": {
-        "default": "validated",
-        "downloadable": [
-          "uploaded",
-          "md5summed",
-          "validating",
-          "validated",
-          "error",
-          "invalid",
-          "released"
-        ],
-        "oneOf": [
-          {
-            "enum": [
-              "uploading",
-              "uploaded",
-              "md5summing",
-              "md5summed",
-              "validating",
-              "error",
-              "invalid",
-              "suppressed",
-              "redacted",
-              "live"
-            ]
-          },
-          {
-            "enum": [
-              "validated",
-              "submitted",
-              "released"
-            ]
-          }
-        ],
-        "public": [
-          "live"
-        ],
-        "term": {
-          "description": "The current state of the object.\n"
-        }
-      },
-      "submitter_id": {
-        "description": "A project-specific identifier for a node. This property is the calling card/nickname/alias for a unit of submission. It can be used in place of the UUID for identifying or recalling a node.\n",
-        "type": [
-          "string"
-        ]
-      },
-      "type": {
-        "type": "string"
-      },
-      "updated_datetime": {
-        "oneOf": [
-          {
-            "format": "date-time",
-            "type": "string"
-          },
-          {
-            "type": "null"
-          }
-        ],
-        "term": {
-          "description": "A combination of date and time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]\n"
-        }
-      },
-      "workflow_description": {
-        "description": "A brief description of the workflow or pipeline used to generate the data.",
-        "type": "string"
-      },
-      "workflow_end_datetime": {
-        "oneOf": [
-          {
-            "format": "date-time",
-            "type": "string"
-          },
-          {
-            "type": "null"
-          }
-        ],
-        "term": {
-          "description": "A combination of date and time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]\n"
-        }
-      },
-      "workflow_link": {
-        "description": "Link to Github hash for the CWL workflow used.",
-        "type": "string"
-      },
-      "workflow_name": {
-        "description": "The name of an encapsulated bioinformatics workflow or pipeline.",
-        "type": "string"
-      },
-      "workflow_start_datetime": {
-        "oneOf": [
-          {
-            "format": "date-time",
-            "type": "string"
-          },
-          {
-            "type": "null"
-          }
-        ],
-        "term": {
-          "description": "A combination of date and time of day in the form [-]CCYY-MM-DDThh:mm:ss[Z|(+|-)hh:mm]\n"
-        }
-      },
-      "workflow_version": {
-        "description": "Major version for a GDC workflow.",
-        "type": "string"
-      }
-    },
-    "required": [
-      "submitter_id",
-      "type",
-      "workflow_name",
-      "workflow_version",
-      "workflow_description"
-    ],
-    "submittable": true,
-    "systemProperties": [
-      "id",
-      "project_id",
-      "created_datetime",
-      "updated_datetime",
-      "state",
-      "file_state",
-      "error_type"
-    ],
-    "title": "Variant Calling Workflow",
     "type": "object",
     "uniqueKeys": [
       [

--- a/src/DataExplorer/DataExplorerVisualizations.jsx
+++ b/src/DataExplorer/DataExplorerVisualizations.jsx
@@ -18,24 +18,18 @@ class DataExplorerVisualizations extends React.Component {
     super(props);
     this.state = {
       manifestEntryCount: 0,
-      idField: null,
       nodeIds: [],
     };
   }
 
   componentWillReceiveProps(nextProps) {
     if (nextProps.arrangerData !== this.props.arrangerData) {
+      const arrangerConfig = nextProps.dataExplorerConfig.arrangerConfig;
       const data = nextProps.arrangerData &&
-        nextProps.arrangerData[nextProps.dataExplorerConfig.arrangerConfig.graphqlField];
+        nextProps.arrangerData[arrangerConfig.graphqlField];
       const aggregations = data && data.aggregations ? data.aggregations : null;
-      let idField = null;
-      if (aggregations && aggregations.node_id) {
-        idField = 'node_id';
-      } else if (aggregations && aggregations.submitter_id) {
-        idField = 'submitter_id';
-      }
-      const nodeIds = idField ? aggregations[idField].buckets.map(bucket => bucket.key) : [];
-      this.setState({ idField, nodeIds }, () => {
+      const nodeIds = aggregations[arrangerConfig.nodeCountField].buckets.map(bucket => bucket.key);
+      this.setState({ nodeIds }, () => {
         this.refreshManifestEntryCount(this.state.nodeIds);
       });
     }
@@ -45,7 +39,7 @@ class DataExplorerVisualizations extends React.Component {
     downloadManifest(
       this.props.api,
       this.props.projectId,
-      this.state.idField,
+      this.props.dataExplorerConfig.arrangerConfig.nodeCountField,
       this.state.nodeIds,
       this.props.dataExplorerConfig.arrangerConfig,
       fileName,
@@ -56,7 +50,7 @@ class DataExplorerVisualizations extends React.Component {
     downloadData(
       this.props.api,
       this.props.projectId,
-      this.state.idField,
+      this.props.dataExplorerConfig.arrangerConfig.nodeCountField,
       this.state.nodeIds,
       this.props.dataExplorerConfig.arrangerConfig,
       fileName,
@@ -67,7 +61,7 @@ class DataExplorerVisualizations extends React.Component {
     exportAllSelectedDataToCloud(
       this.props.api,
       this.props.projectId,
-      this.state.idField,
+      this.props.dataExplorerConfig.arrangerConfig.nodeCountField,
       this.state.nodeIds,
       this.props.dataExplorerConfig.arrangerConfig,
     );
@@ -94,7 +88,7 @@ class DataExplorerVisualizations extends React.Component {
       getManifestEntryCount(
         this.props.api,
         this.props.projectId,
-        this.state.idField,
+        this.props.dataExplorerConfig.arrangerConfig.nodeCountField,
         this.state.nodeIds,
         this.props.dataExplorerConfig.arrangerConfig,
       ).then((r) => {


### PR DESCRIPTION
Description about what this pull request does.

The ETL has gotten rid of `node_id` in the newest version - to accommodate this change and each commons being on a different version of the ETL we need to add a new config field. 

Also added a new title for the login page while I was here.

### New Features
- Changes title on the login page
- Adds a config field for getting the number of cases/subjects/etc.
