### PR TITLE
fix(config): remove default config for tiered access

### DIFF
--- a/data/config/default.json
+++ b/data/config/default.json
@@ -71,20 +71,6 @@
           "link": "/submission",
           "label": "Submit data"
         }
-      ],
-      "homepageChartNodes": [
-        {
-          "node": "case",
-          "name": "Cases"
-        },
-        {
-          "node": "experiment",
-          "name": "Experiments"
-        },
-        {
-          "node": "aliquot",
-          "name": "Aliquots"
-        }
       ]
     },
     "navigation": {

--- a/src/Index/utils.js
+++ b/src/Index/utils.js
@@ -23,7 +23,9 @@ const getProjectNodeCounts = async (callback) => {
   const resultStatus = { needLogin: false };
   if (typeof homepageChartNodes === 'undefined') {
     getProjectsList();
-    callback(resultStatus);
+    if (callback) {
+      callback(resultStatus);
+    }
     return;
   }
 
@@ -39,17 +41,23 @@ const getProjectNodeCounts = async (callback) => {
     switch (res.status) {
     case 200:
       updateRedux(res.data);
-      callback(resultStatus);
+      if (callback) {
+        callback(resultStatus);
+      }
       break;
     case 404:
       // Shouldn't happen, this means peregrine datasets endpoint not enabled
       console.error(`REST endpoint ${datasetUrl} not enabled in Peregrine yet.`);
-      callback(resultStatus);
+      if (callback) {
+        callback(resultStatus);
+      }
       break;
     case 401:
     case 403:
       resultStatus.needLogin = true;
-      callback(resultStatus);
+      if (callback) {
+        callback(resultStatus);
+      }
       break;
     default:
       break;


### PR DESCRIPTION
Portal config has some merge process that will take default.json's `homepageChartNodes`, this will cause bugs for commons not using gitops.json. This PR remove the `homepageChartNodes` config block from default config to avoid that. 

### New Features


### Breaking Changes


### Bug Fixes
  - remove `homepageChartNodes` block from default config

### Improvements


### Dependency updates


### Deployment changes

