### PR TITLE
fix(dd-button-bug): tiny css changes to fix dd graph button off style

### DIFF
--- a/src/DataDictionary/graph/NodePopup/NodePopup.css
+++ b/src/DataDictionary/graph/NodePopup/NodePopup.css
@@ -51,7 +51,7 @@
   height: 30px;
   background-color: var(--g3-color__base-blue);
   color: var(--g3-color__white);
-  margin-top: 10px;
+  margin: 10px auto auto auto;
 }
 
 .node-popup__close {

--- a/src/DataDictionary/table/DataDictionaryNode/DataDictionaryNode.css
+++ b/src/DataDictionary/table/DataDictionaryNode/DataDictionaryNode.css
@@ -66,6 +66,7 @@
   margin: 0 6px;
   padding: unset; /* override .g3-button's paddings */
   font-weight: normal;
+  display: inline;
 }
 
 .data-dictionary-node__download-button:hover, 


### PR DESCRIPTION
There're some style bugs for buttons in the dd graph viewer's node popup and in graph table. This PR changes some CSS to fix them. 

### New Features


### Breaking Changes


### Bug Fixes
  - Fix some dd graph button off style bugs

### Improvements


### Dependency updates


### Deployment changes

