### PR TITLE
Change query to only pull first 20 records

### DIFF
--- a/src/QueryNode/QueryNode.jsx
+++ b/src/QueryNode/QueryNode.jsx
@@ -224,6 +224,7 @@ class QueryNode extends React.Component {
           nodeTypes={this.props.submission.nodeTypes}
           queryNodeCount={queryNodesList.length}
         />
+        <h4>most recent 20:</h4>
         { queryNodesList.map(
           value => (<Entities
             project={project}

--- a/src/QueryNode/ReduxQueryNode.js
+++ b/src/QueryNode/ReduxQueryNode.js
@@ -19,7 +19,7 @@ export const submitSearchForm = (opts, url, history) =>
     return fetchWithCreds({
       path: `${submissionApiPath}graphql`,
       body: JSON.stringify({
-        query: `query Test { ${nodeType} (first: 100000, project_id: "${project}", quick_search: "${submitterId}") {id, type, submitter_id}}`,
+        query: `query Test { ${nodeType} (first: 20, project_id: "${project}", quick_search: "${submitterId}", order_by_desc: "updated_datetime") {id, type, submitter_id}}`,
       }),
       method: 'POST',
       dispatch,


### PR DESCRIPTION
Description about what this pull request does.

The page that displays the records for a project can take a long time to load since it is querying all the submissions - this changes that to only query the first 20 (sorted by date) so a user can validate that their submission succeeded. Added text to clarify this is no longer the full list, but only the most recent 20.

### New Features
- Changing query from 10,000 to 20

### Breaking Changes


### Bug Fixes


### Improvements
- Page won't time out

### Dependency updates


### Deployment changes

