### PR TITLE
Workspace Scroll Bugfix

### DIFF
--- a/src/Workspace/Workspace.less
+++ b/src/Workspace/Workspace.less
@@ -1,6 +1,5 @@
 .workspace {
   width: 100%;
-  height: -webkit-fill-available;
   min-height: inherit;
 }
 


### PR DESCRIPTION
fix(Workspace): remove web-kit-fill-available, prevents jupyter notebook from expanding beyond size of screen, so there is no scrolling issue

### Bug Fixes
Page no longer jumps, as the iframe no longer expands enough to scroll.