### PR TITLE
fix(limit): add arranger query limit to first 10000

### DIFF
--- a/src/DataExplorer/DataExplorerVisualizations.jsx
+++ b/src/DataExplorer/DataExplorerVisualizations.jsx
@@ -224,6 +224,11 @@ class DataExplorerVisualizations extends React.Component {
         { (this.state.exportStatus === 200) ?
           <div className='data-explorer__toaster-text'>
             <div> {this.state.toasterSuccessText} </div>
+            {
+              (this.state.nodeIds.length > 10000) && (
+                <div> (Export/download functionality is limited to first 10,000 records) </div>
+              )
+            }
             <div> File Name: {this.state.exportFileName} </div>
           </div>
           :

--- a/src/DataExplorer/arrangerQueryHelper.js
+++ b/src/DataExplorer/arrangerQueryHelper.js
@@ -1,5 +1,6 @@
 import { hasKeyChain } from './utils';
 
+const LIMIT_COUNT = 10000;
 const getEndpoint = projectId => `/${projectId}/graphql`;
 
 /**
@@ -68,7 +69,7 @@ export const constructGraphQLQueryWithSQON = (
               }`,
     variables: {
       sqon: sqonObj,
-      first: isGettingCount ? 0 : count,
+      first: isGettingCount ? 0 : Math.min(count, LIMIT_COUNT),
     },
   };
   return gqlQuery;


### PR DESCRIPTION
If case number greater than 10k, arranger query returns error. This PR add limitation to only get first 10k, to avoid UI break. 

### New Features


### Breaking Changes


### Bug Fixes
  - add arranger query limit to first 10000 to avoid err response

### Improvements


### Dependency updates


### Deployment changes

