### PR TITLE
fix(export): skip one unnecessary call

### DIFF
--- a/data/config/ncrdc-demo.json
+++ b/data/config/ncrdc-demo.json
@@ -124,7 +124,7 @@
         "chartType": "count",
         "title": "Projects"
       },
-      "submitter_id": {
+      "node_id": {
         "chartType": "count",
         "title": "Subjects"
       },
@@ -179,7 +179,7 @@
       "projectId": "search",
       "graphqlField": "subject",
       "index": "",
-      "nodeCountField": "submitter_id"
+      "nodeCountField": "node_id"
     }
   }
 }

--- a/data/config/ndh.json
+++ b/data/config/ndh.json
@@ -151,7 +151,7 @@
         "chartType": "count",
         "title": "Projects"
       },
-      "submitter_id": {
+      "subject_id": {
         "chartType": "count",
         "title": "Subjects"
       },
@@ -303,7 +303,7 @@
         "referenceIdFieldInResourceIndex": "subject_id",
         "referenceIdFieldInDataIndex": "node_id"
       },
-      "nodeCountField": "submitter_id"
+      "nodeCountField": "subject_id"
     }
   }
 }

--- a/data/config/va.json
+++ b/data/config/va.json
@@ -187,12 +187,11 @@
     },
     "buttons": [
       {
-        "enabled": false,
-        "type": "manifest",
-        "title": "Download Manifest",
+        "enabled": true,
+        "type": "export-to-workspace",
+        "title": "Export To Workspace",
         "leftIcon": "datafile",
-        "rightIcon": "download",
-        "fileName": "manifest.json"
+        "rightIcon": "download"
       }
     ],
     "table": {
@@ -202,7 +201,13 @@
       "projectId": "search",
       "graphqlField": "patients",
       "index": "",
-      "nodeCountField": "Chicago_ID"
+      "nodeCountField": "Chicago_ID",
+      "manifestMapping": {
+        "resourceIndexType": "file",
+        "resourceIdField": "object_id",
+        "referenceIdFieldInResourceIndex": "case_id",
+        "referenceIdFieldInDataIndex": "object_id"
+      }
     }
   }
 }

--- a/src/DataExplorer/actionHelper.js
+++ b/src/DataExplorer/actionHelper.js
@@ -136,25 +136,13 @@ export const exportToWorkspace = async (
     || !hasKeyChain(arrangerConfig, 'manifestMapping.referenceIdFieldInResourceIndex')) {
     errorCallback(500, MSG_EXPORT_MANIFEST_FAIL);
   }
-  const resourceIDList = (await queryDataByIds(
-    apiFunc,
-    projectId,
-    graphqlIdField,
-    selectedTableRows,
-    arrangerConfig.graphqlField,
-    [arrangerConfig.manifestMapping.referenceIdFieldInDataIndex],
-  )).map((d) => {
-    if (!d[arrangerConfig.manifestMapping.referenceIdFieldInDataIndex]) {
-      errorCallback(500, MSG_EXPORT_MANIFEST_FAIL);
-    }
-    return d[arrangerConfig.manifestMapping.referenceIdFieldInDataIndex];
-  });
+
   const manifestJSON = await queryDataByValues(
     apiFunc,
     projectId,
     arrangerConfig.manifestMapping.resourceIndexType,
     arrangerConfig.manifestMapping.referenceIdFieldInResourceIndex,
-    resourceIDList,
+    selectedTableRows,
     [
       arrangerConfig.manifestMapping.resourceIdField,
       arrangerConfig.manifestMapping.referenceIdFieldInResourceIndex,
@@ -207,25 +195,13 @@ export const getManifestEntryCount = async (
     || !hasKeyChain(arrangerConfig, 'manifestMapping.referenceIdFieldInResourceIndex')) {
     throw MSG_GET_MANIFEST_COUNT_FAIL;
   }
-  const resourceIDList = (await queryDataByIds(
-    apiFunc,
-    projectId,
-    graphqlIdField,
-    selectedTableRows,
-    arrangerConfig.graphqlField,
-    [arrangerConfig.manifestMapping.referenceIdFieldInDataIndex],
-  )).map((d) => {
-    if (!d[arrangerConfig.manifestMapping.referenceIdFieldInDataIndex]) {
-      throw MSG_GET_MANIFEST_COUNT_FAIL;
-    }
-    return d[arrangerConfig.manifestMapping.referenceIdFieldInDataIndex];
-  });
+
   const manifestEntryCount = await queryCountByValues(
     apiFunc,
     projectId,
     arrangerConfig.manifestMapping.resourceIndexType,
     arrangerConfig.manifestMapping.referenceIdFieldInResourceIndex,
-    resourceIDList,
+    selectedTableRows,
   );
   return manifestEntryCount;
 };


### PR DESCRIPTION
Not sure why we did that and it's too slow for mickey with that call
just send case_id to file index to get object_id is sufficient

### New Features


### Breaking Changes


### Bug Fixes


### Improvements
- improve export to workspace performance

### Dependency updates


### Deployment changes

