### PR TITLE
Change to Patients in Mickey

### DIFF
--- a/data/config/va.json
+++ b/data/config/va.json
@@ -3,9 +3,9 @@
   "graphql": {
     "boardCounts": [
       {
-        "graphql": "_clinical_supplement_count",
-        "name": "Clinical Supplement",
-        "plural": "Clinical Supplements"
+        "graphql": "_case_count",
+        "name": "Patient",
+        "plural": "Patients"
       },
       {
         "graphql": "_unaligned_reads_file_count",

--- a/data/config/va.json
+++ b/data/config/va.json
@@ -20,8 +20,8 @@
     ],
     "chartCounts": [
       {
-        "graphql": "_clinical_supplement_count",
-        "name": "Clinical Supplement"
+        "graphql": "_case_count",
+        "name": "Patient"
       },
       {
         "graphql": "_unaligned_reads_file_count",


### PR DESCRIPTION
Description about what this pull request does.

Changes Mickey to display number of Patients instead of Clinical Supplements on homepage

### New Features
- More relevant number on homepage for mickey

### Breaking Changes


### Bug Fixes


### Improvements


### Dependency updates


### Deployment changes

