### PR TITLE
Even width for charts

### DIFF
--- a/src/components/charts/SummaryChartGroup/SummaryChartGroup.less
+++ b/src/components/charts/SummaryChartGroup/SummaryChartGroup.less
@@ -13,6 +13,7 @@
   flex-grow: 1;
   margin: 0;
   position: relative;
+  overflow: hidden;
 }
 
 .summary-chart-group__column-left-border {


### PR DESCRIPTION
Description about what this pull request does.

The explorer charts were overflowing - this will force them into equal widths.

### New Features

### Breaking Changes


### Bug Fixes
- Equal width explorer charts

### Improvements


### Dependency updates


### Deployment changes

