### PR TITLE
Fix login logout issues - PXP-3000

### DIFF
--- a/runWebpack.sh
+++ b/runWebpack.sh
@@ -39,7 +39,6 @@ gitops_config() {
   local manifestFile
   local portalApp
   local portalGitopsFolder
-  local logoutInactiveUsers
 
   gitRepo="cdis-manifest"
   hostname="$1"

--- a/runWebpack.sh
+++ b/runWebpack.sh
@@ -12,6 +12,8 @@
 export APP="${APP:-dev}"
 export NODE_ENV="${NODE_ENV:-dev}"
 export HOSTNAME="${HOSTNAME:-"revproxy-service"}"
+echo "THIS"
+echo $LOGOUT_INACTIVE_USERS
 export LOGOUT_INACTIVE_USERS="${LOGOUT_INACTIVE_USERS:-"true"}"
 
 

--- a/runWebpack.sh
+++ b/runWebpack.sh
@@ -70,15 +70,8 @@ gitops_config() {
     return 1
   fi
   echo "INFO: gitops_config - setting APP=$portalApp"
-  logoutInactiveUsers="$(jq -r .global.logout_inactive_users < $manifestFile)"
-  if [[ -z "$logoutInactiveUsers" ]]; then
-    echo "ERROR: unable to determine logout_inactive_users from manifest at $manifestFile"
-    return 1
-  fi
-  echo "INFO: gitops_config - setting LOGOUT_INACTIVE_USERS=$logoutInactiveUsers"
   export HOSTNAME="$hostname"
   export APP="$portalApp"
-  export LOGOUT_INACTIVE_USERS="$logoutInactiveUsers"
   if [[ "$portalApp" == "gitops" ]]; then
     portalGitopsFolder="../$gitRepo/$hostname/portal"
     local it=0

--- a/runWebpack.sh
+++ b/runWebpack.sh
@@ -12,8 +12,6 @@
 export APP="${APP:-dev}"
 export NODE_ENV="${NODE_ENV:-dev}"
 export HOSTNAME="${HOSTNAME:-"revproxy-service"}"
-echo "THIS"
-echo $LOGOUT_INACTIVE_USERS
 export LOGOUT_INACTIVE_USERS="${LOGOUT_INACTIVE_USERS:-"true"}"
 
 

--- a/src/Login/ProtectedContent.jsx
+++ b/src/Login/ProtectedContent.jsx
@@ -4,7 +4,6 @@ import PropTypes from 'prop-types';
 import { fetchUser, fetchOAuthURL, fetchWithCreds, fetchProjects } from '../actions';
 import Spinner from '../components/Spinner';
 import getReduxStore from '../reduxStore';
-import sessionMonitor from '../SessionMonitor';
 import { requiredCerts, submissionApiOauthPath } from '../configs';
 import ReduxAuthTimeoutPopup from '../Popup/ReduxAuthTimeoutPopup';
 import { intersection, isPageFullScreen } from '../utils';
@@ -157,7 +156,7 @@ class ProtectedContent extends React.Component {
           return newState;
         },
       );
-  }
+  };
 
   /**
    * Filter refreshes the gdc-api token (acquired via oauth with user-api) if necessary.

--- a/src/Login/ProtectedContent.jsx
+++ b/src/Login/ProtectedContent.jsx
@@ -64,6 +64,12 @@ class ProtectedContent extends React.Component {
       dataLoaded: false,
       redirectTo: null,
     };
+
+    if(this.public) {
+      sessionMonitor.stopUserLoginCheck();
+    } else {
+      sessionMonitor.startUserLoginCheck();
+    }
   }
 
   /**

--- a/src/Login/ProtectedContent.jsx
+++ b/src/Login/ProtectedContent.jsx
@@ -64,12 +64,6 @@ class ProtectedContent extends React.Component {
       dataLoaded: false,
       redirectTo: null,
     };
-
-    if(this.public) {
-      sessionMonitor.stopUserLoginCheck();
-    } else {
-      sessionMonitor.startUserLoginCheck();
-    }
   }
 
   /**

--- a/src/Login/ProtectedContent.jsx
+++ b/src/Login/ProtectedContent.jsx
@@ -150,6 +150,7 @@ class ProtectedContent extends React.Component {
           const { user } = store.getState();
           newState.user = user;
           if (!user.username) { // not authenticated
+            console.log('protectedContent logoutUser');
             newState.redirectTo = '/login';
             newState.authenticated = false;
           } else if (response.type !== 'UPDATE_POPUP') {
@@ -235,6 +236,7 @@ class ProtectedContent extends React.Component {
             },
             () => {
               // something went wrong - better just re-login
+              console.log('protectedContent logoutUser 2');
               newState.authenticated = false;
               newState.redirectTo = '/login';
               return newState;

--- a/src/Login/ProtectedContent.jsx
+++ b/src/Login/ProtectedContent.jsx
@@ -124,14 +124,6 @@ class ProtectedContent extends React.Component {
     }
   }
 
-  logoutUserWithPopup = () => {
-    console.log("logoutwithpopup");
-    const latestState = Object.assign({}, this.state);
-    latestState.redirectTo = '/login';
-    latestState.authenticated = false;
-    this.setState(latestState);
-  }
-
   /**
    * Start filter the 'newState' for the checkLoginStatus component.
    * Check if the user is logged in, and update state accordingly.
@@ -147,7 +139,7 @@ class ProtectedContent extends React.Component {
     newState.redirectTo = null;
     newState.user = store.getState().user;
 
-    if (nowMs - lastAuthMs < 6000) {
+    if (nowMs - lastAuthMs < 60000) {
       // assume we're still logged in after 1 minute ...
       return Promise.resolve(newState);
     }
@@ -155,9 +147,7 @@ class ProtectedContent extends React.Component {
     return store.dispatch(fetchUser) // make an API call to see if we're still logged in ...
       .then(
         (response) => {
-          console.log('fetchUser response: ', response);
           const { user } = store.getState();
-          console.log('user: ', user);
           newState.user = user;
           if (!user.username) { // not authenticated
             newState.redirectTo = '/login';

--- a/src/Login/ProtectedContent.jsx
+++ b/src/Login/ProtectedContent.jsx
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types';
 import { fetchUser, fetchOAuthURL, fetchWithCreds, fetchProjects } from '../actions';
 import Spinner from '../components/Spinner';
 import getReduxStore from '../reduxStore';
+import sessionMonitor from '../SessionMonitor';
 import { requiredCerts, submissionApiOauthPath } from '../configs';
 import ReduxAuthTimeoutPopup from '../Popup/ReduxAuthTimeoutPopup';
 import { intersection, isPageFullScreen } from '../utils';
@@ -57,12 +58,98 @@ class ProtectedContent extends React.Component {
   };
 
   constructor(props, context) {
+    console.log('constructing protectedContent');
     super(props, context);
     this.state = {
       authenticated: false,
       dataLoaded: false,
       redirectTo: null,
     };
+
+    this.updateSessionTime = 0.1 * 60 * 1000;
+    this.inactiveTimeLimit = 60 * 60 * 1000;
+    this.mostRecentActivityTimestamp = Date.now();
+    this.mostRecentLogoutTime = Date.now();
+    this.allowedTimeBetweenLogoutCalls =  1 * 60 * 1000;
+    this.interval = null;
+    this.numRefreshedCounter = 0;
+    this.stop();
+    this.start();
+  }
+
+  start = () => {
+    console.log('start protectedContent');
+    if (this.interval) { // interval already started
+      return;
+    }
+    window.addEventListener('mousedown', () => this.updateUserActivity(), false);
+    window.addEventListener('keypress', () => this.updateUserActivity(), false);
+    this.interval = setInterval(
+      () => this.updateSession(),
+      this.updateSessionTime,
+    ); // check session every X min
+  }
+
+  stop = () => {
+    if (this.interval) {
+      clearInterval(this.interval);
+      window.removeEventListener('mousedown', this.updateUserActivity(), false);
+      window.removeEventListener('keypress', this.updateUserActivity(), false);
+    }
+  }
+
+  updateUserActivity = () => {
+    this.mostRecentActivityTimestamp = Date.now();
+  }
+
+  updateSession = () => {
+    console.log('protectedContent: updateSession was called');
+    // If user has been inactive for Y min
+    if (Date.now() - this.mostRecentActivityTimestamp >= this.inactiveTimeLimit) {
+      console.log('SessionMonitor just logged u out ');
+      this.logoutUser();
+      return Promise.resolve(0);
+    } else if (Date.now() - this.mostRecentActivityTimestamp < this.inactiveTimeLimit) {
+      return this.refreshSession();
+    } else {
+      console.log('Error calculating inactive time');
+      return Promise.resolve(0);
+    }
+  }
+
+  refreshSession = () => {
+    // hitting Fence endpoint refreshes token
+    console.log('protected content: refreshSession was called');
+    getReduxStore().then(
+      store => {
+        this.checkLoginStatus(store, this.state).then(
+          newState => this.props.public || this.checkQuizStatus(newState)
+        ).then(
+          newState => this.props.public || this.checkApiToken(store, newState)
+        ).then(
+          (newState) => {
+                const filterPromise = (!this.props.public && newState.authenticated
+                  && typeof this.props.filter === 'function')
+                  ? this.props.filter()
+                  : Promise.resolve('ok');
+                // finally update the component state
+                const finish = () => {
+                  const latestState = Object.assign({}, newState);
+                  latestState.dataLoaded = true;
+                  this.setState(latestState);
+                };
+                return filterPromise.then(
+                  finish, finish,
+                );
+              },
+            );
+      });
+  }
+
+  logoutUserWithPopup() {
+    getReduxStore().then((store) => {
+      store.dispatch(logoutAPI());
+    });
   }
 
   /**
@@ -121,6 +208,14 @@ class ProtectedContent extends React.Component {
     }
   }
 
+  logoutUserWithPopup = () => {
+    console.log("logoutwithpopup");
+    const latestState = Object.assign({}, this.state);
+    latestState.redirectTo = '/login';
+    latestState.authenticated = false;
+    this.setState(latestState);
+  }
+
   /**
    * Start filter the 'newState' for the checkLoginStatus component.
    * Check if the user is logged in, and update state accordingly.
@@ -136,26 +231,29 @@ class ProtectedContent extends React.Component {
     newState.redirectTo = null;
     newState.user = store.getState().user;
 
-    if (nowMs - lastAuthMs < 60000) {
+    if (nowMs - lastAuthMs < 6000) {
       // assume we're still logged in after 1 minute ...
       return Promise.resolve(newState);
     }
 
     return store.dispatch(fetchUser) // make an API call to see if we're still logged in ...
       .then(
-        () => {
+        (response) => {
+          console.log('fetchUser response: ', response);
           const { user } = store.getState();
           newState.user = user;
           if (!user.username) { // not authenticated
+            console.log('not authenticated! protected content is gonna ask to log you out!');
             newState.redirectTo = '/login';
             newState.authenticated = false;
           } else { // auth ok - cache it
+            console.log('protected content is not gonna ask to log you out.');
             lastAuthMs = Date.now();
           }
           return newState;
-        },
+        }
       );
-  };
+  }
 
   /**
    * Filter refreshes the gdc-api token (acquired via oauth with user-api) if necessary.

--- a/src/Login/ProtectedContent.jsx
+++ b/src/Login/ProtectedContent.jsx
@@ -64,8 +64,6 @@ class ProtectedContent extends React.Component {
       dataLoaded: false,
       redirectTo: null,
     };
-    // Give the Session Monitor singleton access to the ReduxAuthTimeoutPopup.
-    sessionMonitor.protectedContentComponent = this;
   }
 
   /**

--- a/src/Login/ProtectedContent.jsx
+++ b/src/Login/ProtectedContent.jsx
@@ -154,7 +154,6 @@ class ProtectedContent extends React.Component {
           const { user } = store.getState();
           newState.user = user;
           if (!user.username) { // not authenticated
-            console.log('protectedContent logoutUser');
             newState.redirectTo = '/login';
             newState.authenticated = false;
           } else if (response.type !== 'UPDATE_POPUP') {
@@ -162,7 +161,7 @@ class ProtectedContent extends React.Component {
             lastAuthMs = Date.now();
           }
           return newState;
-        }
+        },
       );
   }
 
@@ -240,7 +239,6 @@ class ProtectedContent extends React.Component {
             },
             () => {
               // something went wrong - better just re-login
-              console.log('protectedContent logoutUser 2');
               newState.authenticated = false;
               newState.redirectTo = '/login';
               return newState;
@@ -309,4 +307,3 @@ class ProtectedContent extends React.Component {
 }
 
 export default ProtectedContent;
-

--- a/src/SessionMonitor/SessionMonitor.test.js
+++ b/src/SessionMonitor/SessionMonitor.test.js
@@ -20,10 +20,8 @@ describe('SessionMonitor', () => {
   it('refreshes the users token if active', () => {
     const sessionMonitor = new SessionMonitor(500, 10000000);
     const refreshSessionSpy = jest.spyOn(sessionMonitor, 'refreshSession');
-    const logoutUserSpy = jest.spyOn(sessionMonitor, 'logoutUser');
 
     sessionMonitor.updateSession();
     expect(refreshSessionSpy).toHaveBeenCalledTimes(1);
-    expect(logoutUserSpy).not.toHaveBeenCalled();
   });
 });

--- a/src/SessionMonitor/SessionMonitor.test.js
+++ b/src/SessionMonitor/SessionMonitor.test.js
@@ -9,7 +9,7 @@ describe('SessionMonitor', () => {
     jest.clearAllTimers();
   });
 
-  it('does not refresh the users token the user after inactivity', () => {
+  it('does not refresh the users token after inactivity', () => {
     const sessionMonitor = new SessionMonitor(500, -1);
     const refreshSessionSpy = jest.spyOn(sessionMonitor, 'refreshSession');
 

--- a/src/SessionMonitor/SessionMonitor.test.js
+++ b/src/SessionMonitor/SessionMonitor.test.js
@@ -9,14 +9,12 @@ describe('SessionMonitor', () => {
     jest.clearAllTimers();
   });
 
-  it('logs the user out after inactivity', () => {
+  it('does not refresh the users token the user after inactivity', () => {
     const sessionMonitor = new SessionMonitor(500, -1);
     const refreshSessionSpy = jest.spyOn(sessionMonitor, 'refreshSession');
-    const logoutUserSpy = jest.spyOn(sessionMonitor, 'logoutUser');
 
     sessionMonitor.updateSession();
     expect(refreshSessionSpy).not.toHaveBeenCalled();
-    expect(logoutUserSpy).toHaveBeenCalledTimes(1);
   });
 
   it('refreshes the users token if active', () => {

--- a/src/SessionMonitor/index.js
+++ b/src/SessionMonitor/index.js
@@ -2,15 +2,16 @@ import { logoutInactiveUsers } from '../localconf';
 import getReduxStore from '../reduxStore';
 import { fetchUser, fetchUserNoRefresh } from '../actions';
 
-
 /* eslint-disable class-methods-use-this */
 export class SessionMonitor {
   constructor(updateSessionTime, inactiveTimeLimit) {
-    this.updateSessionTime = updateSessionTime || 0.05 * 60 * 1000;
+    this.updateSessionTime = updateSessionTime || 5 * 60 * 1000;
     this.inactiveTimeLimit = inactiveTimeLimit || 30 * 60 * 1000;
     this.mostRecentActivityTimestamp = Date.now();
     this.interval = null;
     this.popupShown = false;
+    console.log("logout inactive: ", logoutInactiveUsers);
+    console.log("logout inactive type: ", typeof logoutInactiveUsers);
   }
 
   start() {
@@ -46,7 +47,7 @@ export class SessionMonitor {
     if (this.isUserOnPage('login')) {
       return Promise.resolve(0);
     }
-    
+
     const timeSinceLastActivity = Date.now() - this.mostRecentActivityTimestamp;
     // If user has been inactive for Y min, and they are not in a workspace
     if (timeSinceLastActivity >= this.inactiveTimeLimit

--- a/src/SessionMonitor/index.js
+++ b/src/SessionMonitor/index.js
@@ -72,8 +72,6 @@ export class SessionMonitor {
   }
 
   refreshSession() {
-    console.log('refreshing...');
-
     if (this.isUserOnPage('login')) {
       return;
     }
@@ -127,7 +125,6 @@ export class SessionMonitor {
     var _this = this;
     getReduxStore().then((store) => {
       store.dispatch(fetchUserNoRefresh).then((response) => { 
-        console.log(response);
         if(response.type == "UPDATE_POPUP") {
           _this.popupShown = true;
         }

--- a/src/SessionMonitor/index.js
+++ b/src/SessionMonitor/index.js
@@ -33,7 +33,6 @@ export class SessionMonitor {
   }
 
   updateUserActivity() {
-    console.log('updateUserActivity');
     this.mostRecentActivityTimestamp = Date.now();
   }
 

--- a/src/SessionMonitor/index.js
+++ b/src/SessionMonitor/index.js
@@ -1,4 +1,4 @@
-import { userapiPath, logoutInactiveUsers } from '../localconf';
+import { logoutInactiveUsers } from '../localconf';
 import getReduxStore from '../reduxStore';
 import { fetchUser, fetchUserNoRefresh } from '../actions';
 
@@ -76,7 +76,7 @@ export class SessionMonitor {
     const self = this;
     return getReduxStore().then((store) => {
       store.dispatch(fetchUser).then((response) => { 
-        if (response.type == 'UPDATE_POPUP') {
+        if (response.type === 'UPDATE_POPUP') {
           self.popupShown = true;
         }
       });

--- a/src/SessionMonitor/index.js
+++ b/src/SessionMonitor/index.js
@@ -10,7 +10,6 @@ export class SessionMonitor {
     this.mostRecentActivityTimestamp = Date.now();
     this.interval = null;
     this.popupShown = false;
-    console.log('logoutInactiveUsers: ', logoutInactiveUsers);
   }
 
   start() {
@@ -34,6 +33,7 @@ export class SessionMonitor {
   }
 
   updateUserActivity() {
+    console.log('updateUserActivity');
     this.mostRecentActivityTimestamp = Date.now();
   }
 

--- a/src/SessionMonitor/index.js
+++ b/src/SessionMonitor/index.js
@@ -10,6 +10,7 @@ export class SessionMonitor {
     this.mostRecentActivityTimestamp = Date.now();
     this.interval = null;
     this.popupShown = false;
+    console.log('logoutInactiveUsers: ', logoutInactiveUsers);
   }
 
   start() {

--- a/src/SessionMonitor/index.js
+++ b/src/SessionMonitor/index.js
@@ -12,7 +12,6 @@ export class SessionMonitor {
     this.mostRecentLogoutTime = Date.now();
     this.allowedTimeBetweenLogoutCalls =  0.1 * 60 * 1000;
     this.interval = null;
-    this.protectedContentComponent = null;
   }
 
   start() {

--- a/src/SessionMonitor/index.js
+++ b/src/SessionMonitor/index.js
@@ -1,17 +1,24 @@
 import { userapiPath } from '../localconf';
 import getReduxStore from '../reduxStore';
 import { logoutAPI } from '../actions';
+import { fetchUser } from '../actions';
 
 /* eslint-disable class-methods-use-this */
 export class SessionMonitor {
   constructor(updateSessionTime, inactiveTimeLimit) {
-    this.updateSessionTime = updateSessionTime || 10 * 60 * 1000;
-    this.inactiveTimeLimit = inactiveTimeLimit || 30 * 60 * 1000;
+    console.log('constructing session monitor');
+    this.updateSessionTime = updateSessionTime || 5 * 60 * 1000;
+    this.inactiveTimeLimit = inactiveTimeLimit || 60 * 60 * 1000;
     this.mostRecentActivityTimestamp = Date.now();
+    this.mostRecentLogoutTime = Date.now();
+    this.allowedTimeBetweenLogoutCalls =  1 * 60 * 1000;
     this.interval = null;
+    this.numRefreshedCounter = 0;
   }
 
   start() {
+    return; 
+
     if (this.interval) { // interval already started
       return;
     }
@@ -36,19 +43,56 @@ export class SessionMonitor {
   }
 
   updateSession() {
+    return Promise.resolve(0);
+    console.log('updateSession was called');
     // If user has been inactive for Y min
     if (Date.now() - this.mostRecentActivityTimestamp >= this.inactiveTimeLimit) {
+      console.log('SessionMonitor just logged u out ');
       this.logoutUser();
+      return Promise.resolve(0);
     } else if (Date.now() - this.mostRecentActivityTimestamp < this.inactiveTimeLimit) {
-      this.refreshSession();
+      return this.refreshSession();
     } else {
       console.log('Error calculating inactive time');
+      return Promise.resolve(0);
     }
   }
 
   refreshSession() {
     // hitting Fence endpoint refreshes token
-    fetch(userapiPath);
+    console.log('refreshSession was called');
+
+    // getReduxStore().then(
+    //   store => {
+    //     return store.dispatch(fetchUser) // make an API call to see if we're still logged in ...
+    //         .then(
+    //           () => {
+    //             const { user } = store.getState();
+    //             //newState.user = user;
+    //             if (!user.username) { // not authenticated
+    //             //  newState.redirectTo = '/login';
+    //             //  newState.authenticated = false;
+    //             } else { // auth ok - cache it
+    //             //  lastAuthMs = Date.now();
+    //             }
+    //             //return newState;
+    //           }
+    //         );
+    //   });
+
+    // return fetch(userapiPath);
+    var _this = this;
+    return fetch(`${userapiPath}user/`).then(function(response, data) {
+      console.log('sessoion monitor got the result: ', response);
+      if ((response.status == 401 || response.status == 403) 
+        && Date.now() - _this.mostRecentLogoutTime > _this.allowedTimeBetweenLogoutCalls) {
+        //console.log('logging out user');
+        //_this.logoutUser();
+      }
+      _this.numRefreshedCounter += 1;
+      console.log('_this.numRefreshedCounter: ', _this.numRefreshedCounter);
+      return response;
+    });
   }
 
   logoutUser() {

--- a/src/SessionMonitor/index.js
+++ b/src/SessionMonitor/index.js
@@ -42,11 +42,9 @@ export class SessionMonitor {
   updateSession() {
     // If user has been inactive for Y min
     if (Date.now() - this.mostRecentActivityTimestamp >= this.inactiveTimeLimit) {
-      console.log('updateSession branch 1');
       this.logoutUser();
       return Promise.resolve(0);
     } else if (Date.now() - this.mostRecentActivityTimestamp < this.inactiveTimeLimit) {
-      console.log('updateSession branch 2');
       return this.refreshSession();
     } else {
       console.log('Error calculating inactive time');
@@ -56,30 +54,24 @@ export class SessionMonitor {
 
   refreshSession() {
     // hitting Fence endpoint refreshes token
-    console.log('refreshing session');
     var _this = this;
     return fetch(`${userapiPath}user/`).then(function(response, data) {
-      console.log('sessoion monitor got the result: ', response);
-      if ((response.status == 401 || response.status == 403) 
-        && Date.now() - _this.mostRecentLogoutTime > _this.allowedTimeBetweenLogoutCalls) {
-        console.log('logging out user');
-        _this.logoutUser();
+      if (response.status == 401 || response.status == 403) {
+        _this.notifyUserTheyAreNotLoggedIn();
       }
       return response;
     });
   }
 
-  logoutUser() {
-    if (this.protectedContentComponent !== null) {
-      getReduxStore().then((store) => {
-        store.dispatch(fetchUser).then( result => {
-          console.log('SM 71: ', result);
-        });
-      });
-      //this.protectedContentComponent.logoutUserWithPopup();
-      return;
-    }
+  notifyUserTheyAreNotLoggedIn() {
+    // If the user is browsing a page with ProtectedContent, this code will
+    // display the popup that informs them their session has expired.
+    getReduxStore().then((store) => {
+      store.dispatch(fetchUser)
+    });
+  }
 
+  logoutUser() {
     getReduxStore().then((store) => {
       store.dispatch(logoutAPI());
     });

--- a/src/SessionMonitor/index.js
+++ b/src/SessionMonitor/index.js
@@ -1,98 +1,137 @@
-import { userapiPath } from '../localconf';
+import { userapiPath, logoutInactiveUsers, submissionApiPath } from '../localconf';
 import getReduxStore from '../reduxStore';
-import { logoutApi, logoutUserWithoutRedirect, fetchUser } from '../actions';
+import { logoutAPI, logoutUserWithoutRedirect, fetchUser, fetchUserNoRefresh } from '../actions';
 
 
 /* eslint-disable class-methods-use-this */
 export class SessionMonitor {
   constructor(updateSessionTime, inactiveTimeLimit) {
-    this.updateSessionTime = updateSessionTime || 1 * 60 * 1000;
+    this.updateSessionTime = updateSessionTime || 0.05 * 60 * 1000;
+    this.checkIfUserLoggedInInterval = 5 * 60 * 1000;
     this.inactiveTimeLimit = inactiveTimeLimit || 0.2 * 60 * 1000;
     this.mostRecentActivityTimestamp = Date.now();
     this.mostRecentLogoutTime = Date.now();
-    this.allowedTimeBetweenLogoutCalls =  0.01 * 60 * 1000;
-    this.interval = null;
+    this.allowedTimeBetweenLogoutCalls =  1 * 60 * 1000;
+    this.fenceInterval = null;
+    this.sheepdogInterval = null;
     this.popupShown = false;
   }
 
   start() {
-    if (this.interval) { // interval already started
+    if (this.fenceInterval) { // interval already started
       return;
     }
     window.addEventListener('mousedown', () => this.updateUserActivity(), false);
     window.addEventListener('keypress', () => this.updateUserActivity(), false);
-    this.interval = setInterval(
+    this.fenceInterval = setInterval(
       () => this.updateSession(),
       this.updateSessionTime,
     ); // check session every X min
+
+    this.startUserLoginCheck();
   }
 
   stop() {
-    if (this.interval) {
-      clearInterval(this.interval);
+    if (this.fenceInterval) {
+      clearInterval(this.fenceInterval);
       window.removeEventListener('mousedown', this.updateUserActivity(), false);
       window.removeEventListener('keypress', this.updateUserActivity(), false);
     }
+
+    this.stopUserLoginCheck();
   }
 
   updateUserActivity() {
-    console.log('updateUserActivity');
     this.mostRecentActivityTimestamp = Date.now();
   }
 
+  isUserOnPage(pageName) {
+    const paths = window.location.href.split('/').filter(x => x !== 'dev.html');
+    return paths[paths.length - 1] === pageName;
+  }
+
   updateSession() {
+    if (this.isUserOnPage('login')) {
+      return;
+    }
+    
     const timeSinceLastActivity = Date.now() - this.mostRecentActivityTimestamp;
     const timeSinceLastLogout = Date.now() - this.mostRecentLogoutTime;
     const paths = window.location.href.split('/').filter(x => x !== 'dev.html');
     const userIsInWorkspace = paths[paths.length - 1] === 'workspace';
-    console.log('timeSinceLastLogout: ', timeSinceLastLogout);
-    console.log('allowed time: ', this.allowedTimeBetweenLogoutCalls);
-
     // If user has been inactive for Y min, and they are not in a workspace
     if (timeSinceLastActivity >= this.inactiveTimeLimit && !userIsInWorkspace
-        && timeSinceLastLogout > this.allowedTimeBetweenLogoutCalls ) {
-      this.logoutUser();
-      this.mostRecentLogoutTime = Date.now();
+        && timeSinceLastLogout > this.allowedTimeBetweenLogoutCalls 
+        && logoutInactiveUsers) {
+      // Allow Fence to log out the user. If we don't refresh, Fence will mark them as inactive.
+      this.notifyUserIfTheyAreNotLoggedIn();
       return Promise.resolve(0);
     }
+
     return this.refreshSession();
   }
 
   refreshSession() {
-    console.log('sessionMonitor refreshSession');
+    console.log('refreshing...');
+
+    if (this.isUserOnPage('login')) {
+      return;
+    }
     // hitting Fence endpoint refreshes token
     var _this = this;
     return fetch(`${userapiPath}user/`).then(function(response, data) {
       if (response.status == 401 || response.status == 403) {
-        _this.notifyUserTheyAreNotLoggedIn();
+        _this.notifyUserIfTheyAreNotLoggedIn();
       }
       return response;
     });
   }
 
-  notifyUserTheyAreNotLoggedIn() {
-    // If the user is browsing a page with ProtectedContent, this code will
-    // display the popup that informs them their session has expired.
-    console.log('sessionMonitor -- showing popup');
-    var _this = this;
-    if(!this.popupShown) {
-      getReduxStore().then((store) => {
-        store.dispatch(fetchUser);
-        _this.popupShown = true;
-      });
+  checkIfUserLoggedIn() {
+    return fetch(`${submissionApiPath}`).then(function(response, data) {
+      if (response.status == 401 || response.status == 403) {
+        _this.notifyUserIfTheyAreNotLoggedIn();
+      }
+      return response;
+    });
+  }
+
+  startUserLoginCheck() {
+    // Only start sheepdog check if we won't be logging out inactive users -- 
+    // in the case where the user has been inactive, we'll need the sheepdog
+    // check to see if they're logged out without refreshing their token
+    // (because hitting Fence refreshes their token)
+    if(!this.sheepdogInterval && !logoutInactiveUsers) {
+      this.sheepdogInterval = setInterval(
+        () => this.checkIfUserLoggedIn(),
+        this.checkIfUserLoggedInInterval,
+      );
     }
   }
-  //logoutUserWithoutRedirect()
-  logoutUser() {
-    console.log('sessionMonitor logoutUser');
+
+  stopUserLoginCheck() {
+    if (this.sheepdogInterval) {
+      clearInterval(this.sheepdogInterval);
+      window.removeEventListener('mousedown', this.updateUserActivity(), false);
+      window.removeEventListener('keypress', this.updateUserActivity(), false);
+    }
+  }
+
+  notifyUserIfTheyAreNotLoggedIn() {
+    // If the user is browsing a page with ProtectedContent, this code will
+    // display the popup that informs them their session has expired.
+    if(this.popupShown) {
+      return;
+    }
+    
     var _this = this;
     getReduxStore().then((store) => {
-      store.dispatch(logoutUserWithoutRedirect()).then(function(response) {
-        console.log('session monitor 81: ', response);
-        _this.refreshSession();
-        console.log('on 88');
-      });   
-      // store.dispatch(logoutAPI());
+      store.dispatch(fetchUserNoRefresh).then((response) => { 
+        console.log(response);
+        if(response.type == "UPDATE_POPUP") {
+          _this.popupShown = true;
+        }
+      });
     });
   }
 }

--- a/src/SessionMonitor/index.js
+++ b/src/SessionMonitor/index.js
@@ -64,11 +64,10 @@ export class SessionMonitor {
       return Promise.resolve(0);
     }
     // hitting Fence endpoint refreshes token
-    const self = this;
     return getReduxStore().then((store) => {
       store.dispatch(fetchUser).then((response) => {
         if (response.type === 'UPDATE_POPUP') {
-          self.popupShown = true;
+          this.popupShown = true;
         }
       });
     });
@@ -85,11 +84,10 @@ export class SessionMonitor {
       return;
     }
 
-    const self = this;
     getReduxStore().then((store) => {
       store.dispatch(fetchUserNoRefresh).then((response) => {
         if (response.type === 'UPDATE_POPUP') {
-          self.popupShown = true;
+          this.popupShown = true;
         }
       });
     });

--- a/src/SessionMonitor/index.js
+++ b/src/SessionMonitor/index.js
@@ -10,8 +10,6 @@ export class SessionMonitor {
     this.mostRecentActivityTimestamp = Date.now();
     this.interval = null;
     this.popupShown = false;
-    console.log("logout inactive: ", logoutInactiveUsers);
-    console.log("logout inactive type: ", typeof logoutInactiveUsers);
   }
 
   start() {

--- a/src/SessionMonitor/index.js
+++ b/src/SessionMonitor/index.js
@@ -1,6 +1,6 @@
 import { userapiPath, logoutInactiveUsers, submissionApiPath } from '../localconf';
 import getReduxStore from '../reduxStore';
-import { logoutAPI, logoutUserWithoutRedirect, fetchUser, fetchUserNoRefresh } from '../actions';
+import { fetchUser, fetchUserNoRefresh } from '../actions';
 
 
 /* eslint-disable class-methods-use-this */

--- a/src/SessionMonitor/index.js
+++ b/src/SessionMonitor/index.js
@@ -6,7 +6,7 @@ import { logoutAPI, logoutUserWithoutRedirect, fetchUser, fetchUserNoRefresh } f
 /* eslint-disable class-methods-use-this */
 export class SessionMonitor {
   constructor(updateSessionTime, inactiveTimeLimit) {
-    this.updateSessionTime = updateSessionTime || 0.05 * 60 * 1000;
+    this.updateSessionTime = updateSessionTime || 5 * 60 * 1000;
     this.inactiveTimeLimit = inactiveTimeLimit || 30 * 60 * 1000;
     this.mostRecentActivityTimestamp = Date.now();
     this.interval = null;

--- a/src/SessionMonitor/index.js
+++ b/src/SessionMonitor/index.js
@@ -6,7 +6,7 @@ import { fetchUser, fetchUserNoRefresh } from '../actions';
 /* eslint-disable class-methods-use-this */
 export class SessionMonitor {
   constructor(updateSessionTime, inactiveTimeLimit) {
-    this.updateSessionTime = updateSessionTime || 5 * 60 * 1000;
+    this.updateSessionTime = updateSessionTime || 0.05 * 60 * 1000;
     this.inactiveTimeLimit = inactiveTimeLimit || 30 * 60 * 1000;
     this.mostRecentActivityTimestamp = Date.now();
     this.interval = null;
@@ -65,14 +65,6 @@ export class SessionMonitor {
       return Promise.resolve(0);
     }
     // hitting Fence endpoint refreshes token
-    // var self = this;
-    // return fetch(`${userapiPath}user/`).then(function(response, data) {
-    //   if (response.status == 401 || response.status == 403) {
-    //     self.notifyUserIfTheyAreNotLoggedIn();
-    //   }
-    //   return response;
-    // });
-
     const self = this;
     return getReduxStore().then((store) => {
       store.dispatch(fetchUser).then((response) => { 

--- a/src/SessionMonitor/index.js
+++ b/src/SessionMonitor/index.js
@@ -66,7 +66,7 @@ export class SessionMonitor {
     // hitting Fence endpoint refreshes token
     const self = this;
     return getReduxStore().then((store) => {
-      store.dispatch(fetchUser).then((response) => { 
+      store.dispatch(fetchUser).then((response) => {
         if (response.type === 'UPDATE_POPUP') {
           self.popupShown = true;
         }
@@ -84,7 +84,7 @@ export class SessionMonitor {
     if (this.popupShown) {
       return;
     }
-    
+
     const self = this;
     getReduxStore().then((store) => {
       store.dispatch(fetchUserNoRefresh).then((response) => {

--- a/src/SessionMonitor/index.js
+++ b/src/SessionMonitor/index.js
@@ -74,18 +74,13 @@ export class SessionMonitor {
     });
   }
 
-  checkIfUserLoggedIn() {
-    return fetch(`${submissionApiPath}`).then(function(response, data) {
-      if (response.status == 401 || response.status == 403) {
-        _this.notifyUserIfTheyAreNotLoggedIn();
-      }
-      return response;
-    });
-  }
-
   notifyUserIfTheyAreNotLoggedIn() {
-    /* If the user is browsing a page with ProtectedContent, this code will
-     * display the popup that informs them their session has expired. */
+    /* If a logged-out user is browsing a page with ProtectedContent, this code will
+     * display the popup that informs them their session has expired. 
+     * This function is similar to refreshSession() in that it checks user
+     * auth (401/403 vs 200) but the difference is it does not refresh
+     * the access token nor extend the session.
+     */
     if(this.popupShown) {
       return;
     }

--- a/src/SessionMonitor/index.js
+++ b/src/SessionMonitor/index.js
@@ -77,7 +77,7 @@ export class SessionMonitor {
     /* If a logged-out user is browsing a page with ProtectedContent, this code will
      * display the popup that informs them their session has expired.
      * This function is similar to refreshSession() in that it checks user
-     * auth (401/403 vs 200) but the difference is it does not refresh
+     * auth (401/403 vs 200), but it does not refresh
      * the access token nor extend the session.
      */
     if (this.popupShown) {

--- a/src/actions.js
+++ b/src/actions.js
@@ -247,9 +247,7 @@ export const logoutAPI = () => dispatch => {
     .then(handleResponse('RECEIVE_API_LOGOUT'))
     .then(msg => dispatch(msg))
     .then(
-      () => { 
-        document.location.replace(`${userapiPath}/logout?next=${basename}`),
-      }
+      () => document.location.replace(`${userapiPath}/logout?next=${basename}`),
     );
   }
 

--- a/src/actions.js
+++ b/src/actions.js
@@ -152,6 +152,8 @@ export const fetchWrapper = ({ path, method = 'GET', body = null, customHeaders,
   );
 
 export const fetchGraphQL = (graphQLParams) => {
+  // We first update the session so that the user will be notified
+  // if their auth is insufficient to perform the query.
   return sessionMonitor.updateSession().then(function(result) {
     const request = {
       credentials: 'include',

--- a/src/actions.js
+++ b/src/actions.js
@@ -242,8 +242,6 @@ export const fetchUser = dispatch => fetchCreds({
 export const refreshUser = () => fetchUser;
 
 export const logoutAPI = () => dispatch => { 
-  console.log('logoutAPI was about to be hit!!!');
-  return;
   fetchWithCreds({
     path: `${submissionApiOauthPath}logout`,
     dispatch,

--- a/src/actions.js
+++ b/src/actions.js
@@ -248,7 +248,7 @@ export const logoutAPI = () => dispatch => {
     .then(msg => dispatch(msg))
     .then(
       () => { 
-        document.location.replace(`${userapiPath}/logout?next=${basename}`) 
+        document.location.replace(`${userapiPath}/logout?next=${basename}`),
       }
     );
   }

--- a/src/actions.js
+++ b/src/actions.js
@@ -283,43 +283,7 @@ export const logoutAPI = () => dispatch => {
     );
   }
 
-// A friendlier logout function that will display the "Session expired" popup
-export const logoutUserWithoutRedirect = () => dispatch => {
-  console.log('log out user wo redirect');
-  return fetchWithCreds({
-      path: `${userapiPath}logout/`,
-      dispatch,
-    })
-      .then(handleResponse('RECEIVE_API_LOGOUT'))
-      .then(msg => dispatch(msg))
-      .then((result) => {
-        const path = `${userapiPath}logout/`;
-        const method = 'GET';
-        const request = {
-          credentials: 'include',
-          headers: { ...headers },
-          method,
-        };
-        let pendingRequest = fetch(path, request).then(
-          (response) => {
-            pendingRequest = null;
-            return Promise.resolve(getJsonOrText(path, response, false));
-          },
-          (error) => {
-            pendingRequest = null;
-            if (dispatch) { dispatch(connectionError()); }
-            return Promise.reject(error);
-          },
-        );
-      })
-  // //     .then(msg => dispatch(msg)).then(() => { 
-  // //       fetchWithCreds({
-  // //         path: `${userapiPath}logout`,
-  // //         dispatch,
-  // //     })
-  // // }
-  // );
-}
+
 
 /**
  * Retrieve the oath endpoint for the service under the given oathPath
@@ -358,7 +322,6 @@ export const fetchOAuthURL = oauthPath => dispatch =>
         throw new Error('OAuth authorization failed');
       },
     );
-
 
 /*
  * redux-thunk support asynchronous redux actions via 'thunks' -

--- a/src/actions.js
+++ b/src/actions.js
@@ -154,7 +154,7 @@ export const fetchWrapper = ({ path, method = 'GET', body = null, customHeaders,
 export const fetchGraphQL = (graphQLParams) => {
   // We first update the session so that the user will be notified
   // if their auth is insufficient to perform the query.
-  return sessionMonitor.updateSession().then(function(result) {
+  return sessionMonitor.updateSession().then(() => {
     const request = {
       credentials: 'include',
       headers: { ...headers },
@@ -170,13 +170,12 @@ export const fetchGraphQL = (graphQLParams) => {
         } catch (error) {
           return responseBody;
         }
-      }
-    );
+      });
   });
 };
 
 export const fetchFlatGraphQL = (graphQLParams) => {
-  return sessionMonitor.updateSession().then(function(result) {
+  return sessionMonitor.updateSession().then(() => {
     const request = {
       credentials: 'include',
       headers: { ...headers },
@@ -241,7 +240,7 @@ export const fetchUser = dispatch => fetchCreds({
 
 export const refreshUser = () => fetchUser;
 
-export const logoutAPI = () => dispatch => { 
+export const logoutAPI = () => dispatch => {
   fetchWithCreds({
     path: `${submissionApiOauthPath}logout`,
     dispatch,
@@ -251,7 +250,7 @@ export const logoutAPI = () => dispatch => {
     .then(
       () => document.location.replace(`${userapiPath}/logout?next=${basename}`),
     );
-  }
+};
 
 export const fetchIsUserLoggedInNoRefresh = (opts) => {
   const { path = `${submissionApiPath}`, method = 'GET', dispatch } = opts;
@@ -260,18 +259,18 @@ export const fetchIsUserLoggedInNoRefresh = (opts) => {
     headers: { ...headers },
     method,
   };
-  let pendingRequest = fetch(path, request).then(
+  let requestPromise = fetch(path, request).then(
     (response) => {
-      pendingRequest = null;
+      requestPromise = null;
       return Promise.resolve(getJsonOrText(path, response, false));
     },
     (error) => {
-      pendingRequest = null;
+      requestPromise = null;
       if (dispatch) { dispatch(connectionError()); }
       return Promise.reject(error);
     },
   );
-  return pendingRequest;
+  return requestPromise;
 };
 
 export const fetchUserNoRefresh = dispatch => fetchIsUserLoggedInNoRefresh({

--- a/src/actions.js
+++ b/src/actions.js
@@ -153,7 +153,6 @@ export const fetchWrapper = ({ path, method = 'GET', body = null, customHeaders,
 
 export const fetchGraphQL = (graphQLParams) => {
   return sessionMonitor.updateSession().then(function(result) {
-    console.log('updateSession result: ', result);
     const request = {
       credentials: 'include',
       headers: { ...headers },
@@ -176,7 +175,6 @@ export const fetchGraphQL = (graphQLParams) => {
 
 export const fetchFlatGraphQL = (graphQLParams) => {
   return sessionMonitor.updateSession().then(function(result) {
-    console.log('updateSession result: ', result);
     const request = {
       credentials: 'include',
       headers: { ...headers },

--- a/src/actions.js
+++ b/src/actions.js
@@ -239,6 +239,20 @@ export const fetchUser = dispatch => fetchCreds({
 
 export const refreshUser = () => fetchUser;
 
+export const logoutAPI = () => dispatch => { 
+  fetchWithCreds({
+    path: `${submissionApiOauthPath}logout`,
+    dispatch,
+  })
+    .then(handleResponse('RECEIVE_API_LOGOUT'))
+    .then(msg => dispatch(msg))
+    .then(
+      () => { 
+        document.location.replace(`${userapiPath}/logout?next=${basename}`) 
+      }
+    );
+  }
+
 export const fetchIsUserLoggedInNoRefresh = (opts) => {
   const { path = `${submissionApiPath}`, method = 'GET', dispatch } = opts;
   const request = {
@@ -265,25 +279,6 @@ export const fetchUserNoRefresh = dispatch => fetchIsUserLoggedInNoRefresh({
 }).then(
   (status, data) => handleFetchUser(status, data),
 ).then(msg => dispatch(msg));
-
-
-// A more aggressive logout function that will turn all the user's windmill windows into
-// logout screens after their 30 minute bathroom break.
-export const logoutAPI = () => dispatch => { 
-  fetchWithCreds({
-    path: `${submissionApiOauthPath}logout`,
-    dispatch,
-  })
-    .then(handleResponse('RECEIVE_API_LOGOUT'))
-    .then(msg => dispatch(msg))
-    .then(
-      () => { 
-        document.location.replace(`${userapiPath}/logout?next=${basename}`) 
-      }
-    );
-  }
-
-
 
 /**
  * Retrieve the oath endpoint for the service under the given oathPath

--- a/src/actions.js
+++ b/src/actions.js
@@ -193,8 +193,7 @@ export const fetchFlatGraphQL = (graphQLParams) => {
           return responseBody;
         }
       });
-    }
-  );
+  });
 };
 
 export const handleResponse = type => ({ data, status }) => {

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -46,7 +46,7 @@ import ErrorWorkspacePlaceholder from './Workspace/ErrorWorkspacePlaceholder';
 import './index.less';
 
 // monitor user's session
-sessionMonitor.start();
+// sessionMonitor.start();
 
 // render the app after the store is configured
 async function init() {

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -46,7 +46,7 @@ import ErrorWorkspacePlaceholder from './Workspace/ErrorWorkspacePlaceholder';
 import './index.less';
 
 // monitor user's session
-// sessionMonitor.start();
+sessionMonitor.start();
 
 // render the app after the store is configured
 async function init() {

--- a/src/localconf.js
+++ b/src/localconf.js
@@ -50,6 +50,7 @@ function buildConfig(opts) {
     title: 'Login from Google',
   };
   const loginPath = `${userapiPath}login/`;
+  const logoutInactiveUsers = !!(process.env.LOGOUT_INACTIVE_USERS) || true;
   const graphqlSchemaUrl = `${hostname}data/schema.json`;
   const workspaceUrl = '/lw-workspace/';
   const workspaceErrorUrl = '/no-workspace-access/';
@@ -63,6 +64,8 @@ function buildConfig(opts) {
   if (typeof components.index.homepageChartNodes === 'undefined') {
     indexPublic = false;
   }
+
+  console.log(process.env);
 
   let useGuppyForExplorer = false;
   if (config.dataExplorerConfig.guppyConfig) {
@@ -194,6 +197,7 @@ function buildConfig(opts) {
     colorsForCharts,
     login,
     loginPath,
+    logoutInactiveUsers,
     requiredCerts,
     lineLimit,
     certs: components.certs,

--- a/src/localconf.js
+++ b/src/localconf.js
@@ -65,8 +65,6 @@ function buildConfig(opts) {
     indexPublic = false;
   }
 
-  console.log(process.env);
-
   let useGuppyForExplorer = false;
   if (config.dataExplorerConfig.guppyConfig) {
     useGuppyForExplorer = true;

--- a/src/localconf.js
+++ b/src/localconf.js
@@ -50,7 +50,7 @@ function buildConfig(opts) {
     title: 'Login from Google',
   };
   const loginPath = `${userapiPath}login/`;
-  const logoutInactiveUsers = !!(process.env.LOGOUT_INACTIVE_USERS) || true;
+  const logoutInactiveUsers = !(process.env.LOGOUT_INACTIVE_USERS === 'false');
   const graphqlSchemaUrl = `${hostname}data/schema.json`;
   const workspaceUrl = '/lw-workspace/';
   const workspaceErrorUrl = '/no-workspace-access/';
@@ -64,7 +64,6 @@ function buildConfig(opts) {
   if (typeof components.index.homepageChartNodes === 'undefined') {
     indexPublic = false;
   }
-  console.log(process.env);
 
   let useGuppyForExplorer = false;
   if (config.dataExplorerConfig.guppyConfig) {

--- a/src/localconf.js
+++ b/src/localconf.js
@@ -64,6 +64,7 @@ function buildConfig(opts) {
   if (typeof components.index.homepageChartNodes === 'undefined') {
     indexPublic = false;
   }
+  console.log(process.env);
 
   let useGuppyForExplorer = false;
   if (config.dataExplorerConfig.guppyConfig) {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -30,7 +30,7 @@ const plugins = [
   new webpack.DefinePlugin({ // <-- key to reducing React's size
     'process.env': {
       'NODE_ENV': JSON.stringify(process.env.NODE_ENV || 'dev'),
-      'LOGOUT_INACTIVE_USERS': !(process.env.LOGOUT_INACTIVE_USERS === 'false'),
+      LOGOUT_INACTIVE_USERS: !(process.env.LOGOUT_INACTIVE_USERS === 'false'),
       REACT_APP_PROJECT_ID: JSON.stringify(process.env.REACT_APP_PROJECT_ID || 'search'),
       REACT_APP_ARRANGER_API: JSON.stringify(process.env.REACT_APP_ARRANGER_API || '/api/v0/flat-search'),
       REACT_APP_DISABLE_SOCKET: JSON.stringify(process.env.REACT_APP_DISABLE_SOCKET || 'true'),

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -23,12 +23,14 @@ const plugins = [
   new webpack.EnvironmentPlugin({'MOCK_STORE': null}),
   new webpack.EnvironmentPlugin(['APP']),
   new webpack.EnvironmentPlugin({'BASENAME': '/'}),
+  new webpack.EnvironmentPlugin(['LOGOUT_INACTIVE_USERS']),
   new webpack.EnvironmentPlugin(['REACT_APP_PROJECT_ID']),
   new webpack.EnvironmentPlugin(['REACT_APP_ARRANGER_API']),
   new webpack.EnvironmentPlugin(['REACT_APP_DISABLE_SOCKET']),
   new webpack.DefinePlugin({ // <-- key to reducing React's size
     'process.env': {
       'NODE_ENV': JSON.stringify(process.env.NODE_ENV || 'dev'),
+      'LOGOUT_INACTIVE_USERS': !(process.env.LOGOUT_INACTIVE_USERS === 'false'),
       REACT_APP_PROJECT_ID: JSON.stringify(process.env.REACT_APP_PROJECT_ID || 'search'),
       REACT_APP_ARRANGER_API: JSON.stringify(process.env.REACT_APP_ARRANGER_API || '/api/v0/flat-search'),
       REACT_APP_DISABLE_SOCKET: JSON.stringify(process.env.REACT_APP_DISABLE_SOCKET || 'true'),


### PR DESCRIPTION
This PR focuses on the user session lifecycle. Deployed at https://zakir.planx-pla.net/

### Bug fixes
-> The query page now calls updateSession() before executing a query. This fixes the bug where query results come back empty with a 200 response in the case where the user's session has expired. 

-> The refreshSession function now hits /user/user instead of just /user, so that we can notify the user with the ReduxAuthTimeoutPopup if their session is over (/user is public, /user/user is not). 


### Code changes
-> The SessionMonitor no longer logs out users. If a user has been inactive and the config has logoutInactiveUsers == true, we just decline to refresh their session and allow Fence to log them out. At this point, we start using Sheepdog to check their auth status instead of Fence, so that we can check their auth status without refreshing the access token. 

-> Users are allowed to keep a workspace tab open for the duration of the Fence session lifetime without being logged out (likely 8 hours). We can't detect user activity within the workspace iframe, so a solution to detect their activity is not trivial. (Note that once a Jupyter pod is spawned, it stays alive regardless of whether or not we redirect their browser to the login page.) Allowing "inactivity" on this page will make it easier for users to perform long-running analysis operations in a notebook overnight (the redirect didn't work before anyway, because the browser displays that "You have unsaved changes" popup which can be declined).

-> The session is now updated every 5 minutes, rather than every 10 minutes. If a user's auth has expired and the session is not updated, the user won't know they've been logged out until they navigate to a new page (or until they notice that pages are suddenly refusing to serve them data). Increasing the updateSession frequency is helpful in this situation. 


### Deployment changes
New manifest.json variable: logout_inactive_users. Defaults to true if not provided.

https://github.com/uc-cdis/cloud-automation/pull/818
