### PR TITLE
fix: account for trailing slashes in URLs

### DIFF
--- a/src/SessionMonitor/SessionMonitor.test.js
+++ b/src/SessionMonitor/SessionMonitor.test.js
@@ -24,4 +24,27 @@ describe('SessionMonitor', () => {
     sessionMonitor.updateSession();
     expect(refreshSessionSpy).toHaveBeenCalledTimes(1);
   });
+
+  it('detects the page correctly', () => {
+    const sessionMonitor = new SessionMonitor(500, 10000000);
+    expect(
+      sessionMonitor.pageFromURL("https://niaid.bionimbus.org/workspace/") 
+    ).toEqual('workspace');
+
+    expect(
+      sessionMonitor.pageFromURL("https://niaid.bionimbus.org/workspace") 
+    ).toEqual('workspace');
+
+    expect(
+      sessionMonitor.pageFromURL("https://niaid.bionimbus.org/dev.html/workspace/") 
+    ).toEqual('workspace');
+
+    expect(
+      sessionMonitor.pageFromURL("data.braincommons.org/login") 
+    ).toEqual('login');
+
+    expect(
+      sessionMonitor.pageFromURL("data.braincommons.org//login//") 
+    ).toEqual('login');
+  });
 });

--- a/src/SessionMonitor/SessionMonitor.test.js
+++ b/src/SessionMonitor/SessionMonitor.test.js
@@ -46,5 +46,13 @@ describe('SessionMonitor', () => {
     expect(
       sessionMonitor.pageFromURL("data.braincommons.org//login//") 
     ).toEqual('login');
+
+    expect(
+      sessionMonitor.pageFromURL("https://niaid.bionimbus.org/analysis/ndhHIV//") 
+    ).toEqual('ndhHIV');
+
+    expect(
+      sessionMonitor.pageFromURL("https://niaid.bionimbus.org/dev.html/analysis/ndhHIV//") 
+    ).toEqual('ndhHIV');
   });
 });

--- a/src/SessionMonitor/SessionMonitor.test.js
+++ b/src/SessionMonitor/SessionMonitor.test.js
@@ -28,31 +28,31 @@ describe('SessionMonitor', () => {
   it('detects the page correctly', () => {
     const sessionMonitor = new SessionMonitor(500, 10000000);
     expect(
-      sessionMonitor.pageFromURL("https://niaid.bionimbus.org/workspace/") 
+      sessionMonitor.pageFromURL("https://example.subdomain.org/workspace/") 
     ).toEqual('workspace');
 
     expect(
-      sessionMonitor.pageFromURL("https://niaid.bionimbus.org/workspace") 
+      sessionMonitor.pageFromURL("https://example.subdomain.org/workspace") 
     ).toEqual('workspace');
 
     expect(
-      sessionMonitor.pageFromURL("https://niaid.bionimbus.org/dev.html/workspace/") 
+      sessionMonitor.pageFromURL("https://example.subdomain.org/dev.html/workspace/") 
     ).toEqual('workspace');
 
     expect(
-      sessionMonitor.pageFromURL("data.braincommons.org/login") 
+      sessionMonitor.pageFromURL("example-site.example-subdomain.org/login") 
     ).toEqual('login');
 
     expect(
-      sessionMonitor.pageFromURL("data.braincommons.org//login//") 
+      sessionMonitor.pageFromURL("example-site.example-subdomain.org//login//") 
     ).toEqual('login');
 
     expect(
-      sessionMonitor.pageFromURL("https://niaid.bionimbus.org/analysis/ndhHIV//") 
-    ).toEqual('ndhHIV');
+      sessionMonitor.pageFromURL("https://example.subdomain.org/analysis/abc123//") 
+    ).toEqual('abc123');
 
     expect(
-      sessionMonitor.pageFromURL("https://niaid.bionimbus.org/dev.html/analysis/ndhHIV//") 
-    ).toEqual('ndhHIV');
+      sessionMonitor.pageFromURL("https://example.subdomain.org/dev.html/analysis/abc123//") 
+    ).toEqual('abc123');
   });
 });

--- a/src/SessionMonitor/index.js
+++ b/src/SessionMonitor/index.js
@@ -38,7 +38,7 @@ export class SessionMonitor {
 
   isUserOnPage(pageName) {
     let paths = window.location.href.split('/').filter(x => x !== 'dev.html');
-    paths = paths.filter(path => path != ""); // To account for trailing slashes
+    paths = paths.filter(path => path !== ""); // To account for trailing slashes
     return paths[paths.length - 1] === pageName;
   }
 

--- a/src/SessionMonitor/index.js
+++ b/src/SessionMonitor/index.js
@@ -37,7 +37,8 @@ export class SessionMonitor {
   }
 
   isUserOnPage(pageName) {
-    const paths = window.location.href.split('/').filter(x => x !== 'dev.html');
+    let paths = window.location.href.split('/').filter(x => x !== 'dev.html');
+    paths = paths.filter(path => path != ""); // To account for trailing slashes
     return paths[paths.length - 1] === pageName;
   }
 

--- a/src/SessionMonitor/index.js
+++ b/src/SessionMonitor/index.js
@@ -36,10 +36,13 @@ export class SessionMonitor {
     this.mostRecentActivityTimestamp = Date.now();
   }
 
+  pageFromURL(currentURL) {
+    let paths = currentURL.split('/').filter(x => x !== 'dev.html' && x !== '');
+    return paths[paths.length - 1];
+  }
+
   isUserOnPage(pageName) {
-    let paths = window.location.href.split('/').filter(x => x !== 'dev.html');
-    paths = paths.filter(path => path !== ""); // To account for trailing slashes
-    return paths[paths.length - 1] === pageName;
+    return this.pageFromURL(window.location.href) === pageName;
   }
 
   updateSession() {


### PR DESCRIPTION
Qingya found a small bug in the function isUserOnPage in the SessionMonitor -- the updateSession function logs out an inactive user in the workspace if the URL ends with a slash. This PR fixes that issue.