### PR TITLE
fix(post): move usedless post-install, to speedup local dev

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ install:
     - npm install --force
 
 script:
+    - npm run relay
     - npm run params
     - npm test
     - bash ./testSchema.sh

--- a/package.json
+++ b/package.json
@@ -126,7 +126,6 @@
   },
   "scripts": {
     "test": "jest",
-    "postinstall": "node ./data/gqlSetup.js > src/gqlHelper.js && relay-compiler --verbose --src src --exclude '**/generated/**' '**/Explorer/**' --schema ./data/schema.json --extensions js jsx",
     "relay": "node ./data/gqlSetup.js > src/gqlHelper.js && relay-compiler --verbose --src src --exclude '**/generated/**' '**/Explorer/**' --schema ./data/schema.json --extensions js jsx",
     "schema": "node ./data/getSchema",
     "params": "node ./data/getTexts > src/params.js",


### PR DESCRIPTION
It's quite annoying/useless to do a relay after npm install (and sometimes it cause error because local config) so I will just remove it. 

### New Features


### Breaking Changes


### Bug Fixes


### Improvements
 - remove useless post-install just to speed up local developing

### Dependency updates


### Deployment changes

