### PR TITLE
feat(unity): support Unity Portal

### DIFF
--- a/src/CoreMetadata/CoreMetadataHeader.jsx
+++ b/src/CoreMetadata/CoreMetadataHeader.jsx
@@ -1,5 +1,8 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
+import {
+  userapiPath,
+} from '../configs';
 
 const DOWNLOAD_BTN_CAPTION = 'Download';
 
@@ -51,7 +54,7 @@ class CoreMetadataHeader extends Component {
       const canDownload = canUserDownload(user, projectAvail, projectId);
       let downloadButton = null;
       if (canDownload) {
-        const downloadLink = `/user/data/download/${this.props.metadata.object_id}?expires_in=900&redirect`;
+        const downloadLink = `${userapiPath}/data/download/${this.props.metadata.object_id}?expires_in=900&redirect`;
 
         downloadButton = (
           <a href={downloadLink}>

--- a/src/index.ejs
+++ b/src/index.ejs
@@ -2,7 +2,7 @@
 <html>
   <head>
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self' https://login.bionimbus.org https://wayf.incommonfederation.org; img-src 'self' data: https://*.s3.amazonaws.com https://www.google-analytics.com; script-src 'self' 'unsafe-eval' https://www.google-analytics.com; worker-src 'self' blob:; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; object-src 'none'; font-src 'self' data: https://fonts.googleapis.com https://fonts.gstatic.com; connect-src 'self' https://login.bionimbus.org https://wayf.incommonfederation.org; frame-src 'self';">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self' https://login.bionimbus.org https://wayf.incommonfederation.org; img-src 'self' data: https://*.s3.amazonaws.com https://www.google-analytics.com; script-src 'self' 'unsafe-eval' https://www.google-analytics.com; worker-src 'self' blob:; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; object-src 'none'; font-src 'self' data: https://fonts.googleapis.com https://fonts.gstatic.com; connect-src 'self' https://login.bionimbus.org https://wayf.incommonfederation.org <%= htmlWebpackPlugin.options.connect_src %>; frame-src 'self';">
     <meta name="viewport" content="width=device-width" />
     <link href="https://fonts.googleapis.com/icon?family=Source+Sans+Pro" rel="stylesheet">
     <link rel="stylesheet/less" type="text/css" media="all" href="<%= htmlWebpackPlugin.options.basename %>/node_modules/@gen3/ui-component/dist/css/base.less">

--- a/src/localconf.js
+++ b/src/localconf.js
@@ -13,6 +13,8 @@ function buildConfig(opts) {
     app: process.env.APP || 'generic',
     basename: process.env.BASENAME || '/',
     hostname: typeof window !== 'undefined' ? `${window.location.protocol}//${window.location.hostname}/` : 'http://localhost/',
+    fenceURL: process.env.FENCE_URL,
+    indexdURL: process.env.INDEXD_URL,
     gaDebug: !!(process.env.GA_DEBUG && process.env.GA_DEBUG === 'true'),
     tierAccessLevel: process.env.TIER_ACCESS_LEVEL || 'private',
     tierAccessLimit: Number.parseInt(process.env.TIER_ACCESS_LIMIT, 10) || 1000,
@@ -32,10 +34,20 @@ function buildConfig(opts) {
     app,
     basename,
     hostname,
+    fenceURL,
+    indexdURL,
     gaDebug,
     tierAccessLevel,
     tierAccessLimit,
   } = Object.assign({}, defaults, opts);
+
+  function ensureTailingSlash(url) {
+    let u = new URL(url);
+    u.pathname += u.pathname.endsWith('/') ? '' : '/';
+    u.hash = '';
+    u.search = '';
+    return u.href;
+  }
 
   const submissionApiPath = `${hostname}api/v0/submission/`;
   const apiPath = `${hostname}api/`;
@@ -43,11 +55,11 @@ function buildConfig(opts) {
   const graphqlPath = `${hostname}api/v0/submission/graphql/`;
   const dataDictionaryTemplatePath = `${hostname}api/v0/submission/template/`;
   const arrangerGraphqlPath = `${hostname}api/v0/flat-search/search/graphql`;
-  let userapiPath = `${hostname}user/`;
+  let userapiPath = typeof fenceURL === 'undefined' ? `${hostname}user/` : ensureTailingSlash(fenceURL);
   const jobapiPath = `${hostname}job/`;
   const credentialCdisPath = `${userapiPath}credentials/cdis/`;
   const coreMetadataPath = `${hostname}coremetadata/`;
-  const indexdPath = `${hostname}index/`;
+  const indexdPath = typeof indexdURL === 'undefined' ? `${hostname}index/` : ensureTailingSlash(indexdURL);
   const wtsPath = `${hostname}wts/oauth2/`;
   let login = {
     url: `${userapiPath}login/google?redirect=`,
@@ -98,7 +110,7 @@ function buildConfig(opts) {
     ],
   };
 
-  if (app === 'gdc') {
+  if (app === 'gdc' && typeof fenceURL === 'undefined') {
     userapiPath = dev === true ? `${hostname}user/` : `${hostname}api/`;
     login = {
       url: 'https://itrusteauth.nih.gov/affwebservices/public/saml2sso?SPID=https://bionimbus-pdc.opensciencedatacloud.org/shibboleth&RelayState=',

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -29,6 +29,8 @@ const plugins = [
   new webpack.EnvironmentPlugin(['REACT_APP_DISABLE_SOCKET']),
   new webpack.EnvironmentPlugin(['TIER_ACCESS_LEVEL']),
   new webpack.EnvironmentPlugin(['TIER_ACCESS_LIMIT']),
+  new webpack.EnvironmentPlugin(['FENCE_URL']),
+  new webpack.EnvironmentPlugin(['INDEXD_URL']),
   new webpack.DefinePlugin({ // <-- key to reducing React's size
     'process.env': {
       'NODE_ENV': JSON.stringify(process.env.NODE_ENV || 'dev'),
@@ -42,6 +44,16 @@ const plugins = [
     title: title,
     basename: pathPrefix,
     template: 'src/index.ejs',
+    connect_src: (function () {
+      let rv = {};
+      if (typeof process.env.FENCE_URL !== 'undefined') {
+        rv[(new URL(process.env.FENCE_URL)).origin] = true;
+      }
+      if (typeof process.env.INDEXD_URL !== 'undefined') {
+        rv[(new URL(process.env.INDEXD_URL)).origin] = true;
+      }
+      return Object.keys(rv).join(' ');
+    })(),
     hash: true
   }),
   new webpack.optimize.AggressiveMergingPlugin(), //Merge chunks


### PR DESCRIPTION
In Unity Portal deployment, sub-portals should have `"fence_hostname": "https://master.domain.com/"` in `manifest.json`. Mind the trailing slash!

### New Features
- Add support for external Fence