### PR TITLE
fix(chart): fix index chart crash when less than 3 nodes provided

### DIFF
--- a/src/Index/relayer.js
+++ b/src/Index/relayer.js
@@ -2,6 +2,7 @@ import { fetchQuery } from 'relay-runtime';
 import environment from '../environment';
 import { GQLHelper } from '../gqlHelper';
 import getReduxStore from '../reduxStore';
+import { config } from '../params';
 
 const gqlHelper = GQLHelper.getGQLHelper();
 
@@ -35,16 +36,16 @@ const updateReduxError = async error => getReduxStore().then(
  */
 const transformRelayProps = (data) => {
   const { fileCount } = GQLHelper.extractFileInfo(data);
+  const nodeCount = Math.min(config.graphql.boardCounts.length + 1, 4);
   const projectList = (data.projectList || []).map(
     proj =>
       // fill in missing properties
       Object.assign({ name: 'unknown',
-        counts: [0, 0, 0, 0],
+        counts: (new Array(nodeCount)).fill(0),
         charts: [0, 0],
       }, proj),
 
   );
-  // console.log( "Got filecount: " + fileCount );
   let summaryCounts = Object.keys(data).filter(
     key => key.indexOf('count') === 0).map(key => key).sort()
     .map(key => data[key],

--- a/src/components/charts/IndexBarChart/index.jsx
+++ b/src/components/charts/IndexBarChart/index.jsx
@@ -51,6 +51,7 @@ const createChartData = (projectList, countNames, sumList) => {
     (project, i) => {
       project.counts.forEach(
         (count, j) => {
+          if (typeof indexChart[j] === 'undefined') return;
           indexChart[j][`count${i}`] = (sumList[j] > 0) ?
             ((count * 100) / sumList[j]).toFixed(2) : 0;
         },


### PR DESCRIPTION
It happens in IBDGC portal: For index chart config block inside portal config, when only 2 or less nodes are provided, the chart component will crash. This PR add more out-of-index check and refine the initialization logic. 

### New Features


### Breaking Changes


### Bug Fixes
  - fix  index chart crash bug when less than 3 nodes

### Improvements


### Dependency updates


### Deployment changes

