### PR TITLE
fix: guppy explorer getManifest function returned incorrect format

### DIFF
--- a/src/GuppyDataExplorer/ExplorerButtonGroup/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerButtonGroup/index.jsx
@@ -195,7 +195,7 @@ class ExplorerButtonGroup extends React.Component {
 
   exportToWorkspace = async () => {
     this.setState({ exportingToWorkspace: true });
-    let resultManifest = await this.getManifest();
+    const resultManifest = await this.getManifest();
     if (resultManifest) {
       fetchWithCreds({
         path: `${manifestServiceApiPath}`,

--- a/src/GuppyDataExplorer/ExplorerButtonGroup/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerButtonGroup/index.jsx
@@ -194,11 +194,13 @@ class ExplorerButtonGroup extends React.Component {
 
   exportToWorkspace = async () => {
     this.setState({ exportingToWorkspace: true });
-    const resultManifest = await this.getManifest();
+    let resultManifest = await this.getManifest();
     if (resultManifest) {
+      const idField = this.props.guppyConfig.manifestMapping.resourceIdField;
+      resultManifest = resultManifest.filter(x => typeof x[idField] !== 'undefined');
       fetchWithCreds({
         path: `${manifestServiceApiPath}`,
-        body: JSON.stringify(resultManifest),
+        body: JSON.stringify(resultManifest.flat()),
         method: 'POST',
       })
         .then(

--- a/src/GuppyDataExplorer/ExplorerButtonGroup/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerButtonGroup/index.jsx
@@ -90,7 +90,7 @@ class ExplorerButtonGroup extends React.Component {
     const fileType = this.props.guppyConfig.manifestMapping.resourceIndexType;
     const caseIDList = await this.props.downloadRawDataByFields({ fields: [caseField] })
       .then(res => res.map(i => i[caseField]));
-    const resultManifest = await this.props.downloadRawDataByTypeAndFilter(
+    let resultManifest = await this.props.downloadRawDataByTypeAndFilter(
       fileType, {
         [caseFieldInFileIndex]: {
           selectedValues: caseIDList,
@@ -98,6 +98,7 @@ class ExplorerButtonGroup extends React.Component {
       },
       [caseFieldInFileIndex, fileFieldInFileIndex],
     );
+    resultManifest = resultManifest.filter(x => typeof x[fileFieldInFileIndex] !== 'undefined');
     return resultManifest;
   };
 
@@ -196,8 +197,6 @@ class ExplorerButtonGroup extends React.Component {
     this.setState({ exportingToWorkspace: true });
     let resultManifest = await this.getManifest();
     if (resultManifest) {
-      const idField = this.props.guppyConfig.manifestMapping.resourceIdField;
-      resultManifest = resultManifest.filter(x => typeof x[idField] !== 'undefined');
       fetchWithCreds({
         path: `${manifestServiceApiPath}`,
         body: JSON.stringify(resultManifest.flat()),

--- a/src/GuppyDataExplorer/ExplorerButtonGroup/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerButtonGroup/index.jsx
@@ -99,7 +99,7 @@ class ExplorerButtonGroup extends React.Component {
       [caseFieldInFileIndex, fileFieldInFileIndex],
     );
     resultManifest = resultManifest.filter(x => typeof x[fileFieldInFileIndex] !== 'undefined');
-    return resultManifest;
+    return resultManifest.flat();
   };
 
   getToaster = () => ((
@@ -199,7 +199,7 @@ class ExplorerButtonGroup extends React.Component {
     if (resultManifest) {
       fetchWithCreds({
         path: `${manifestServiceApiPath}`,
-        body: JSON.stringify(resultManifest.flat()),
+        body: JSON.stringify(resultManifest),
         method: 'POST',
       })
         .then(


### PR DESCRIPTION
### Bug Fixes
- Guppy export to workspace flow was using incorrect manifest format and was including entries with undefined object_ids, resulting in a 400 response from the manifest service