### PR TITLE
Add download/export buttons for file explorer

### DIFF
--- a/data/config/gtex.json
+++ b/data/config/gtex.json
@@ -254,11 +254,10 @@
         "leftIcon": "user",
         "rightIcon": "download",
         "fileName": "clinical.json",
-        "dropdownId": "download",
-        "tooltipText": "You have not selected any cases to download. Please use the checkboxes on the left to select specific cases you would like to download."
+        "dropdownId": "download"
       },
       {
-        "enabled": false,
+        "enabled": true,
         "type": "manifest",
         "title": "Download Manifest",
         "leftIcon": "datafile",
@@ -270,8 +269,7 @@
         "enabled": true,
         "type": "export",
         "title": "Export All to Terra",
-        "rightIcon": "external-link",
-        "tooltipText": "You have not selected any cases to export. Please use the checkboxes on the left to select specific cases you would like to export."
+        "rightIcon": "external-link"
       },
       {
         "enabled": true,
@@ -350,6 +348,25 @@
         "object_id"
       ]
     },
+    "dropdowns": {},
+    "buttons": [
+      {
+        "enabled": true,
+        "type": "file-manifest",
+        "title": "Download Manifest",
+        "leftIcon": "datafile",
+        "rightIcon": "download",
+        "fileName": "file-manifest.json",
+        "dropdownId": "download"
+      },
+      {
+        "enabled": true,
+        "type": "export-files-to-workspace",
+        "title": "Export to Workspace",
+        "leftIcon": "datafile",
+        "rightIcon": "download"
+      }
+    ],
     "guppyConfig": {
       "dataType": "file",
       "fieldMapping": [
@@ -365,8 +382,6 @@
       "accessibleFieldCheckList": ["project_id"],
       "accessibleValidationField": "project_id",
       "downloadAccessor": "object_id"
-    },
-    "buttons": [],
-    "dropdowns": {}
+    }
   }
 }

--- a/src/GuppyDataExplorer/ExplorerButtonGroup/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerButtonGroup/index.jsx
@@ -108,12 +108,12 @@ class ExplorerButtonGroup extends React.Component {
       [refFieldInResourceIndex, resourceFieldInResourceIndex],
     );
     resultManifest = resultManifest.filter(
-      x => !!x[resourceFieldInResourceIndex]
+      x => !!x[resourceFieldInResourceIndex],
     );
     /* eslint-disable no-param-reassign */
-    resultManifest.forEach(function(x) {
-      if(typeof x[refFieldInResourceIndex] === "string") {
-        x[refFieldInResourceIndex] = [ x[refFieldInResourceIndex] ];
+    resultManifest.forEach((x) => {
+      if (typeof x[refFieldInResourceIndex] === 'string') {
+        x[refFieldInResourceIndex] = [x[refFieldInResourceIndex]];
       }
     });
     return resultManifest.flat();
@@ -231,7 +231,7 @@ class ExplorerButtonGroup extends React.Component {
           },
         );
     } else {
-      this.exportToWorkspaceMessageHandler(400, "There were no data files found matching the cohort you created.");
+      this.exportToWorkspaceMessageHandler(400, 'There were no data files found matching the cohort you created.');
     }
   };
 

--- a/src/GuppyDataExplorer/ExplorerButtonGroup/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerButtonGroup/index.jsx
@@ -119,14 +119,6 @@ class ExplorerButtonGroup extends React.Component {
     return resultManifest.flat();
   };
 
-  getFileManifest = async () => {
-    const fileIDField = this.props.guppyConfig.manifestMapping.referenceIdFieldInDataIndex;
-    const dataIDField = this.props.guppyConfig.manifestMapping.resourceIdField;
-    const resultManifest = await this.props.downloadRawDataByFields({ fields: [fileIDField] })
-      .then(res => res.map(i => ({ [fileIDField]: i[fileIDField] })));
-    return resultManifest;
-  };
-
   getToaster = () => ((
     <Toaster isEnabled={this.state.toasterOpen} className={'explorer-button-group__toaster-div'}>
       <Button


### PR DESCRIPTION
Description about what this pull request does.

Please make sure to follow the [DEV guidelines](https://gen3.org/resources/developer/dev-introduction/) before asking for review.

### New Features
- Download manifest and export to workspace capability from file explorer

### Breaking Changes


### Bug Fixes


### Improvements
- updated locally stored config to be in sync with gitops

### Dependency updates


### Deployment changes
- require `fileExplorerConfig` block with `buttons`
