### PR TITLE
Feat/button auth

### DIFF
--- a/data/config/default.json
+++ b/data/config/default.json
@@ -283,5 +283,12 @@
         "file_format"
       ]
     }
+  },
+  "componentToResourceMapping": {
+    "Workspace" : {
+      "resource": "/workspace",
+      "method": "access",
+      "service": "jupyterhub"
+    }
   }
 }

--- a/data/config/default.json
+++ b/data/config/default.json
@@ -284,11 +284,5 @@
       ]
     }
   },
-  "componentToResourceMapping": {
-    "Workspace" : {
-      "resource": "/workspace",
-      "method": "access",
-      "service": "jupyterhub"
-    }
-  }
+  "componentToResourceMapping": {}
 }

--- a/src/GuppyDataExplorer/ExplorerButtonGroup/ReduxExplorerButtonGroup.js
+++ b/src/GuppyDataExplorer/ExplorerButtonGroup/ReduxExplorerButtonGroup.js
@@ -4,6 +4,7 @@ import { dispatchJob, checkJob, fetchJobResult, resetJobState } from '../../Anal
 
 const mapStateToProps = state => ({
   job: state.analysis.job,
+  userAccess: state.userAccess.access,
 });
 
 const mapDispatchToProps = dispatch => ({

--- a/src/GuppyDataExplorer/ExplorerButtonGroup/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerButtonGroup/index.jsx
@@ -205,7 +205,7 @@ class ExplorerButtonGroup extends React.Component {
   };
 
   exportToPFB = () => {
-    this.props.submitJob({ action: 'export', input: {filter: getGQLFilter(this.props.filter) }});
+    this.props.submitJob({ action: 'export', input: { filter: getGQLFilter(this.props.filter) } });
     this.props.checkJobStatus();
     this.setState({
       toasterOpen: true,
@@ -304,6 +304,16 @@ class ExplorerButtonGroup extends React.Component {
     }
   };
 
+  // check if the user has access to this resource
+  isButtonDisplayed = (buttonConfig) => {
+    if (buttonConfig.type === 'export-to-workspace' || buttonConfig.type === 'export-files-to-workspace') {
+      const authResult = this.props.userAccess.Workspace;
+      return typeof authResult !== 'undefined' ? authResult : true;
+    }
+
+    return true;
+  };
+
   isButtonEnabled = (buttonConfig) => {
     if (this.props.isLocked) {
       return !this.props.isLocked;
@@ -332,6 +342,10 @@ class ExplorerButtonGroup extends React.Component {
   };
 
   renderButton = (buttonConfig) => {
+    if (!this.isButtonDisplayed(buttonConfig)) {
+      return null;
+    }
+
     const clickFunc = this.getOnClickFunction(buttonConfig);
     const pendingState = buttonConfig.type === 'manifest' ? (this.state.pendingManifestEntryCountRequestNumber > 0) : false;
     let buttonTitle = buttonConfig.title;
@@ -444,6 +458,7 @@ ExplorerButtonGroup.propTypes = {
   checkJobStatus: PropTypes.func.isRequired,
   fetchJobResult: PropTypes.func.isRequired,
   isLocked: PropTypes.bool.isRequired,
+  userAccess: PropTypes.object.isRequired,
 };
 
 ExplorerButtonGroup.defaultProps = {

--- a/src/Layout/reduxer.js
+++ b/src/Layout/reduxer.js
@@ -24,6 +24,7 @@ export const ReduxNavBar = (() => {
     navItems: components.navigation.items,
     dictIcons,
     activeTab: state.bar.active,
+    userAccess: state.userAccess.access,
     isFullWidth: isPageFullScreen(state.bar.active),
   });
 

--- a/src/actions.js
+++ b/src/actions.js
@@ -421,15 +421,19 @@ export const fetchVersionInfo = dispatch =>
     ).then(msg => dispatch(msg));
 
 
+// asks arborist which restricted access components the user has access to
 export const fetchUserAccess = async (dispatch) => {
   // restricted access components and their associated arborist resources:
   const mapping = config.componentToResourceMapping || {};
 
   // TODO: when the auth/resources endpoint is exposed, we can reduce this to
-  // a single call to arborist instead of using the auth/request endpoint
+  // a single call instead of multiple calls to the auth/request endpoint
   const userAccess = await Object.keys(mapping).reduce(async (res, name) => {
     const dict = await res;
     const e = mapping[name];
+
+    // makes a call to arborist's auth/request endpoint
+    // returns true if the user has access to the resource, false otherwise
     dict[name] = await fetch(
       `${authzPath}?resource=${e.resource}&method=${e.method}&service=${e.service}`,
     )

--- a/src/actions.js
+++ b/src/actions.js
@@ -426,13 +426,11 @@ export const fetchUserAccess = async (dispatch) => {
   // restricted access components and their associated arborist resources:
   const mapping = config.componentToResourceMapping || {};
 
-  // TODO: when the auth/resources endpoint is exposed, we can reduce this to
-  // a single call instead of multiple calls to the auth/request endpoint
   const userAccess = await Object.keys(mapping).reduce(async (res, name) => {
     const dict = await res;
     const e = mapping[name];
 
-    // makes a call to arborist's auth/request endpoint
+    // makes a call to arborist's auth/proxy endpoint
     // returns true if the user has access to the resource, false otherwise
     dict[name] = await fetch(
       `${authzPath}?resource=${e.resource}&method=${e.method}&service=${e.service}`,

--- a/src/components/layout/NavBar.jsx
+++ b/src/components/layout/NavBar.jsx
@@ -23,11 +23,10 @@ class NavBar extends Component {
     this.props.onInitActive();
   }
 
-  getUserAccess = () => this.props.navItems.reduce((res, item) => {
-    const authResult = this.props.userAccess[item.name];
-    res[item.name] = typeof authResult !== 'undefined' ? authResult : true;
-    return res;
-  }, {})
+  canUserSeeComponent = (componentName) => {
+    const authResult = this.props.userAccess[componentName];
+    return typeof authResult !== 'undefined' ? authResult : true;
+  }
 
   isActive = (id) => {
     const toCompare = this.props.activeTab.split('/').filter(x => x !== 'dev.html').join('/');
@@ -39,7 +38,6 @@ class NavBar extends Component {
   }
 
   render() {
-    const userAccess = this.getUserAccess();
     const navItems = this.props.navItems.map(
       (item, index) => {
         const navButton = (item.link.startsWith('http') ?
@@ -62,7 +60,7 @@ class NavBar extends Component {
             />
           </Link>)
         );
-        return userAccess[item.name] ? navButton : null;
+        return this.canUserSeeComponent(item.name) ? navButton : null;
       });
 
     return (

--- a/src/components/layout/NavBar.jsx
+++ b/src/components/layout/NavBar.jsx
@@ -5,7 +5,6 @@ import MediaQuery from 'react-responsive';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import NavButton from './NavButton';
 import { breakpoints } from '../../localconf';
-import { fetchAuthorization } from '../../actions';
 import './NavBar.less';
 
 /**
@@ -17,26 +16,18 @@ class NavBar extends Component {
     super(props);
     this.state = {
       menuOpen: false,
-      buttonAccess: this.props.navItems.reduce((res, item) => {
-        res[item.name] = false;
-        return res;
-      }, {}),
     };
   }
 
   componentDidMount() {
     this.props.onInitActive();
-    this.updateAuth();
   }
 
-  async updateAuth() {
-    const newAccess = await this.props.navItems.reduce(async (res, item) => {
-      const dict = await res;
-      dict[item.name] = await fetchAuthorization(item.name);
-      return dict;
-    }, Promise.resolve({}));
-    this.setState({ buttonAccess: newAccess });
-  }
+  getUserAccess = () => this.props.navItems.reduce((res, item) => {
+    const authResult = this.props.userAccess[item.name];
+    res[item.name] = typeof authResult !== 'undefined' ? authResult : true;
+    return res;
+  }, {})
 
   isActive = (id) => {
     const toCompare = this.props.activeTab.split('/').filter(x => x !== 'dev.html').join('/');
@@ -48,6 +39,7 @@ class NavBar extends Component {
   }
 
   render() {
+    const userAccess = this.getUserAccess();
     const navItems = this.props.navItems.map(
       (item, index) => {
         const navButton = (item.link.startsWith('http') ?
@@ -70,7 +62,7 @@ class NavBar extends Component {
             />
           </Link>)
         );
-        return this.state.buttonAccess[item.name] ? navButton : null;
+        return userAccess[item.name] ? navButton : null;
       });
 
     return (
@@ -141,6 +133,7 @@ class NavBar extends Component {
 
 NavBar.propTypes = {
   navItems: PropTypes.array.isRequired,
+  userAccess: PropTypes.object.isRequired,
   dictIcons: PropTypes.object.isRequired,
   navTitle: PropTypes.string,
   activeTab: PropTypes.string,

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -12,7 +12,7 @@ import ReactGA from 'react-ga';
 import { Helmet } from 'react-helmet';
 
 import '@gen3/ui-component/dist/css/base.less';
-import { fetchDictionary, fetchSchema, fetchVersionInfo } from './actions';
+import { fetchDictionary, fetchSchema, fetchVersionInfo, fetchUserAccess } from './actions';
 import ReduxLogin, { fetchLogin } from './Login/ReduxLogin';
 import ProtectedContent from './Login/ProtectedContent';
 import HomePage from './Homepage/page';
@@ -63,6 +63,8 @@ async function init() {
       store.dispatch(fetchSchema),
       store.dispatch(fetchDictionary),
       store.dispatch(fetchVersionInfo),
+      // resources can be open to anonymous users, so fetch access:
+      store.dispatch(fetchUserAccess),
     ],
   );
   // FontAwesome icons

--- a/src/localconf.js
+++ b/src/localconf.js
@@ -15,6 +15,7 @@ function buildConfig(opts) {
     hostname: typeof window !== 'undefined' ? `${window.location.protocol}//${window.location.hostname}/` : 'http://localhost/',
     fenceURL: process.env.FENCE_URL,
     indexdURL: process.env.INDEXD_URL,
+    arboristURL: process.env.ARBORIST_URL,
     gaDebug: !!(process.env.GA_DEBUG && process.env.GA_DEBUG === 'true'),
     tierAccessLevel: process.env.TIER_ACCESS_LEVEL || 'private',
     tierAccessLimit: Number.parseInt(process.env.TIER_ACCESS_LIMIT, 10) || 1000,
@@ -36,13 +37,14 @@ function buildConfig(opts) {
     hostname,
     fenceURL,
     indexdURL,
+    arboristURL,
     gaDebug,
     tierAccessLevel,
     tierAccessLimit,
   } = Object.assign({}, defaults, opts);
 
-  function ensureTailingSlash(url) {
-    let u = new URL(url);
+  function ensureTrailingSlash(url) {
+    const u = new URL(url);
     u.pathname += u.pathname.endsWith('/') ? '' : '/';
     u.hash = '';
     u.search = '';
@@ -55,16 +57,17 @@ function buildConfig(opts) {
   const graphqlPath = `${hostname}api/v0/submission/graphql/`;
   const dataDictionaryTemplatePath = `${hostname}api/v0/submission/template/`;
   const arrangerGraphqlPath = `${hostname}api/v0/flat-search/search/graphql`;
-  let userapiPath = typeof fenceURL === 'undefined' ? `${hostname}user/` : ensureTailingSlash(fenceURL);
+  let userapiPath = typeof fenceURL === 'undefined' ? `${hostname}user/` : ensureTrailingSlash(fenceURL);
   const jobapiPath = `${hostname}job/`;
   const credentialCdisPath = `${userapiPath}credentials/cdis/`;
   const coreMetadataPath = `${hostname}coremetadata/`;
-  const indexdPath = typeof indexdURL === 'undefined' ? `${hostname}index/` : ensureTailingSlash(indexdURL);
+  const indexdPath = typeof indexdURL === 'undefined' ? `${hostname}index/` : ensureTrailingSlash(indexdURL);
   const wtsPath = `${hostname}wts/oauth2/`;
   let login = {
     url: `${userapiPath}login/google?redirect=`,
     title: 'Login from Google',
   };
+  const authzPath = typeof arboristURL === 'undefined' ? `${hostname}authz` : arboristURL;
   const loginPath = `${userapiPath}login/`;
   const logoutInactiveUsers = !(process.env.LOGOUT_INACTIVE_USERS === 'false');
   const workspaceTimeoutInMinutes = process.env.WORKSPACE_TIMEOUT_IN_MINUTES || 480;
@@ -252,6 +255,7 @@ function buildConfig(opts) {
     tierAccessLevel,
     tierAccessLimit,
     explorerPublic,
+    authzPath,
   };
 }
 

--- a/src/reducers.js
+++ b/src/reducers.js
@@ -16,7 +16,6 @@ import ddgraph from './DataDictionary/reducers';
 import privacyPolicy from './PrivacyPolicy/reducers';
 import { logoutListener } from './Login/ProtectedContent';
 import { fetchUserAccess } from './actions';
-import { config } from './params';
 import getReduxStore from './reduxStore';
 
 const status = (state = {}, action) => {
@@ -62,17 +61,7 @@ const user = (state = {}, action) => {
 };
 
 
-// TODO: try making actual requests to arborist instead. maybe during
-// initialization? because resources can be open to anonymous users
-const initialUserAccess = {
-  // assume anonymous users do not have access to the restricted resources
-  access: Object.keys(config.componentToResourceMapping || {})
-    .reduce((res, e) => {
-      res[e] = false;
-      return res;
-    }, {}),
-};
-const userAccess = (state = initialUserAccess, action) => {
+const userAccess = (state = { access: {} }, action) => {
   switch (action.type) {
   case 'RECEIVE_USER_ACCESS':
     return { ...state, access: action.data };


### PR DESCRIPTION
PXP-3189 and part of PXP-3508

Disable UI components based on arborist access.
Requires https://github.com/uc-cdis/cloud-automation/pull/959

Needs a new "componentToResourceMapping" block in gitops.json. Example:

```
"componentToResourceMapping": {
  "Workspace" : {
    "resource": "/workspace",
    "method": "access",
    "service": "jupyterhub"
  },
  "SomeUIComponent" : {
    "resource": "/abc/xyz",
    "method": "read",
    "service": "someService"
  }
}
```

When a user logs in, we ask arborist whether this user has access to each resource defined in `componentToResourceMapping`. We send multiple requests to Arborist's `auth/proxy` endpoint.

~A possible improvement is to expose the `auth/resources` endpoint so that we can fetch all the resources the user has access to in a single call.~ We are not using the `auth/resources` endpoint because it lists all the resources the user has access to, regardless of which actions the user is allowed to perform on the resource

### New Features
- Disable UI components based on arborist access

### Deployment changes
- Needs a version of cloud-automation that exposes arborist's `auth/proxy` endpoint
