### PR TITLE
History pane can scroll

### DIFF
--- a/src/css/graphiql.css
+++ b/src/css/graphiql.css
@@ -26,6 +26,10 @@
   overflow: hidden;
 }
 
+.graphiql-container .historyPaneWrap {
+  overflow: scroll;
+}
+
 .graphiql-container .editorWrap {
   display: -webkit-box;
   display: -ms-flexbox;


### PR DESCRIPTION
Description about what this pull request does.

CSS change to allow scrolling in GraphiQL History pane.

### New Features
- Implemented XXX

### Breaking Changes


### Bug Fixes
- The GraphiQL history pane wasn't scrolling so only partial history was available - this allows it to scroll to see the full history

### Improvements


### Dependency updates


### Deployment changes
