### PR TITLE
feat(idx-button-auth): hide idx button if no auth

### DIFF
--- a/src/Index/reduxer.jsx
+++ b/src/Index/reduxer.jsx
@@ -51,6 +51,7 @@ export const ReduxIndexButtonBar = (() => {
     buttons: components.index.buttons,
     dictIcons,
     activeTab: state.bar.active,
+    userAccess: state.userAccess.access,
   });
 
   // Bar chart does not dispatch anything

--- a/src/components/IndexButtonBar.jsx
+++ b/src/components/IndexButtonBar.jsx
@@ -9,35 +9,42 @@ import './IndexButtonBar.css';
  * @param {dictIcons, buttons} params
  */
 class IndexButtonBar extends Component {
+  canUserSeeComponent = (componentName) => {
+    const authResult = this.props.userAccess[componentName];
+    return typeof authResult !== 'undefined' ? authResult : true;
+  }
+
   render() {
+    const indexButtonItems = this.props.buttons.map(
+      item => {
+	const indexButton = (
+          <div className='index-button-bar__thumbnail-button' key={item.name}>
+            <div className='h3-typo index-button-bar__thumbnail-title'>{item.name}</div>
+            <div className='index-button-bar__icon'>
+              <IconComponent
+                dictIcons={this.props.dictIcons}
+                iconName={item.icon}
+                height='90px'
+              />
+            </div>
+            <div className='body-typo index-button-bar__thumbnail-text'>{item.body}</div>
+            <Button
+              className='index-button-bar__item'
+              onClick={() => {
+                this.props.onActiveTab(item.link);
+                this.props.history.push(`${item.link}`);
+              }}
+              label={item.label}
+              buttonType='primary'
+            />
+          </div>
+	);
+	return this.canUserSeeComponent(item.name) ? indexButton : null;
+      }
+    );
     return (
       <div className='index-button-bar'>
-        {
-          this.props.buttons.map(
-            item => (
-              <div className='index-button-bar__thumbnail-button' key={item.name}>
-                <div className='h3-typo index-button-bar__thumbnail-title'>{item.name}</div>
-                <div className='index-button-bar__icon'>
-                  <IconComponent
-                    dictIcons={this.props.dictIcons}
-                    iconName={item.icon}
-                    height='90px'
-                  />
-                </div>
-                <div className='body-typo index-button-bar__thumbnail-text'>{item.body}</div>
-                <Button
-                  className='index-button-bar__item'
-                  onClick={() => {
-                    this.props.onActiveTab(item.link);
-                    this.props.history.push(`${item.link}`);
-                  }}
-                  label={item.label}
-                  buttonType='primary'
-                />
-              </div>
-            ),
-          )
-        }
+        { indexButtonItems }
       </div>
     );
   }
@@ -48,6 +55,7 @@ IndexButtonBar.propTypes = {
   buttons: PropTypes.array.isRequired,
   onActiveTab: PropTypes.func,
   history: PropTypes.object.isRequired,
+  userAccess: PropTypes.object.isRequired,
 };
 
 IndexButtonBar.defaultProps = {

--- a/src/components/IndexButtonBar.jsx
+++ b/src/components/IndexButtonBar.jsx
@@ -15,36 +15,37 @@ class IndexButtonBar extends Component {
   }
 
   render() {
-    const indexButtonItems = this.props.buttons.map(
-      item => {
-	const indexButton = (
-          <div className='index-button-bar__thumbnail-button' key={item.name}>
-            <div className='h3-typo index-button-bar__thumbnail-title'>{item.name}</div>
-            <div className='index-button-bar__icon'>
-              <IconComponent
-                dictIcons={this.props.dictIcons}
-                iconName={item.icon}
-                height='90px'
-              />
-            </div>
-            <div className='body-typo index-button-bar__thumbnail-text'>{item.body}</div>
-            <Button
-              className='index-button-bar__item'
-              onClick={() => {
-                this.props.onActiveTab(item.link);
-                this.props.history.push(`${item.link}`);
-              }}
-              label={item.label}
-              buttonType='primary'
-            />
-          </div>
-	);
-	return this.canUserSeeComponent(item.name) ? indexButton : null;
-      }
-    );
     return (
       <div className='index-button-bar'>
-        { indexButtonItems }
+        {
+          this.props.buttons.map(
+            item => {
+              const indexButton = (
+                <div className='index-button-bar__thumbnail-button' key={item.name}>
+                  <div className='h3-typo index-button-bar__thumbnail-title'>{item.name}</div>
+                  <div className='index-button-bar__icon'>
+                    <IconComponent
+                      dictIcons={this.props.dictIcons}
+                      iconName={item.icon}
+                      height='90px'
+                    />
+                  </div>
+                  <div className='body-typo index-button-bar__thumbnail-text'>{item.body}</div>
+                  <Button
+                    className='index-button-bar__item'
+                    onClick={() => {
+                      this.props.onActiveTab(item.link);
+                      this.props.history.push(`${item.link}`);
+                    }}
+                    label={item.label}
+                    buttonType='primary'
+                  />
+                </div>
+              );
+              return this.canUserSeeComponent(item.name) ? indexButton : null;
+            }
+          )
+        }
       </div>
     );
   }


### PR DESCRIPTION
Builds on this PR https://github.com/uc-cdis/data-portal/pull/565 

Disables index button bars (card thingies?) based on Arborist access.

So if for example you have the following `componentToResourceMapping` block in gitops.json: 

```
"componentToResourceMapping": {
  "Analyze Data" : {
    "resource": "/workspace",
    "method": "access",
    "service": "jupyterhub"
  }
}
```
then only users with `/workspace` will see the Analyze Data card on the home page. 


### New Features
- Disable index button bars based on Arborist access


