### PR TITLE
fix/redirect to hostname

### DIFF
--- a/src/actions.js
+++ b/src/actions.js
@@ -3,7 +3,7 @@ import {
   apiPath,
   userapiPath,
   headers,
-  basename,
+  hostname,
   submissionApiOauthPath,
   submissionApiPath,
   graphqlPath,
@@ -247,7 +247,7 @@ export const logoutAPI = () => (dispatch) => {
     .then(handleResponse('RECEIVE_API_LOGOUT'))
     .then(msg => dispatch(msg))
     .then(
-      () => document.location.replace(`${userapiPath}/logout?next=${basename}`),
+      () => document.location.replace(`${userapiPath}/logout?next=${hostname}`),
     );
 };
 


### PR DESCRIPTION
To address https://ctds-planx.atlassian.net/browse/PXP-4115
Use `hostname` for logout redirect URL so it could work for NDE

### New Features


### Breaking Changes


### Bug Fixes
- Use `hostname` as logout redirect URL

### Improvements


### Dependency updates


### Deployment changes

