### PR TITLE
Feat/presigned url btn

### DIFF
--- a/src/CoreMetadata/CoreMetadataHeader.jsx
+++ b/src/CoreMetadata/CoreMetadataHeader.jsx
@@ -83,6 +83,10 @@ class CoreMetadataHeader extends Component {
         />);
       }
 
+      if (!this.props.metadata.data_format) {
+        /* eslint no-console: ["error", { allow: ["error"] }] */
+        console.error('WARNING: null value found for mandatory field \'data_format\', please verify the correctness of metadata');
+      }
       const properties = `${this.props.metadata.data_format} | ${fileSizeTransform(this.props.metadata.file_size)} | ${this.props.metadata.object_id} | ${this.dateTransform(this.props.metadata.updated_datetime)}`;
 
       return (

--- a/src/CoreMetadata/CoreMetadataHeader.jsx
+++ b/src/CoreMetadata/CoreMetadataHeader.jsx
@@ -8,6 +8,7 @@ import { userapiPath } from '../configs';
 const DOWNLOAD_BTN_CAPTION = 'Download';
 const SIGNED_URL_BTN_CAPTION = 'Generate Signed URL';
 const SIGNED_URL_MSG = 'Please copy your signed URL below (this generated signed URL will expires after 3600 seconds):';
+const SIGNED_URL_ERROR_MSG = 'A error has occurred when generating signed URL:';
 
 function fileTypeTransform(type) {
   let t = type.replace(/_/g, ' '); // '-' to ' '
@@ -102,11 +103,11 @@ class CoreMetadataHeader extends Component {
           {
             this.props.signedURLPopup === true &&
             <Popup
-              message={SIGNED_URL_MSG}
+              message={(!this.props.error) ? SIGNED_URL_MSG : SIGNED_URL_ERROR_MSG}
               error={this.props.error}
-              lines={[
+              lines={(!this.props.error) ? [
                 { code: this.props.signedURL },
-              ]}
+              ] : []}
               title='Generated Signed URL'
               leftButtons={[
                 {
@@ -119,6 +120,7 @@ class CoreMetadataHeader extends Component {
                   caption: 'Copy',
                   fn: () => copy(this.props.signedURL),
                   icon: 'copy',
+                  enabled: (!this.props.error),
                 },
               ]}
               onClose={() => this.onSignedURLPopupClose()}

--- a/src/CoreMetadata/CoreMetadataHeader.jsx
+++ b/src/CoreMetadata/CoreMetadataHeader.jsx
@@ -4,6 +4,7 @@ import copy from 'clipboard-plus';
 import React, { Component } from 'react';
 import Popup from '../components/Popup';
 import { userapiPath } from '../configs';
+import isEnabled from '../helpers/featureFlags';
 
 const DOWNLOAD_BTN_CAPTION = 'Download';
 const SIGNED_URL_BTN_CAPTION = 'Generate Signed URL';
@@ -76,12 +77,15 @@ class CoreMetadataHeader extends Component {
               {DOWNLOAD_BTN_CAPTION}
             </button>
           </a>);
-        signedURLButton = (<Button
-          onClick={() => this.onGenerateSignedURL()}
-          label={SIGNED_URL_BTN_CAPTION}
-          className='core-metadata-page__column--right--signed-url-button'
-          buttonType='primary'
-        />);
+
+        if (isEnabled('signedURLButton')) {
+          signedURLButton = (<Button
+            onClick={() => this.onGenerateSignedURL()}
+            label={SIGNED_URL_BTN_CAPTION}
+            className='core-metadata-page__column--right--signed-url-button'
+            buttonType='primary'
+          />);
+        }
       }
 
       if (!this.props.metadata.data_format) {

--- a/src/CoreMetadata/CoreMetadataHeader.jsx
+++ b/src/CoreMetadata/CoreMetadataHeader.jsx
@@ -7,7 +7,7 @@ import { userapiPath } from '../configs';
 
 const DOWNLOAD_BTN_CAPTION = 'Download';
 const SIGNED_URL_BTN_CAPTION = 'Generate Signed URL';
-const SIGNED_URL_MSG = 'Please copy your signed URL below (this generated signed URL will expires after 3600 seconds):';
+const SIGNED_URL_MSG = 'Please copy your signed URL below (this generated signed URL will expire in an hour):';
 const SIGNED_URL_ERROR_MSG = 'An error has occurred when generating signed URL:';
 
 function fileTypeTransform(type) {

--- a/src/CoreMetadata/CoreMetadataHeader.jsx
+++ b/src/CoreMetadata/CoreMetadataHeader.jsx
@@ -8,7 +8,7 @@ import { userapiPath } from '../configs';
 const DOWNLOAD_BTN_CAPTION = 'Download';
 const SIGNED_URL_BTN_CAPTION = 'Generate Signed URL';
 const SIGNED_URL_MSG = 'Please copy your signed URL below (this generated signed URL will expires after 3600 seconds):';
-const SIGNED_URL_ERROR_MSG = 'A error has occurred when generating signed URL:';
+const SIGNED_URL_ERROR_MSG = 'An error has occurred when generating signed URL:';
 
 function fileTypeTransform(type) {
   let t = type.replace(/_/g, ' '); // '-' to ' '

--- a/src/CoreMetadata/page.less
+++ b/src/CoreMetadata/page.less
@@ -14,3 +14,7 @@
 .core-metadata-page__column--right {
   padding: 20px 0 20px 25px;
 }
+
+.core-metadata-page__column--right--signed-url-button {
+  margin-left: 20px;
+}

--- a/src/CoreMetadata/reducers.js
+++ b/src/CoreMetadata/reducers.js
@@ -4,6 +4,12 @@ const coreMetadata = (state = {}, action) => {
     return { ...state, metadata: action.metadata };
   case 'CORE_METADATA_ERROR':
     return { ...state, error: action.error };
+  case 'RECEIVE_SIGNED_URL':
+    return { ...state, url: action.url };
+  case 'signed_URL_ERROR':
+    return { ...state, error: action.error };
+  case 'CLEAR_SIGNED_URL':
+    return { ...state, url: null, error: null };
   case 'DOWNLOAD_FILE':
     return { ...state, file: action.data };
   case 'DOWNLOAD_FILE_ERROR':

--- a/src/CoreMetadata/reducers.js
+++ b/src/CoreMetadata/reducers.js
@@ -6,7 +6,7 @@ const coreMetadata = (state = {}, action) => {
     return { ...state, error: action.error };
   case 'RECEIVE_SIGNED_URL':
     return { ...state, url: action.url };
-  case 'signed_URL_ERROR':
+  case 'SIGNED_URL_ERROR':
     return { ...state, error: action.error };
   case 'CLEAR_SIGNED_URL':
     return { ...state, url: null, error: null };

--- a/src/CoreMetadata/reduxer.js
+++ b/src/CoreMetadata/reduxer.js
@@ -23,7 +23,7 @@ export const generateSignedURL = objectId =>
           default:
             dispatch({
               type: 'SIGNED_URL_ERROR',
-              error: data,
+              error: `Error occurred during generating signed URL. Error code: ${status}`,
             });
             return dispatch(updatePopup({ signedURLPopup: true }));
           }

--- a/src/components/FileTypePicture.jsx
+++ b/src/components/FileTypePicture.jsx
@@ -11,7 +11,7 @@ function dataFormatToFileType(dictIcons, dataFormat) {
 
 class FileTypePicture extends Component {
   render() {
-    const dataFormat = this.props.metadata ? this.props.metadata.data_format : 'file';
+    const dataFormat = (this.props.metadata && this.props.metadata.data_format) ? this.props.metadata.data_format : 'file';
     const fileType = dataFormatToFileType(this.props.dictIcons, dataFormat);
     if (!fileType) return null;
     const content = (

--- a/src/components/Popup.jsx
+++ b/src/components/Popup.jsx
@@ -64,12 +64,14 @@ const Popup = ({
                 key={btn.caption}
                 onClick={btn.fn}
                 label={btn.caption}
+                enabled={(btn.enabled !== undefined) ? btn.enabled : true}
                 buttonType='default'
               /> :
                 <Button
                   key={btn.caption}
                   onClick={btn.fn}
                   label={btn.caption}
+                  enabled={(btn.enabled !== undefined) ? btn.enabled : true}
                   buttonType='default'
                   rightIcon={btn.icon}
                 />,
@@ -84,12 +86,14 @@ const Popup = ({
                 key={btn.caption}
                 onClick={btn.fn}
                 label={btn.caption}
+                enabled={(btn.enabled !== undefined) ? btn.enabled : true}
                 buttonType='primary'
               /> :
                 <Button
                   key={btn.caption}
                   onClick={btn.fn}
                   label={btn.caption}
+                  enabled={(btn.enabled !== undefined) ? btn.enabled : true}
                   buttonType='primary'
                   rightIcon={btn.icon}
                 />,


### PR DESCRIPTION
`Generate Sign URL` button for files, which can be enabled by putting `"signedURLButton": true` in `featureFlags` block of portal config

### New Features
- New `Generate Sign URL` button in file info page, requires `"signedURLButton": true` in `featureFlags` block

### Breaking Changes


### Bug Fixes
- Add check for files that don't have required `data_format` field in metadata and prevent file info page from crashing in that case

### Improvements


### Dependency updates


### Deployment changes

