### PR TITLE
feat(fullpage-workspace): Allow workspace to extend to full-page (PXP-4217)

### DIFF
--- a/src/Workspace/Workspace.less
+++ b/src/Workspace/Workspace.less
@@ -1,21 +1,53 @@
 .workspace {
   width: 100%;
   min-height: inherit;
-  padding: 40px 20px;
+  display: flex;
+  flex-flow: column;
+  background: inherit;
+}
+
+// Add a left/right margin to workspace on large screens,
+// unless the workspace is full-paged.
+@media screen and (min-width: 1291px) {
+  .workspace:not(.workspace--fullpage) {
+    padding: 0 20px;
+  }
+}
+
+.workspace--fullpage {
+  position: fixed;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  width: 100vw;
+  height: 100vh;
+  overflow: hidden;
 }
 
 .workspace__iframe {
+  flex: 1 0 60vh;
   display: flex;
-  flex-flow: column;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
 }
 
-.workspace__terminate-button {
+.workspace__button {
   width: max-content;
-  margin: 20px 20px;
+  margin: 20px auto;
+}
+
+.workspace__buttongroup {
+  height: 60px;
+  flex: 0 0 60px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
 }
 
 .workspace__iframe iframe {
-  height: 100vh;
+  height: 100%;
   width: 100%;
 }
 

--- a/src/Workspace/Workspace.less
+++ b/src/Workspace/Workspace.less
@@ -1,4 +1,4 @@
-.workspace {
+.workspace__container {
   width: 100%;
   min-height: inherit;
   display: flex;
@@ -9,12 +9,12 @@
 // Add a left/right margin to workspace on large screens,
 // unless the workspace is full-paged.
 @media screen and (min-width: 1291px) {
-  .workspace:not(.workspace--fullpage) {
+  .workspace__container:not(.workspace__container--fullpage) {
     padding: 0 20px;
   }
 }
 
-.workspace--fullpage {
+.workspace__container--fullpage {
   position: fixed;
   top: 0;
   bottom: 0;
@@ -25,7 +25,7 @@
   overflow: hidden;
 }
 
-.workspace__iframe {
+.workspace {
   flex: 1 0 60vh;
   display: flex;
   flex-direction: column;

--- a/src/Workspace/index.jsx
+++ b/src/Workspace/index.jsx
@@ -199,14 +199,14 @@ class Workspace extends React.Component {
     if (this.state.connectedStatus && this.state.notebookStatus && !this.state.defaultNotebook) {
       return (
         <div
-          className={`workspace ${this.state.notebookIsfullpage ? 'workspace--fullpage' : ''}`}
+          className={`workspace__container ${this.state.notebookIsfullpage ? 'workspace__container--fullpage' : ''}`}
         >
           {
             this.state.notebookStatus === 'Running' ||
               this.state.notebookStatus === 'Stopped' ?
               <React.Fragment>
                 <iframe
-                  className='workspace__iframe'
+                  className='workspace'
                   title='Workspace'
                   frameBorder='0'
                   src={`${workspaceUrl}proxy/`}
@@ -221,7 +221,7 @@ class Workspace extends React.Component {
           {
             this.state.notebookStatus === 'Launching' ?
               <React.Fragment>
-                <div className='workspace__iframe'>
+                <div className='workspace'>
                   <Spinner text='Launching workspace...' />
                 </div>
                 <div className='workspace__buttongroup'>

--- a/src/Workspace/index.jsx
+++ b/src/Workspace/index.jsx
@@ -24,6 +24,7 @@ class Workspace extends React.Component {
       interval: null,
       notebookType: null,
       defaultNotebook: false,
+      notebookIsfullpage: false,
     };
     this.notebookStates = [
       'Not Found',
@@ -151,39 +152,81 @@ class Workspace extends React.Component {
     }
   }
 
+  handleTerminateButtonClick = () => {
+    // exit full page
+    this.setState({ notebookIsfullpage: false });
+    // terminate workspace
+    this.terminateWorkspace();
+  }
+
+  handleFullpageButtonClick = () => {
+    this.setState({
+      notebookIsfullpage: !this.state.notebookIsfullpage,
+    });
+  }
+
   render() {
     const terminateButton = (
       <Button
-        className='workspace__terminate-button'
-        onClick={() => this.terminateWorkspace()}
+        className='workspace__button'
+        onClick={this.handleTerminateButtonClick}
         label='Terminate Workspace'
         buttonType='primary'
         isPending={this.state.notebookStatus === 'Terminating'}
       />
     );
 
+    const cancelButton = (
+      <Button
+        className='workspace__button'
+        onClick={() => this.terminateWorkspace()}
+        label='Cancel'
+        buttonType='primary'
+        isPending={this.state.notebookStatus === 'Terminating'}
+      />
+    );
+
+    const fullpageButton = (
+      <Button
+        className='workspace__button'
+        onClick={this.handleFullpageButtonClick}
+        label={this.state.notebookIsfullpage ? 'Exit fullscreen' : 'Make fullscreen'}
+        buttonType='secondary'
+        rightIcon={this.state.notebookIsfullpage ? 'back' : 'external-link'}
+      />
+    );
+
     if (this.state.connectedStatus && this.state.notebookStatus && !this.state.defaultNotebook) {
       return (
-        <div className='workspace'>
+        <div
+          className={`workspace ${this.state.notebookIsfullpage ? 'workspace--fullpage' : ''}`}
+        >
           {
             this.state.notebookStatus === 'Running' ||
               this.state.notebookStatus === 'Stopped' ?
-              <div className='workspace__iframe'>
-                { terminateButton }
+              <React.Fragment>
                 <iframe
+                  className='workspace__iframe'
                   title='Workspace'
                   frameBorder='0'
-                  className='workspace'
                   src={`${workspaceUrl}proxy/`}
                 />
-              </div>
+                <div className='workspace__buttongroup'>
+                  { terminateButton }
+                  { fullpageButton }
+                </div>
+              </React.Fragment>
               : null
           }
           {
             this.state.notebookStatus === 'Launching' ?
               <React.Fragment>
-                { terminateButton }
-                <Spinner text='Launching workspace...' />
+                <div className='workspace__iframe'>
+                  <Spinner text='Launching workspace...' />
+                </div>
+                <div className='workspace__buttongroup'>
+                  { cancelButton }
+                </div>
               </React.Fragment>
               : null
           }

--- a/src/Workspace/index.jsx
+++ b/src/Workspace/index.jsx
@@ -190,7 +190,7 @@ class Workspace extends React.Component {
       <Button
         className='workspace__button'
         onClick={this.handleFullpageButtonClick}
-        label={this.state.notebookIsfullpage ? 'Exit fullscreen' : 'Make fullscreen'}
+        label={this.state.notebookIsfullpage ? 'Exit Fullscreen' : 'Make Fullscreen'}
         buttonType='secondary'
         rightIcon={this.state.notebookIsfullpage ? 'back' : 'external-link'}
       />


### PR DESCRIPTION
(PXP-4217) https://ctds-planx.atlassian.net/browse/PXP-4217

Allows user to make workspace take up the whole page, covering
the windmill header and footer. Small UI changes to button placement
and workspace size on workspaces page.

- Tested in Chrome 77, Firefox 69, and Safari 13.0.1
- Currently deployed at https://mpingram.planx-pla.net

### New Features
* 'Make fullscreen' button on Workspaces page allows workspace to
  expand to full screen.

### Improvements
* UI change: Increases default size of workspace.
* UI change: Moves 'Terminate Workspace' button to bottom of page,
  leaving more space at top of page for workspace.
* UI change: Changes 'Terminate Workspace' button text to 'Cancel'
  while workspace is loading.
