### PR TITLE
Arborist UI integration

### DIFF
--- a/data/config/default.json
+++ b/data/config/default.json
@@ -284,5 +284,6 @@
       ]
     }
   },
+  "useArboristUI": false,
   "componentToResourceMapping": {}
 }

--- a/src/Homepage/reduxer.js
+++ b/src/Homepage/reduxer.js
@@ -34,10 +34,10 @@ export const ReduxProjectDashboard = (() => {
 export const ReduxTransaction = (() => {
   const mapStateToProps = (state) => {
     if (state.homepage && state.homepage.transactions) {
-      return { log: state.homepage.transactions };
+      return { log: state.homepage.transactions, userAuthMapping: state.userAuthMapping };
     }
 
-    return { log: [] };
+    return { log: [], userAuthMapping: state.userAuthMapping };
   };
 
   // Table does not dispatch anything

--- a/src/Index/page.jsx
+++ b/src/Index/page.jsx
@@ -1,8 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import MediaQuery from 'react-responsive';
-import Introduction from '../components/Introduction';
-import { ReduxIndexButtonBar, ReduxIndexBarChart, ReduxIndexCounts } from './reduxer';
+import { ReduxIndexButtonBar, ReduxIndexBarChart, ReduxIndexCounts, ReduxIntroduction } from './reduxer';
 import dictIcons from '../img/icons';
 import { components } from '../params';
 import getProjectNodeCounts from './utils';
@@ -24,7 +23,7 @@ class IndexPageComponent extends React.Component {
       <div className='index-page'>
         <div className='index-page__top'>
           <div className='index-page__introduction'>
-            <Introduction data={components.index.introduction} dictIcons={dictIcons} />
+            <ReduxIntroduction data={components.index.introduction} dictIcons={dictIcons} />
             <MediaQuery query={`(max-width: ${breakpoints.tablet}px)`}>
               <ReduxIndexCounts />
             </MediaQuery>

--- a/src/Index/reduxer.jsx
+++ b/src/Index/reduxer.jsx
@@ -5,6 +5,7 @@ import { setActive } from '../Layout/reduxer';
 import IndexBarChart from '../components/charts/IndexBarChart/.';
 import IndexCounts from '../components/cards/IndexCounts/.';
 import IndexButtonBar from '../components/IndexButtonBar';
+import Introduction from '../components/Introduction';
 import { components } from '../params';
 
 export const ReduxIndexBarChart = (() => {
@@ -60,4 +61,12 @@ export const ReduxIndexButtonBar = (() => {
   });
 
   return connect(mapStateToProps, mapDispatchToProps)(IndexButtonBar);
+})();
+
+export const ReduxIntroduction = (() => {
+  const mapStateToProps = state => ({
+    userAuthMapping: state.userAuthMapping,
+  });
+
+  return connect(mapStateToProps)(Introduction);
 })();

--- a/src/Layout/reduxer.js
+++ b/src/Layout/reduxer.js
@@ -43,6 +43,7 @@ export const ReduxTopBar = (() => {
     topItems: components.topBar.items,
     activeTab: state.bar.active,
     user: state.user,
+    userAuthMapping: state.userAuthMapping,
     isFullWidth: isPageFullScreen(state.bar.active),
   });
 

--- a/src/QueryNode/ReduxQueryNode.js
+++ b/src/QueryNode/ReduxQueryNode.js
@@ -117,6 +117,7 @@ const mapStateToProps = (state, ownProps) => {
     ownProps,
     queryNodes: state.queryNodes,
     popups: Object.assign({}, state.popups),
+    userAuthMapping: state.userAuthMapping,
   };
   return result;
 };

--- a/src/Submission/ProjectDashboard.jsx
+++ b/src/Submission/ProjectDashboard.jsx
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import ProjectTable from '../components/tables/ProjectTable';
+import ReduxProjectTable from '../components/tables/reduxer';
 import ReduxSubmissionHeader from './ReduxSubmissionHeader';
 import './ProjectDashboard.less';
 
@@ -13,7 +13,11 @@ class ProjectDashboard extends Component {
           Data Submission
         </div>
         <ReduxSubmissionHeader />
-        <ProjectTable projectList={projectList} summaries={this.props.details} {...this.props} />
+        <ReduxProjectTable
+          projectList={projectList}
+          summaries={this.props.details}
+          {...this.props}
+        />
       </div>
     );
   }

--- a/src/Submission/ProjectSubmission.jsx
+++ b/src/Submission/ProjectSubmission.jsx
@@ -6,6 +6,7 @@ import DataModelGraph from '../DataModelGraph/DataModelGraph';
 import SubmitForm from './SubmitForm';
 import Spinner from '../components/Spinner';
 import './ProjectSubmission.less';
+import { useArboristUI } from '../configs';
 
 const ProjectSubmission = (props) => {
   // hack to detect if dictionary data is available, and to trigger fetch if not
@@ -28,14 +29,32 @@ const ProjectSubmission = (props) => {
     return <MyDataModelGraph project={props.project} />;
   };
 
+  const userHasCreateOrUpdateForThisProject = () => {
+    const actionHasCreateOrUpdate = x => { return x['method'] === 'create' || x['method'] === 'update' }
+
+    var split = props.project.split('-');
+    var program = split[0]
+    var project = split.slice(1).join('-')
+    var resourcePath = ["/programs", program, "projects", project].join('/')
+
+    var resource = props.userAuthMapping[resourcePath]
+    return resource !== undefined && resource.some(actionHasCreateOrUpdate)
+  }
+
   return (
     <div className='project-submission'>
       <h2 className='project-submission__title'>{props.project}</h2>
       {
         <Link className='project-submission__link' to={`/${props.project}/search`}>browse nodes</Link>
       }
-      <MySubmitForm />
-      <MySubmitTSV project={props.project} />
+      {
+        (useArboristUI && !userHasCreateOrUpdateForThisProject()) ? null :
+          <MySubmitForm />
+      }
+      {
+        (useArboristUI && !userHasCreateOrUpdateForThisProject()) ? null :
+          <MySubmitTSV project={props.project} />
+      }
       { displayData() }
     </div>
   );
@@ -50,6 +69,7 @@ ProjectSubmission.propTypes = {
   dataModelGraph: PropTypes.func,
   onGetCounts: PropTypes.func.isRequired,
   typeList: PropTypes.array,
+  userAuthMapping: PropTypes.object.isRequired,
 };
 
 ProjectSubmission.defaultProps = {

--- a/src/Submission/ReduxProjectSubmission.js
+++ b/src/Submission/ReduxProjectSubmission.js
@@ -145,6 +145,7 @@ const ReduxProjectSubmission = (() => {
     submitTSV: ReduxSubmitTSV,
     dataModelGraph: ReduxDataModelGraph,
     project: ownProps.params.project,
+    userAuthMapping: state.userAuthMapping,
   });
 
   const mapDispatchToProps = dispatch => ({

--- a/src/Submission/ReduxSubmissionHeader.js
+++ b/src/Submission/ReduxSubmissionHeader.js
@@ -47,6 +47,7 @@ const ReduxSubmissionHeader = (() => {
     unmappedFileCount: state.submission.unmappedFileCount,
     unmappedFileSize: state.submission.unmappedFileSize,
     user: state.user,
+    userAuthMapping: state.userAuthMapping,
   });
 
   const mapDispatchToProps = dispatch => ({

--- a/src/Submission/SubmissionHeader.jsx
+++ b/src/Submission/SubmissionHeader.jsx
@@ -5,6 +5,7 @@ import Gen3ClientSvg from '../img/gen3client.svg';
 import MapFilesSvg from '../img/mapfiles.svg';
 import { humanFileSize } from '../utils.js';
 import './SubmissionHeader.less';
+import { useArboristUI } from '../configs';
 
 class SubmissionHeader extends React.Component {
   componentDidMount = () => {
@@ -17,6 +18,13 @@ class SubmissionHeader extends React.Component {
 
   openGen3Tutorials = () => {
     window.open('https://gen3.org/resources/user/gen3-client/', '_blank');
+  }
+
+  userHasDataUpload = () => {
+    //data_upload policy is resource data_file, method file_upload, service fence
+    const actionIsFileUpload = x => { return x['method'] === 'file_upload' && x['service'] === 'fence' }
+    var resource = this.props.userAuthMapping['/data_file']
+    return resource !== undefined && resource.some(actionIsFileUpload)
   }
 
   render() {
@@ -52,27 +60,30 @@ class SubmissionHeader extends React.Component {
             />
           </div>
         </div>
-        <div className='submission-header__section'>
-          <div className='submission-header__section-image'>
-            <MapFilesSvg />
-          </div>
-          <div className='submission-header__section-info'>
-            <div className='h3-typo'>Map My Files</div>
-            <div className='h4-typo'>
-              {this.props.unmappedFileCount} files | {totalFileSize}
+        {
+          (useArboristUI && !this.userHasDataUpload()) ? null :
+          <div className='submission-header__section'>
+            <div className='submission-header__section-image'>
+              <MapFilesSvg />
             </div>
-            <div className='body-typo'>
-              Mapping files to metadata in order to create medical meaning.
+            <div className='submission-header__section-info'>
+              <div className='h3-typo'>Map My Files</div>
+              <div className='h4-typo'>
+                {this.props.unmappedFileCount} files | {totalFileSize}
+              </div>
+              <div className='body-typo'>
+                Mapping files to metadata in order to create medical meaning.
+              </div>
+              <Button
+                onClick={() => { window.location.href = `${window.location.href}/files`; }}
+                className='submission-header__section-button'
+                label='Map My Files'
+                buttonType='primary'
+                enabled
+              />
             </div>
-            <Button
-              onClick={() => { window.location.href = `${window.location.href}/files`; }}
-              className='submission-header__section-button'
-              label='Map My Files'
-              buttonType='primary'
-              enabled
-            />
           </div>
-        </div>
+        }
       </div>
     );
   }
@@ -83,6 +94,7 @@ SubmissionHeader.propTypes = {
   unmappedFileCount: PropTypes.number,
   fetchUnmappedFileStats: PropTypes.func.isRequired,
   user: PropTypes.object.isRequired,
+  userAuthMapping: PropTypes.object.isRequired,
 };
 
 SubmissionHeader.defaultProps = {

--- a/src/actions.js
+++ b/src/actions.js
@@ -456,13 +456,14 @@ export const fetchUserAccess = async (dispatch) => {
 };
 
 // asks arborist for the user's auth mapping if Arborist UI enabled
-export const fetchUserAuthMapping = async (dispatch, getState) => {
+export const fetchUserAuthMapping = async (dispatch) => {
   if (!config.useArboristUI) {
     return;
   }
 
+  // Arborist will get the username from the jwt
   const authMapping = await fetch(
-    `${authzMappingPath}?username=${getState().user.username}`,
+    `${authzMappingPath}`,
   ).then((fetchRes) => {
     switch (fetchRes.status) {
     case 200:

--- a/src/actions.js
+++ b/src/actions.js
@@ -472,7 +472,6 @@ export const fetchUserAuthMapping = async (dispatch) => {
       // This is dispatched on app init and on user login.
       // Could be not logged in -> no username -> 404; this is ok
       // There may be plans to update Arborist to return anonymous access when username not found
-      console.log(`Arborist returned "${fetchRes.status}" in mapping call`);
       return {};
     }
   });

--- a/src/components/Introduction.jsx
+++ b/src/components/Introduction.jsx
@@ -2,6 +2,7 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 import IconicLink from './buttons/IconicLink';
 import './Introduction.less';
+import { useArboristUI } from '../configs';
 
 class Introduction extends Component {
   static propTypes = {
@@ -9,7 +10,24 @@ class Introduction extends Component {
     dictIcons: PropTypes.object.isRequired,
   };
 
+  userHasCreateForAnyProject = () => {
+    const actionHasCreate = x => { return (x["method"] === "create") }
+    //array of arrays of { service: x, method: y }
+    var actionArrays = Object.values(this.props.userAuthMapping)
+    var hasCreate = actionArrays.some(x => { return x.some(actionHasCreate) })
+    return hasCreate
+  }
+
   render() {
+    var buttonText = 'Submit Data'
+    if (useArboristUI) {
+      if (this.userHasCreateForAnyProject()) {
+        buttonText = 'Submit/Browse Data'
+      } else {
+        buttonText = 'Browse Data'
+      }
+    }
+
     return (
       <div className='introduction'>
         <div className='h1-typo introduction__title'>{this.props.data.heading}</div>
@@ -20,11 +38,15 @@ class Introduction extends Component {
           className='introduction__icon'
           icon='upload'
           iconColor='#'
-          caption='Submit Data'
+          caption={buttonText}
         />
       </div>
     );
   }
 }
+
+Introduction.propTypes = {
+  userAuthMapping: PropTypes.object.isRequired,
+};
 
 export default Introduction;

--- a/src/components/layout/TopBar.jsx
+++ b/src/components/layout/TopBar.jsx
@@ -3,12 +3,21 @@ import { Link } from 'react-router-dom';
 import PropTypes from 'prop-types';
 import TopIconButton from './TopIconButton';
 import './TopBar.less';
+import { useArboristUI } from '../../configs';
 
 /**
  * NavBar renders row of nav-items of form { name, icon, link }
  */
 class TopBar extends Component {
   isActive = id => this.props.activeTab === id;
+
+  userHasCreateForAnyProject = () => {
+    const actionHasCreate = x => { return (x["method"] === "create") }
+    //array of arrays of { service: x, method: y }
+    var actionArrays = Object.values(this.props.userAuthMapping)
+    var hasCreate = actionArrays.some(x => { return x.some(actionHasCreate) })
+    return hasCreate
+  }
 
   render() {
     return (
@@ -17,8 +26,16 @@ class TopBar extends Component {
           <nav className='top-bar__nav'>
             {
               this.props.topItems.map(
-                item => (
-                  (item.link.startsWith('http')) ?
+                item => {
+                  var buttonText = item.name
+                  if (item.name === 'Submit Data' && useArboristUI) {
+                    if (this.userHasCreateForAnyProject()) {
+                      buttonText = 'Submit/Browse Data'
+                    } else {
+                      buttonText = 'Browse Data'
+                    }
+                  }
+                  return (item.link.startsWith('http')) ?
                     <a
                       className='top-bar__link'
                       key={item.link}
@@ -27,7 +44,7 @@ class TopBar extends Component {
                       rel='noopener noreferrer'
                     >
                       <TopIconButton
-                        name={item.name}
+                        name={buttonText}
                         icon={item.icon}
                         isActive={this.isActive(item.link)}
                         onActiveTab={() => this.props.onActiveTab(item.link)}
@@ -39,13 +56,13 @@ class TopBar extends Component {
                       to={item.link}
                     >
                       <TopIconButton
-                        name={item.name}
+                        name={buttonText}
                         icon={item.icon}
                         isActive={this.isActive(item.link)}
                         onActiveTab={() => this.props.onActiveTab(item.link)}
                       />
                     </Link>
-                ),
+                }
               )
             }
             {
@@ -80,6 +97,7 @@ class TopBar extends Component {
 TopBar.propTypes = {
   topItems: PropTypes.array.isRequired,
   user: PropTypes.shape({ username: PropTypes.string }).isRequired,
+  userAuthMapping: PropTypes.object.isRequired,
   activeTab: PropTypes.string,
   onActiveTab: PropTypes.func,
   onLogoutClick: PropTypes.func.isRequired,

--- a/src/components/tables/ProjectTable.jsx
+++ b/src/components/tables/ProjectTable.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import Button from '@gen3/ui-component/dist/components/Button';
 import Table from './base/Table';
 import { useArboristUI } from '../../configs';
+import './ProjectTable.less';
 
 function compare(a, b) {
   if (a.name < b.name) { return -1; }
@@ -30,6 +31,7 @@ class ProjectTable extends React.Component {
     proj.name,
     ...proj.counts,
     <Button
+      className='project-table__submit-button'
       key={i}
       onClick={() => this.props.history.push(`/${proj.name}`)}
       label={buttonText}

--- a/src/components/tables/ProjectTable.jsx
+++ b/src/components/tables/ProjectTable.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import Button from '@gen3/ui-component/dist/components/Button';
 import Table from './base/Table';
+import { useArboristUI } from '../../configs';
 
 function compare(a, b) {
   if (a.name < b.name) { return -1; }
@@ -20,22 +21,37 @@ class ProjectTable extends React.Component {
     return ['Project', ...summaryFields, ''];
   };
 
-  getData = projectList => projectList.map((proj, i) => [
+  getData = projectList => projectList.map((proj, i) => {
+    var buttonText = "Submit Data"
+    if (useArboristUI) {
+      buttonText = this.userHasCreateOnProject(proj.name) ? "Submit/Browse Data" : "Browse Data";
+    }
+    return [
     proj.name,
     ...proj.counts,
     <Button
       key={i}
       onClick={() => this.props.history.push(`/${proj.name}`)}
-      label='Submit Data'
+      label={buttonText}
       buttonType='primary'
       rightIcon='upload'
     />,
-  ]);
+  ]});
 
   getFooter = (summaries) => {
     const totalCounts = summaries.map(entry => entry.value);
     return ['Totals', ...totalCounts, ''];
   };
+
+  userHasCreateOnProject = (projectName) => {
+    var split = projectName.split('-');
+    var program = split[0]
+    var project = split.slice(1).join('-')
+    var resource = ["/programs", program, "projects", project].join('/')
+    var actions = this.props.userAuthMapping[resource]
+
+    return actions !== undefined && actions.some(x => x["method"] === "create")
+  }
 
   render() {
     const projectList = (this.props.projectList || []).sort(
@@ -57,6 +73,7 @@ ProjectTable.propTypes = {
   projectList: PropTypes.array,
   summaries: PropTypes.array,
   history: PropTypes.object.isRequired,
+  userAuthMapping: PropTypes.object.isRequired,
 };
 
 ProjectTable.defaultProps = {

--- a/src/components/tables/ProjectTable.less
+++ b/src/components/tables/ProjectTable.less
@@ -1,0 +1,4 @@
+.project-table__submit-button {
+  width: 60%;
+  justify-content: space-between;
+}

--- a/src/components/tables/TransactionLogTable.jsx
+++ b/src/components/tables/TransactionLogTable.jsx
@@ -4,10 +4,12 @@ import Table from './base/Table';
 import Spinner from '../Spinner';
 import { humanFileSize } from '../../utils.js';
 import './TransactionLogTable.less';
+import { useArboristUI } from '../../configs';
 
 const formatText = text => text[0] + text.slice(1).toLowerCase();
 
 class TransactionLogTable extends Component {
+
   getLocalTime = (gmtTimeString) => {
     const date = new Date(gmtTimeString);
     const offsetMins = date.getTimezoneOffset();
@@ -25,6 +27,16 @@ class TransactionLogTable extends Component {
     return totalSize;
   };
 
+  userHasCreateOrUpdateForAnyProject = () => {
+    const actionHasCreateOrUpdate = x => {
+      return (x["method"] === "create" || x["method"] === "update")
+    }
+    //array of arrays of { service: x, method: y }
+    var actionArrays = Object.values(this.props.userAuthMapping)
+    var hasCreateOrUpdate = actionArrays.some(x => { return x.some(actionHasCreateOrUpdate) })
+    return hasCreateOrUpdate
+  }
+
   stateToColor = state => (state === 'SUCCEEDED' &&
       <div className='form-special-number transaction-log-table__status-bar'>{formatText(state)}</div>)
     || ((state === 'FAILED' || state === 'ERRORED') &&
@@ -40,6 +52,7 @@ class TransactionLogTable extends Component {
   ]);
 
   render() {
+    if (useArboristUI && !this.userHasCreateOrUpdateForAnyProject()) { return null; }
     if (!this.props.log || this.props.log === []) { return <Spinner />; }
     return (<Table
       title='Recent Submissions'
@@ -51,6 +64,7 @@ class TransactionLogTable extends Component {
 
 TransactionLogTable.propTypes = {
   log: PropTypes.array.isRequired,
+  userAuthMapping: PropTypes.object.isRequired,
 };
 
 export default TransactionLogTable;

--- a/src/components/tables/reduxer.js
+++ b/src/components/tables/reduxer.js
@@ -1,0 +1,14 @@
+import { connect } from 'react-redux';
+import ProjectTable from './ProjectTable';
+
+const ReduxProjectTable = (() => {
+  const mapStateToProps = state => {
+    return {
+      userAuthMapping: state.userAuthMapping,
+    }
+  };
+
+  return connect(mapStateToProps)(ProjectTable);
+})();
+
+export default ReduxProjectTable;

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -12,7 +12,7 @@ import ReactGA from 'react-ga';
 import { Helmet } from 'react-helmet';
 
 import '@gen3/ui-component/dist/css/base.less';
-import { fetchDictionary, fetchSchema, fetchVersionInfo, fetchUserAccess } from './actions';
+import { fetchDictionary, fetchSchema, fetchVersionInfo, fetchUserAccess, fetchUserAuthMapping } from './actions';
 import ReduxLogin, { fetchLogin } from './Login/ReduxLogin';
 import ProtectedContent from './Login/ProtectedContent';
 import HomePage from './Homepage/page';
@@ -65,6 +65,7 @@ async function init() {
       store.dispatch(fetchVersionInfo),
       // resources can be open to anonymous users, so fetch access:
       store.dispatch(fetchUserAccess),
+      store.dispatch(fetchUserAuthMapping),
     ],
   );
   // FontAwesome icons

--- a/src/localconf.js
+++ b/src/localconf.js
@@ -73,7 +73,8 @@ function buildConfig(opts) {
     url: `${userapiPath}login/google?redirect=`,
     title: 'Login from Google',
   };
-  const authzPath = typeof arboristURL === 'undefined' ? `${hostname}authz` : arboristURL;
+  const authzPath = typeof arboristURL === 'undefined' ? `${hostname}authz` : `${arboristURL}authz`;
+  const authzMappingPath = typeof arboristURL === 'undefined' ? `${hostname}authz/mapping` : `${arboristURL}authz/mapping`;
   const loginPath = `${userapiPath}login/`;
   const logoutInactiveUsers = !(process.env.LOGOUT_INACTIVE_USERS === 'false');
   const useIndexdAuthz = !(process.env.USE_INDEXD_AUTHZ === 'false');
@@ -266,6 +267,7 @@ function buildConfig(opts) {
     useIndexdAuthz,
     explorerPublic,
     authzPath,
+    authzMappingPath,
   };
 }
 

--- a/src/localconf.js
+++ b/src/localconf.js
@@ -103,6 +103,11 @@ function buildConfig(opts) {
     useGuppyForExplorer = true;
   }
 
+  let useArboristUI = false;
+  if (config.useArboristUI) {
+    useArboristUI = config.useArboristUI;
+  }
+
   // for "libre" data commons, explorer page is public
   let explorerPublic = false;
   if (tierAccessLevel === 'libre') {
@@ -261,6 +266,7 @@ function buildConfig(opts) {
     manifestServiceApiPath,
     wtsPath,
     useGuppyForExplorer,
+    useArboristUI,
     analysisApps,
     tierAccessLevel,
     tierAccessLimit,

--- a/src/reducers.js
+++ b/src/reducers.js
@@ -15,7 +15,7 @@ import bar from './Layout/reducers';
 import ddgraph from './DataDictionary/reducers';
 import privacyPolicy from './PrivacyPolicy/reducers';
 import { logoutListener } from './Login/ProtectedContent';
-import { fetchUserAccess } from './actions';
+import { fetchUserAccess, fetchUserAuthMapping } from './actions';
 import getReduxStore from './reduxStore';
 
 const status = (state = {}, action) => {
@@ -43,6 +43,7 @@ const user = (state = {}, action) => {
   switch (action.type) {
   case 'RECEIVE_USER':
     getReduxStore().then(store => store.dispatch(fetchUserAccess));
+    getReduxStore().then(store => store.dispatch(fetchUserAuthMapping));
     return { ...state, ...action.user, fetched_user: true };
   case 'REGISTER_ROLE':
     return {
@@ -65,6 +66,15 @@ const userAccess = (state = { access: {} }, action) => {
   switch (action.type) {
   case 'RECEIVE_USER_ACCESS':
     return { ...state, access: action.data };
+  default:
+    return state;
+  }
+};
+
+const userAuthMapping = (state = {}, action) => {
+  switch(action.type) {
+  case 'RECEIVE_USER_AUTH_MAPPING':
+    return { ...state, ...action.data };
   default:
     return state;
   }
@@ -98,6 +108,7 @@ const reducers = combineReducers({ explorer,
   auth: logoutListener,
   ddgraph,
   userAccess,
+  userAuthMapping,
 });
 
 export default reducers;


### PR DESCRIPTION
arborist ui integration--change UI based on user's authz. 
see spec [here](https://docs.google.com/document/d/1IsUlRwoNLUNtT5I9D2tzmepC3y8vdhjmuLfUh-wumvU)

Needs Arborist's GET /auth/mapping endpoint to be exposed via revproxy: 
https://github.com/uc-cdis/arborist/pull/110 
https://github.com/uc-cdis/cloud-automation/pull/1006 

To use this feature, add `"useArboristUI": true` in gitops.json


### New Features
- get auth mapping from arborist if useArboristUI true in config
- per-project submit data buttons change verbiage based on user's authz
- top bar submit data button changes verbiage based on user's authz
- toggle visibility of recent submissions table based on user's authz
- toggle visibility of map my files card based on user's authz
- toggle form submission and upload file button visibility on project page based on user's authz
- toggle node browser delete button visibility based on user's authz 

### Deployment changes 
- if deployed with "useArboristUI": true, needs Arborist's GET /auth/mapping endpoint to be exposed via revproxy. (useArboristUI false by default)