### PR TITLE
fix/don't shrink if only using jupyterhub

### DIFF
--- a/src/Workspace/index.jsx
+++ b/src/Workspace/index.jsx
@@ -272,7 +272,7 @@ class Workspace extends React.Component {
         <iframe
           title='Workspace'
           frameBorder='0'
-          className='workspace'
+          className='workspace__container'
           src={workspaceUrl}
         />
       );


### PR DESCRIPTION
Fixed a bug that is causing workspace to shrink if not using hatchery

### New Features


### Breaking Changes


### Bug Fixes
- Fixed a bug that is causing workspace to shrink if not using hatchery

### Improvements


### Dependency updates


### Deployment changes

