### PR TITLE
Fix(jenkins): Revert change to classname on workspaces page

### DIFF
--- a/src/Workspace/Workspace.less
+++ b/src/Workspace/Workspace.less
@@ -1,4 +1,4 @@
-.workspace__container {
+.workspace {
   width: 100%;
   min-height: inherit;
   display: flex;
@@ -9,12 +9,12 @@
 // Add a left/right margin to workspace on large screens,
 // unless the workspace is full-paged.
 @media screen and (min-width: 1291px) {
-  .workspace__container:not(.workspace__container--fullpage) {
+  .workspace:not(.workspace--fullpage) {
     padding: 0 20px;
   }
 }
 
-.workspace__container--fullpage {
+.workspace--fullpage {
   position: fixed;
   top: 0;
   bottom: 0;
@@ -25,7 +25,7 @@
   overflow: hidden;
 }
 
-.workspace {
+.workspace__iframe {
   flex: 1 0 60vh;
   display: flex;
   flex-direction: column;
@@ -44,11 +44,6 @@
   display: flex;
   justify-content: center;
   align-items: center;
-}
-
-.workspace__iframe iframe {
-  height: 100%;
-  width: 100%;
 }
 
 .workspace__options {

--- a/src/Workspace/index.jsx
+++ b/src/Workspace/index.jsx
@@ -199,14 +199,14 @@ class Workspace extends React.Component {
     if (this.state.connectedStatus && this.state.notebookStatus && !this.state.defaultNotebook) {
       return (
         <div
-          className={`workspace__container ${this.state.notebookIsfullpage ? 'workspace__container--fullpage' : ''}`}
+          className={`workspace ${this.state.notebookIsfullpage ? 'workspace--fullpage' : ''}`}
         >
           {
             this.state.notebookStatus === 'Running' ||
               this.state.notebookStatus === 'Stopped' ?
               <React.Fragment>
                 <iframe
-                  className='workspace'
+                  className='workspace__iframe'
                   title='Workspace'
                   frameBorder='0'
                   src={`${workspaceUrl}proxy/`}
@@ -221,7 +221,7 @@ class Workspace extends React.Component {
           {
             this.state.notebookStatus === 'Launching' ?
               <React.Fragment>
-                <div className='workspace'>
+                <div className='workspace__iframe'>
                   <Spinner text='Launching workspace...' />
                 </div>
                 <div className='workspace__buttongroup'>
@@ -272,7 +272,7 @@ class Workspace extends React.Component {
         <iframe
           title='Workspace'
           frameBorder='0'
-          className='workspace__container'
+          className='workspace'
           src={workspaceUrl}
         />
       );


### PR DESCRIPTION
**Bug Fixes**

Jenkins `exportToWorkspace` test looks for an element on the page with
the 'workspace' classname. A previous commit (3fc783d8h) changed this classname, causing
Jenkins tests to fail -- this commit reverts the classname change, preventing further issues
with Jenkins tests.


