### PR TITLE
PXP-4445 fix(bar-chart): Add right margin to make last tick visible

### DIFF
--- a/src/components/charts/IndexBarChart/index.jsx
+++ b/src/components/charts/IndexBarChart/index.jsx
@@ -173,8 +173,8 @@ IndexBarChart.defaultProps = {
   barChartStyle: {
     margins: {
       top: 20,
-      right: 0,
-      left: 250,
+      right: 20,
+      left: 230,
       bottom: 5,
     },
     layout: 'vertical',


### PR DESCRIPTION
This feels like a hacky solution (why is content spilling into margin?) but seems to be the [recharts-endorsed](http://recharts.org/en-US/guide/getting-started) way to do this (see 3). 

### Bug Fixes
Add right margin (and reduce left) to index-bar-chart to make last x-axis tick (100%) visible. 


