### PR TITLE
Fix(jenkins-tests): Revert changes causing workspace tests to fail

### DIFF
--- a/src/Workspace/Workspace.less
+++ b/src/Workspace/Workspace.less
@@ -1,4 +1,4 @@
-.workspace__container {
+div.workspace, div.workspace__default {
   width: 100%;
   min-height: inherit;
   display: flex;
@@ -9,12 +9,12 @@
 // Add a left/right margin to workspace on large screens,
 // unless the workspace is full-paged.
 @media screen and (min-width: 1291px) {
-  .workspace__container:not(.workspace__container--fullpage) {
+  div.workspace:not(.workspace--fullpage) {
     padding: 0 20px;
   }
 }
 
-.workspace__container--fullpage {
+div.workspace--fullpage {
   position: fixed;
   top: 0;
   bottom: 0;
@@ -25,7 +25,7 @@
   overflow: hidden;
 }
 
-.workspace {
+.workspace__iframe {
   flex: 1 0 60vh;
   display: flex;
   flex-direction: column;
@@ -47,7 +47,7 @@
 }
 
 .workspace__iframe iframe {
-  height: 100%;
+  flex: 1 0 auto;
   width: 100%;
 }
 
@@ -66,4 +66,12 @@
   background: var(--g3-color__bg-cloud);
   z-index: 1;
   text-align: center;
+}
+
+.workspace__spinner-container {
+  flex: 1 0 60vh;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
 }

--- a/src/Workspace/index.jsx
+++ b/src/Workspace/index.jsx
@@ -197,20 +197,25 @@ class Workspace extends React.Component {
     );
 
     if (this.state.connectedStatus && this.state.notebookStatus && !this.state.defaultNotebook) {
+      // NOTE both the containing element and the iframe have class '.workspace',
+      // although no styles should be shared between them. The reason for this
+      // is for backwards compatibility with Jenkins integration tests that select by classname.
       return (
         <div
-          className={`workspace__container ${this.state.notebookIsfullpage ? 'workspace__container--fullpage' : ''}`}
+          className={`workspace ${this.state.notebookIsfullpage ? 'workspace--fullpage' : ''}`}
         >
           {
             this.state.notebookStatus === 'Running' ||
               this.state.notebookStatus === 'Stopped' ?
               <React.Fragment>
-                <iframe
-                  className='workspace'
-                  title='Workspace'
-                  frameBorder='0'
-                  src={`${workspaceUrl}proxy/`}
-                />
+                <div className='workspace__iframe'>
+                  <iframe
+                    className='workspace'
+                    title='Workspace'
+                    frameBorder='0'
+                    src={`${workspaceUrl}proxy/`}
+                  />
+                </div>
                 <div className='workspace__buttongroup'>
                   { terminateButton }
                   { fullpageButton }
@@ -221,7 +226,7 @@ class Workspace extends React.Component {
           {
             this.state.notebookStatus === 'Launching' ?
               <React.Fragment>
-                <div className='workspace'>
+                <div className='workspace__spinner-container'>
                   <Spinner text='Launching workspace...' />
                 </div>
                 <div className='workspace__buttongroup'>
@@ -232,7 +237,9 @@ class Workspace extends React.Component {
           }
           {
             this.state.notebookStatus === 'Terminating' ?
-              <Spinner text='Terminating workspace...' />
+              <div className='workspace__spinner-container'>
+                <Spinner text='Terminating workspace...' />
+              </div>
               : null
           }
           {
@@ -268,13 +275,19 @@ class Workspace extends React.Component {
         </div>
       );
     } else if (this.state.defaultNotebook && this.state.connectedStatus) {
+      // If this commons does not use Hatchery to spawn workspaces, then this
+      // default workspace is shown.
       return (
-        <iframe
-          title='Workspace'
-          frameBorder='0'
-          className='workspace__container'
-          src={workspaceUrl}
-        />
+        <div className='workspace__default'>
+          <div className='workspace__iframe'>
+            <iframe
+              title='Workspace'
+              frameBorder='0'
+              className='workspace'
+              src={workspaceUrl}
+            />
+          </div>
+        </div>
       );
     }
     return <Spinner />;

--- a/src/Workspace/index.jsx
+++ b/src/Workspace/index.jsx
@@ -279,14 +279,12 @@ class Workspace extends React.Component {
       // default workspace is shown.
       return (
         <div className='workspace__default'>
-          <div className='workspace__iframe'>
-            <iframe
-              title='Workspace'
-              frameBorder='0'
-              className='workspace'
-              src={workspaceUrl}
-            />
-          </div>
+          <iframe
+            title='Workspace'
+            frameBorder='0'
+            className='workspace'
+            src={workspaceUrl}
+          />
         </div>
       );
     }


### PR DESCRIPTION
Commit [3fc783](https://github.com/uc-cdis/data-portal/commit/3fc783d83335d09e1be2c14e8e481855ea0758e9) changed or removed many of classnames depended on by Jenkins integration tests, causing the integration tests to fail. Changing the Jenkins tests themselves is complex due to backwards compatibility requirements (Jenkins tests must still support older versions of the portal), so this commit reverts the classname changes while keeping the fullscreen workspace feature.

Details: The Jenkins @exportToWorkspaceHatchery and @exportToWorkspaceJupyterhub integration tests use classnames of specific elements on the Workspaces page. Specifically, the @exportToWorkspaceHatchery tests expect an element with classname '.workspace' to be on the /workspaces page before a workspace is spawned, and expect an iframe element with classname '.workspace' to appear in a containing element with classname '.workspace__iframe' after a workspace is spawned. The @exportToWorkspaceJupyterHub tests expect an iframe with classname '.workspace' to appear after a workspace is spawned.
  

### Bug Fixes

- Revert changes to classnames made by commit [3fc783](https://github.com/uc-cdis/data-portal/commit/3fc783d83335d09e1be2c14e8e481855ea0758e9)
  to pass Jenkins tests
- Alter the fix for fullscreen workspaces made in commit [d0fc46](https://github.com/uc-cdis/data-portal/commit/d0fc466cd09262fde6798777b0389aad4f445544)
  to pass Jenkins tests


