### PR TITLE
PXP-4372 Fix/file size

### DIFF
--- a/src/GuppyDataExplorer/ExplorerTable/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerTable/index.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import ReactTable from 'react-table';
 import 'react-table/react-table.css';
 import { GuppyConfigType, TableConfigType } from '../configTypeDef';
-import { capitalizeFirstLetter } from '../../utils';
+import { capitalizeFirstLetter, humanFileSize } from '../../utils';
 import './ExplorerTable.css';
 import LockIcon from '../../img/icons/lock.svg';
 
@@ -71,9 +71,16 @@ class ExplorerTable extends React.Component {
         accessor: field,
         maxWidth: 400,
         width: this.getWidthForColumn(field, name),
-        Cell: row => (this.props.guppyConfig.downloadAccessor === field ?
-          <div><span title={row.value}><a href={`/files/${row.value}`}>{row.value}</a></span></div>
-          : <div><span title={row.value}>{row.value}</span></div>),
+        Cell: (row) => {
+          switch (field) {
+          case this.props.guppyConfig.downloadAccessor:
+            return (<div><span title={row.value}><a href={`/files/${row.value}`}>{row.value}</a></span></div>);
+          case 'file_size':
+            return (<div><span title={row.value}>{humanFileSize(row.value)}</span></div>);
+          default:
+            return (<div><span title={row.value}>{row.value}</span></div>);
+          }
+        },
       };
     });
     const { totalCount } = this.props;

--- a/src/utils.js
+++ b/src/utils.js
@@ -3,6 +3,9 @@ import * as d3 from 'd3-scale';
 import { submissionApiPath } from './localconf';
 
 export const humanFileSize = (size) => {
+  if (typeof size !== 'number') {
+    return '';
+  }
   const i = size === 0 ? 0 : Math.floor(Math.log(size) / Math.log(1024));
   const sizeStr = (size / (1024 ** i)).toFixed(2) * 1;
   const suffix = ['B', 'KB', 'MB', 'GB', 'TB'][i];


### PR DESCRIPTION
This PR fullfills https://ctds-planx.atlassian.net/browse/PXP-4372

The Guppy file explorer page now can display human-readable file sizes
In order to handle large file size, Guppy 0.3.7+ is needed

Deployed in https://qa-brain.planx-pla.net

### New Features


### Breaking Changes


### Bug Fixes


### Improvements
- Display human-readable file sizes in file explorer page

### Dependency updates


### Deployment changes
- Need Guppy 0.3.7+ to handle large file size
