### PR TITLE
Fix/permissions PXP-4524

### DIFF
--- a/data/config/default.json
+++ b/data/config/default.json
@@ -285,7 +285,6 @@
     }
   },
   "useArboristUI": false,
-  "useArboristAuthz": false,
   "showArboristAuthzOnProfile": false,
   "showFenceAuthzOnProfile": true,
   "componentToResourceMapping": {}

--- a/data/config/default.json
+++ b/data/config/default.json
@@ -285,5 +285,8 @@
     }
   },
   "useArboristUI": false,
+  "useArboristAuthz": false,
+  "showArboristAuthzOnProfile": false,
+  "showFenceAuthzOnProfile": true,
   "componentToResourceMapping": {}
 }

--- a/src/CoreMetadata/CoreMetadataHeader.jsx
+++ b/src/CoreMetadata/CoreMetadataHeader.jsx
@@ -44,12 +44,12 @@ class CoreMetadataHeader extends Component {
 
   render() {
     if (this.props.metadata) {
-      // display the download button if the user can download this file
       const { projectAvail } = this.props;
       const projectId = this.props.metadata.project_id;
       let downloadButton = null;
       let signedURLButton = null;
 
+      // downloadButton should always render if useArboristUI false. Otherwise according to authz.
       if (
         !useArboristUI
         || userHasMethodOnProject('read-storage', projectId, this.props.userAuthMapping)

--- a/src/CoreMetadata/CoreMetadataHeader.jsx
+++ b/src/CoreMetadata/CoreMetadataHeader.jsx
@@ -3,8 +3,10 @@ import PropTypes from 'prop-types';
 import copy from 'clipboard-plus';
 import React, { Component } from 'react';
 import Popup from '../components/Popup';
-import { userapiPath } from '../configs';
+import { userapiPath, useArboristUI } from '../configs';
 import isEnabled from '../helpers/featureFlags';
+
+import { userHasMethodOnProject } from '../authMappingUtils';
 
 const DOWNLOAD_BTN_CAPTION = 'Download';
 const SIGNED_URL_BTN_CAPTION = 'Generate Signed URL';
@@ -24,28 +26,8 @@ function fileSizeTransform(size) {
   return `${sizeStr} ${suffix}`;
 }
 
-function canUserDownload(user, projectAvail, projectID) {
-  const parts = projectID.split('-');
-  const program = parts[0];
-  parts.shift();
-  const project = parts.join('-');
-  let hasAccess = false;
-  if (projectID in projectAvail) {
-    if (projectAvail[projectID] === 'Open') {
-      hasAccess = true;
-    }
-  }
-  if ('project_access' in user && program in user.project_access) {
-    if (user.project_access[program].includes('read-storage')) {
-      hasAccess = true;
-    }
-  }
-  if ('project_access' in user && project in user.project_access) {
-    if (user.project_access[project].includes('read-storage')) {
-      hasAccess = true;
-    }
-  }
-  return hasAccess;
+function projectIsOpenData(projectAvail, projectID) {
+  return (projectID in projectAvail && projectAvail[projectID] === 'Open');
 }
 
 class CoreMetadataHeader extends Component {
@@ -63,12 +45,16 @@ class CoreMetadataHeader extends Component {
   render() {
     if (this.props.metadata) {
       // display the download button if the user can download this file
-      const { user, projectAvail } = this.props;
+      const { projectAvail } = this.props;
       const projectId = this.props.metadata.project_id;
-      const canDownload = canUserDownload(user, projectAvail, projectId);
       let downloadButton = null;
       let signedURLButton = null;
-      if (canDownload) {
+
+      if (
+        !useArboristUI
+        || userHasMethodOnProject('read-storage', projectId, this.props.userAuthMapping)
+        || projectIsOpenData(projectAvail, projectId)
+      ) {
         const downloadLink = `${userapiPath}/data/download/${this.props.metadata.object_id}?expires_in=900&redirect`;
 
         downloadButton = (
@@ -150,8 +136,8 @@ CoreMetadataHeader.propTypes = {
   signedURL: PropTypes.string,
   signedURLPopup: PropTypes.bool,
   error: PropTypes.string,
-  user: PropTypes.object.isRequired,
   projectAvail: PropTypes.object.isRequired,
+  userAuthMapping: PropTypes.object.isRequired,
   onGenerateSignedURL: PropTypes.func.isRequired,
   onUpdatePopup: PropTypes.func.isRequired,
   onClearSignedURL: PropTypes.func.isRequired,

--- a/src/CoreMetadata/reduxer.js
+++ b/src/CoreMetadata/reduxer.js
@@ -63,7 +63,7 @@ export const ReduxCoreMetadataHeader = (() => {
     signedURL: state.coreMetadata.url,
     signedURLPopup: state.popups.signedURLPopup,
     error: state.coreMetadata.error,
-    user: state.user,
+    userAuthMapping: state.userAuthMapping,
     projectAvail: state.submission.projectAvail,
   });
 

--- a/src/UserProfile/ReduxUserProfile.js
+++ b/src/UserProfile/ReduxUserProfile.js
@@ -113,6 +113,7 @@ const clearCreationSession = () => ({
 const mapStateToProps = state => ({
   user: state.user,
   userProfile: state.userProfile,
+  userAuthMapping: state.userAuthMapping,
   popups: state.popups,
   submission: state.submission,
 });

--- a/src/UserProfile/UserProfile.jsx
+++ b/src/UserProfile/UserProfile.jsx
@@ -8,7 +8,7 @@ import Popup from '../components/Popup';
 import { credentialCdisPath } from '../localconf';
 import KeyTable from '../components/tables/KeyTable';
 import AccessTable from '../components/tables/AccessTable';
-import { useArboristAuthz, showArboristAuthzOnProfile, showFenceAuthzOnProfile } from '../configs';
+import { showArboristAuthzOnProfile, showFenceAuthzOnProfile } from '../configs';
 import './UserProfile.less';
 
 const NO_ACCESS_MSG = 'You have no access to storage service. Please contact an admin to get it!';
@@ -142,7 +142,7 @@ const UserProfile = ({ user, userProfile, userAuthMapping, popups, submission, o
         <AccessTable projects={submission.projects} projectsAccesses={user.project_access} />
       }
       {
-        useArboristAuthz && showArboristAuthzOnProfile &&
+        showArboristAuthzOnProfile &&
         <AccessTable projects={submission.projects} userAuthMapping={userAuthMapping} />
       }
     </div>

--- a/src/UserProfile/UserProfile.jsx
+++ b/src/UserProfile/UserProfile.jsx
@@ -8,6 +8,7 @@ import Popup from '../components/Popup';
 import { credentialCdisPath } from '../localconf';
 import KeyTable from '../components/tables/KeyTable';
 import AccessTable from '../components/tables/AccessTable';
+import { useArboristAuthz, showArboristAuthzOnProfile, showFenceAuthzOnProfile } from '../configs';
 import './UserProfile.less';
 
 const NO_ACCESS_MSG = 'You have no access to storage service. Please contact an admin to get it!';
@@ -21,7 +22,7 @@ export const saveToFile = (savingStr, filename) => {
   FileSaver.saveAs(blob, filename);
 };
 
-const UserProfile = ({ user, userProfile, popups, submission, onCreateKey,
+const UserProfile = ({ user, userProfile, userAuthMapping, popups, submission, onCreateKey,
   onClearCreationSession, onUpdatePopup, onDeleteKey,
   onRequestDeleteKey, onClearDeleteSession }) => {
   const onCreate = () => {
@@ -136,7 +137,14 @@ const UserProfile = ({ user, userProfile, popups, submission, onCreateKey,
           }
         </ul>
       }
-      <AccessTable projects={submission.projects} projectsAccesses={user.project_access} />
+      {
+        showFenceAuthzOnProfile &&
+        <AccessTable projects={submission.projects} projectsAccesses={user.project_access} />
+      }
+      {
+        useArboristAuthz && showArboristAuthzOnProfile &&
+        <AccessTable projects={submission.projects} userAuthMapping={userAuthMapping} />
+      }
     </div>
   );
 };
@@ -144,6 +152,7 @@ const UserProfile = ({ user, userProfile, popups, submission, onCreateKey,
 UserProfile.propTypes = {
   user: PropTypes.object.isRequired,
   userProfile: PropTypes.object.isRequired,
+  userAuthMapping: PropTypes.object.isRequired,
   popups: PropTypes.object.isRequired,
   submission: PropTypes.object,
   onClearCreationSession: PropTypes.func.isRequired,

--- a/src/actions.js
+++ b/src/actions.js
@@ -457,7 +457,7 @@ export const fetchUserAccess = async (dispatch) => {
 
 // asks arborist for the user's auth mapping if Arborist UI enabled
 export const fetchUserAuthMapping = async (dispatch) => {
-  if (!config.useArboristUI) {
+  if (!config.useArboristAuthz && !config.useArboristUI) {
     return;
   }
 

--- a/src/actions.js
+++ b/src/actions.js
@@ -457,7 +457,7 @@ export const fetchUserAccess = async (dispatch) => {
 
 // asks arborist for the user's auth mapping if Arborist UI enabled
 export const fetchUserAuthMapping = async (dispatch) => {
-  if (!config.useArboristAuthz && !config.useArboristUI) {
+  if (!config.showArboristAuthzOnProfile && !config.useArboristUI) {
     return;
   }
 

--- a/src/authMappingUtils.js
+++ b/src/authMappingUtils.js
@@ -13,6 +13,24 @@ const resourcePathFromProjectID = (projectID) => {
 };
 
 
+export const projectCodeFromResourcePath = (resourcePath) => {
+  // If resourcePath is anything other than /programs/foo/projects/bar[/morestuff],
+  // e.g. /gen3/programs/foo/projects/bar or /workspace or /programs/foo/bar/projects/baz,
+  // this will just return ''
+  // because concept of projectID/project code for peregrine/sheepdog incompatible with those cases.
+  // Otherwise, returns project code (not project ID i.e. name-code!).
+  const split = resourcePath.split('/');
+  return (split.length < 5 || split[1] !== 'programs' || split[3] !== 'projects') ? '' : split[4];
+};
+
+
+export const listifyMethodsFromMapping = (actions) => {
+  // actions is an array of objects { 'service': x, 'method': y }
+  const reducer = (accumulator, currval) => accumulator.concat([currval.method]);
+  return actions.reduce(reducer, []);
+};
+
+
 export const userHasDataUpload = (userAuthMapping = {}) => {
   // data_upload policy is resource data_file, method file_upload, service fence
   const actionIsFileUpload = x => x.method === 'file_upload' && x.service === 'fence';

--- a/src/components/tables/AccessTable.jsx
+++ b/src/components/tables/AccessTable.jsx
@@ -20,10 +20,10 @@ class AccessTable extends React.Component {
   getDataFenceProjectAccess = (projectsAccesses, projects) =>
     Object.keys(projectsAccesses).map(p => [
       p in projects ?
-        <Link className='access-table__project-cell' to={`/${projects[p]}`}>
+        <Link to={`/${projects[p]}`}>
           {p}
         </Link> :
-        <div className='access-table__project-cell'>
+        <div>
           {p}
         </div>,
       projectsAccesses[p].join(', '),
@@ -34,10 +34,10 @@ class AccessTable extends React.Component {
       const projCode = projectCodeFromResourcePath(r); // will be project code or ''
       return [
         projCode in projects ?
-          <Link className='access-table__project-cell' to={`/${projects[projCode]}`}>
+          <Link to={`/${projects[projCode]}`}>
             {r}
           </Link> :
-          <div className='access-table__project-cell'>
+          <div>
             {r}
           </div>,
         listifyMethodsFromMapping(userAuthMapping[r]).join(', '),

--- a/src/components/tables/AccessTable.less
+++ b/src/components/tables/AccessTable.less
@@ -1,9 +1,5 @@
 .access-table .base-table__cell,
 .access-table .base-table__column-head {
   text-align: left;
-}
-
-.access-table__project-cell {
-  display: inline-block;
-  width: 30%;
+  width: 50%;
 }

--- a/src/localconf.js
+++ b/src/localconf.js
@@ -103,11 +103,6 @@ function buildConfig(opts) {
     useGuppyForExplorer = true;
   }
 
-  let useArboristAuthz = false;
-  if (config.useArboristAuthz) {
-    useArboristAuthz = config.useArboristAuthz;
-  }
-
   let showArboristAuthzOnProfile = false;
   if (config.showArboristAuthzOnProfile) {
     showArboristAuthzOnProfile = config.showArboristAuthzOnProfile;
@@ -282,7 +277,6 @@ function buildConfig(opts) {
     manifestServiceApiPath,
     wtsPath,
     useGuppyForExplorer,
-    useArboristAuthz,
     showArboristAuthzOnProfile,
     showFenceAuthzOnProfile,
     useArboristUI,

--- a/src/localconf.js
+++ b/src/localconf.js
@@ -103,6 +103,11 @@ function buildConfig(opts) {
     useGuppyForExplorer = true;
   }
 
+  let useArboristAuthz = false;
+  if (config.useArboristAuthz) {
+    useArboristAuthz = config.useArboristAuthz;
+  }
+
   let useArboristUI = false;
   if (config.useArboristUI) {
     useArboristUI = config.useArboristUI;
@@ -267,6 +272,7 @@ function buildConfig(opts) {
     manifestServiceApiPath,
     wtsPath,
     useGuppyForExplorer,
+    useArboristAuthz,
     useArboristUI,
     analysisApps,
     tierAccessLevel,

--- a/src/localconf.js
+++ b/src/localconf.js
@@ -108,6 +108,16 @@ function buildConfig(opts) {
     useArboristAuthz = config.useArboristAuthz;
   }
 
+  let showArboristAuthzOnProfile = false;
+  if (config.showArboristAuthzOnProfile) {
+    showArboristAuthzOnProfile = config.showArboristAuthzOnProfile;
+  }
+
+  let showFenceAuthzOnProfile = false;
+  if (config.showFenceAuthzOnProfile) {
+    showFenceAuthzOnProfile = config.showFenceAuthzOnProfile;
+  }
+
   let useArboristUI = false;
   if (config.useArboristUI) {
     useArboristUI = config.useArboristUI;
@@ -273,6 +283,8 @@ function buildConfig(opts) {
     wtsPath,
     useGuppyForExplorer,
     useArboristAuthz,
+    showArboristAuthzOnProfile,
+    showFenceAuthzOnProfile,
     useArboristUI,
     analysisApps,
     tierAccessLevel,


### PR DESCRIPTION
This PR makes the profile page show authz info from fence or arborist or both or neither, depending on the config. Additionally it fixes the file page's download button. See details below. 

For download button, here is why we are throwing out the Fence authz checks: 
1. They appear to have been ad hoc in the first place 
2. They are broken in some cases in commons using centralized auth, whenever fence's userinfo project_access is no longer in sync with Arborist authz (e.g. synapse). 
3. To fall back on the Fence checks if no centralized auth would have required a third new "useArboristAuthz" config var and there was already pushback from the team against more config 
4. We are transitioning to centralized auth anyway

### New Features
- add config vars showArboristAuthzOnProfile and showFenceAuthzOnProfile
- make profile page show authz info from fence/arborist/both/neither based on configs 
- make file page 'download' button toggle according to arborist authz

### Breaking Changes
- file page 'download' button will always render if useArboristUI is false (it no longer respects Fence authz). If useArboristUI is true, it will render if user has read-storage. Previously, it checked user.project_access (from Fence userinfo) and rendered if user had read-storage. 


