### PR TITLE
fix(profile-default): default to showing fence project access on profile

### DIFF
--- a/src/localconf.js
+++ b/src/localconf.js
@@ -108,7 +108,7 @@ function buildConfig(opts) {
     showArboristAuthzOnProfile = config.showArboristAuthzOnProfile;
   }
 
-  let showFenceAuthzOnProfile = false;
+  let showFenceAuthzOnProfile = true;
   if (config.showFenceAuthzOnProfile) {
     showFenceAuthzOnProfile = config.showFenceAuthzOnProfile;
   }


### PR DESCRIPTION
default to showing fence project access on profile if nothing is configured (this is the old behavior) 

related to (amends) (but not in the git sense) https://github.com/uc-cdis/data-portal/pull/610 