### PR TITLE
Fix(PXP-3968): Fix explorer download button not disabled

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1685,8 +1685,8 @@
       }
     },
     "@gen3/guppy": {
-      "version": "github:uc-cdis/guppy#49b5fd4c79bf3280f65855bc6830e9acc0515418",
-      "from": "github:uc-cdis/guppy#fix/pxp-3968",
+      "version": "0.3.11",
+      "resolved": "github:uc-cdis/guppy#49b5fd4c79bf3280f65855bc6830e9acc0515418",
       "requires": {
         "@elastic/elasticsearch": "^7.0.0-rc.1",
         "@gen3/ui-component": "0.3.10",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1685,12 +1685,11 @@
       }
     },
     "@gen3/guppy": {
-      "version": "0.3.9",
-      "resolved": "https://registry.npmjs.org/@gen3/guppy/-/guppy-0.3.9.tgz",
-      "integrity": "sha512-qlI8yhsxIIETwC3/lqCN0RBL11nUxKJeME7FlKmHIRKFW/eEbml0U36WZHFuAa2irccIg6QEcHafYl07hVdn6A==",
+      "version": "github:uc-cdis/guppy#49b5fd4c79bf3280f65855bc6830e9acc0515418",
+      "from": "github:uc-cdis/guppy#fix/pxp-3968",
       "requires": {
         "@elastic/elasticsearch": "^7.0.0-rc.1",
-        "@gen3/ui-component": "0.3.7",
+        "@gen3/ui-component": "0.3.10",
         "apollo-server": "^2.4.8",
         "apollo-server-express": "^2.4.8",
         "body-parser": "^1.18.3",
@@ -1710,24 +1709,6 @@
         "react": "^16.8.4"
       },
       "dependencies": {
-        "@gen3/ui-component": {
-          "version": "0.3.7",
-          "resolved": "https://registry.npmjs.org/@gen3/ui-component/-/ui-component-0.3.7.tgz",
-          "integrity": "sha512-HGVPrpENeuJ7IZki/0fTXEauKMUBqAkgQB+HkiRwsm+iiQU5WL4FFuL80rP6LLuYkYmcQ93+t5UhhMs/m2s8Nw==",
-          "requires": {
-            "babel-loader": "^8.0.5",
-            "postcss-loader": "^3.0.0",
-            "postcss-svgo": "^4.0.2",
-            "prop-types": "^15.7.2",
-            "rc-slider": "^8.6.6",
-            "rc-tooltip": "^3.7.3",
-            "react": "^16.8.4",
-            "react-dom": "^16.8.4",
-            "react-router-dom": "^4.3.1",
-            "recharts": "^1.5.0",
-            "stylelint": "^9.10.1"
-          }
-        },
         "file-saver": {
           "version": "2.0.2",
           "resolved": "https://registry.npmjs.org/file-saver/-/file-saver-2.0.2.tgz",
@@ -4415,9 +4396,9 @@
       },
       "dependencies": {
         "core-js": {
-          "version": "3.3.2",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.3.2.tgz",
-          "integrity": "sha512-S1FfZpeBchkhyoY76YAdFzKS4zz9aOK7EeFaNA2aJlyXyA+sgqz6xdxmLPGXEAf0nF44MVN1kSjrA9Kt3ATDQg=="
+          "version": "3.3.5",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.3.5.tgz",
+          "integrity": "sha512-0J3K+Par/ZydhKg8pEiTcK/9d65/nqJOzY62uMkjeBmt05fDOt/khUVjDdh8TpeIuGQDy1yLDDCjiWN/8pFIuw=="
         },
         "node-fetch": {
           "version": "2.6.0",
@@ -4447,12 +4428,12 @@
       }
     },
     "apollo-server": {
-      "version": "2.9.6",
-      "resolved": "https://registry.npmjs.org/apollo-server/-/apollo-server-2.9.6.tgz",
-      "integrity": "sha512-sDvrGpMQsTGQ9FTkFm3xracrSUi8nFoh3svlD98pe6qb75UDDrXAZgxwQCSOwZ3BkaJ7UkdndfhnruhFstTeMw==",
+      "version": "2.9.7",
+      "resolved": "https://registry.npmjs.org/apollo-server/-/apollo-server-2.9.7.tgz",
+      "integrity": "sha512-maGGCsK4Ft5ucox5ZJf6oaKhgPvzHY3jXWbA1F/mn0/EYX8e1RVO3Qtj8aQQ0/vCKx8r4vYgj+ctqBVaN/nr4A==",
       "requires": {
-        "apollo-server-core": "^2.9.6",
-        "apollo-server-express": "^2.9.6",
+        "apollo-server-core": "^2.9.7",
+        "apollo-server-express": "^2.9.7",
         "express": "^4.0.0",
         "graphql-subscriptions": "^1.0.0",
         "graphql-tools": "^4.0.0"
@@ -4467,9 +4448,9 @@
       }
     },
     "apollo-server-core": {
-      "version": "2.9.6",
-      "resolved": "https://registry.npmjs.org/apollo-server-core/-/apollo-server-core-2.9.6.tgz",
-      "integrity": "sha512-2tHAWQxP7HrETI/BZvg2fem6YlahF9HUp4Y6SSL95WP3uNMOJBlN12yM1y+O2u5K5e4jwdPNaLjoL2A/26XrLw==",
+      "version": "2.9.7",
+      "resolved": "https://registry.npmjs.org/apollo-server-core/-/apollo-server-core-2.9.7.tgz",
+      "integrity": "sha512-EqKyROy+21sM93YHjGpy6wlnzK/vH0fnZh7RCf3uB69aQ3OjgdP4AQ5oWRQ62NDN+aoic7OLhChSDJeDonq/NQ==",
       "requires": {
         "@apollographql/apollo-tools": "^0.4.0",
         "@apollographql/graphql-playground-html": "1.6.24",
@@ -4480,7 +4461,7 @@
         "apollo-engine-reporting": "^1.4.7",
         "apollo-server-caching": "^0.5.0",
         "apollo-server-env": "^2.4.3",
-        "apollo-server-errors": "^2.3.3",
+        "apollo-server-errors": "^2.3.4",
         "apollo-server-plugin-base": "^0.6.5",
         "apollo-server-types": "^0.2.5",
         "apollo-tracing": "^0.8.5",
@@ -4511,14 +4492,14 @@
       }
     },
     "apollo-server-errors": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/apollo-server-errors/-/apollo-server-errors-2.3.3.tgz",
-      "integrity": "sha512-MO4oJ129vuCcbqwr5ZwgxqGGiLz3hCyowz0bstUF7MR+vNGe4oe3DWajC9lv4CxrhcqUHQOeOPViOdIo1IxE3g=="
+      "version": "2.3.4",
+      "resolved": "https://registry.npmjs.org/apollo-server-errors/-/apollo-server-errors-2.3.4.tgz",
+      "integrity": "sha512-Y0PKQvkrb2Kd18d1NPlHdSqmlr8TgqJ7JQcNIfhNDgdb45CnqZlxL1abuIRhr8tiw8OhVOcFxz2KyglBi8TKdA=="
     },
     "apollo-server-express": {
-      "version": "2.9.6",
-      "resolved": "https://registry.npmjs.org/apollo-server-express/-/apollo-server-express-2.9.6.tgz",
-      "integrity": "sha512-j80azBeXvLvyZsbqCnus7GH+w8vk+2IOnYzROZu/f0D2roDZtsu1XZkn+aplDJZXMcEXtqB6t4qNpyvV4zY0XQ==",
+      "version": "2.9.7",
+      "resolved": "https://registry.npmjs.org/apollo-server-express/-/apollo-server-express-2.9.7.tgz",
+      "integrity": "sha512-+DuJk1oq34Zx0bLYzgBgJH/eXS0JNxw2JycHQvV0+PAQ0Qi01oomJRA2r1S5isnfnSAnHb2E9jyBTptoHdw3MQ==",
       "requires": {
         "@apollographql/graphql-playground-html": "1.6.24",
         "@types/accepts": "^1.3.5",
@@ -4526,7 +4507,7 @@
         "@types/cors": "^2.8.4",
         "@types/express": "4.17.1",
         "accepts": "^1.3.5",
-        "apollo-server-core": "^2.9.6",
+        "apollo-server-core": "^2.9.7",
         "apollo-server-types": "^0.2.5",
         "body-parser": "^1.18.3",
         "cors": "^2.8.4",
@@ -12019,9 +12000,9 @@
       "integrity": "sha512-jApXqWBzNXQ8jYa/HLkZJaVw9jgwNqZkywa2zfFn16Iv1Zb7ELNHkJaXHR7Quvd5SIGsy6Ny7SUKATgnu05uEg=="
     },
     "graphql-tools": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/graphql-tools/-/graphql-tools-4.0.5.tgz",
-      "integrity": "sha512-kQCh3IZsMqquDx7zfIGWBau42xe46gmqabwYkpPlCLIjcEY1XK+auP7iGRD9/205BPyoQdY8hT96MPpgERdC9Q==",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/graphql-tools/-/graphql-tools-4.0.6.tgz",
+      "integrity": "sha512-jHLQw8x3xmSNRBCsaZqelXXsFfUSUSktSCUP8KYHiX1Z9qEuwcMpAf+FkdBzk8aTAFqOlPdNZ3OI4DKKqGKUqg==",
       "requires": {
         "apollo-link": "^1.2.3",
         "apollo-utilities": "^1.0.1",
@@ -22101,9 +22082,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "10.14.22",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.14.22.tgz",
-          "integrity": "sha512-9taxKC944BqoTVjE+UT3pQH0nHZlTvITwfsOZqyc+R3sfJuxaTtxWjfn1K2UlxyPcKHf0rnaXcVFrS9F9vf0bw=="
+          "version": "10.17.2",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.2.tgz",
+          "integrity": "sha512-sAh60KDol+MpwOr1RTK0+HgBEYejKsxdpmrOS1Wts5bI03dLzq8F7T0sRXDKeaEK8iWDlGfdzxrzg6vx/c5pNA=="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "@fortawesome/fontawesome-svg-core": "^1.2.2",
     "@fortawesome/free-solid-svg-icons": "^5.2.0",
     "@fortawesome/react-fontawesome": "^0.1.0",
-    "@gen3/guppy": "^0.3.9",
+    "@gen3/guppy": "^0.3.11",
     "@gen3/ui-component": "0.3.10",
     "@storybook/addon-actions": "^5.0.0",
     "@storybook/react": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "@fortawesome/fontawesome-svg-core": "^1.2.2",
     "@fortawesome/free-solid-svg-icons": "^5.2.0",
     "@fortawesome/react-fontawesome": "^0.1.0",
-    "@gen3/guppy": "^0.3.11",
+    "@gen3/guppy": "uc-cdis/guppy#fix/pxp-3968",
     "@gen3/ui-component": "0.3.10",
     "@storybook/addon-actions": "^5.0.0",
     "@storybook/react": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "@fortawesome/fontawesome-svg-core": "^1.2.2",
     "@fortawesome/free-solid-svg-icons": "^5.2.0",
     "@fortawesome/react-fontawesome": "^0.1.0",
-    "@gen3/guppy": "uc-cdis/guppy#fix/pxp-3968",
+    "@gen3/guppy": "^0.3.9",
     "@gen3/ui-component": "0.3.10",
     "@storybook/addon-actions": "^5.0.0",
     "@storybook/react": "^5.0.0",

--- a/src/GuppyDataExplorer/ExplorerFilter/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerFilter/index.jsx
@@ -117,6 +117,7 @@ class ExplorerFilter extends React.Component {
       onProcessFilterAggsData: this.onProcessFilterAggsData,
       onUpdateAccessLevel: this.props.onUpdateAccessLevel,
       adminAppliedPreFilters: this.props.adminAppliedPreFilters,
+      accessibleFieldCheckList: this.props.accessibleFieldCheckList,
     };
     let filterFragment;
     switch (this.state.selectedAccessFilter) {
@@ -177,6 +178,7 @@ ExplorerFilter.propTypes = {
   accessibleFieldObject: PropTypes.object, // inherit from GuppyWrapper
   unaccessibleFieldObject: PropTypes.object, // inherit from GuppyWrapper
   adminAppliedPreFilters: PropTypes.object, // inherit from GuppyWrapper
+  accessibleFieldCheckList: PropTypes.arrayOf(PropTypes.string), // inherit from GuppyWrapper
   getAccessButtonLink: PropTypes.string,
 };
 
@@ -192,6 +194,7 @@ ExplorerFilter.defaultProps = {
   accessibleFieldObject: {},
   unaccessibleFieldObject: {},
   adminAppliedPreFilters: {},
+  accessibleFieldCheckList: [],
   getAccessButtonLink: undefined,
 };
 


### PR DESCRIPTION
https://ctds-planx.atlassian.net/browse/PXP-3968

Bug: Sometimes, the download button in explorer (button type='data') is not disabled when viewing metadata or files the user does not have access to.
Cause: Data from guppy is validated using the 'accessibleValidationField' in the guppy config, but the 'accessibleValidationField' was not always included by default in the data requested from guppy. If the 'accessibleValidationField' was not included, the data validation check that enables/disables the 'data' button would fail and default to 'enabled.'
Fix: Always fetch 'accessibleValidationField' from guppy. This is done by always fetching the fields in 'accessibleFieldCheckList', which includes 'accessibleValidationField'.

Guppy PR for this bugfix: https://github.com/uc-cdis/guppy/pull/66

### Bug Fixes
Fix bug in Windmill explorer in which download buttons would sometimes appear to be enabled, even if users didn't have access to all data.
