### PR TITLE
fix(profile-default): fix config bug

### DIFF
--- a/src/localconf.js
+++ b/src/localconf.js
@@ -109,7 +109,7 @@ function buildConfig(opts) {
   }
 
   let showFenceAuthzOnProfile = true;
-  if (config.showFenceAuthzOnProfile) {
+  if (config.showFenceAuthzOnProfile === false) {
     showFenceAuthzOnProfile = config.showFenceAuthzOnProfile;
   }
 


### PR DESCRIPTION
Fix dumb thing that I did so that windmill will correctly default to showing Fence permissions on profile page but not show them if config.showFenceAuthzOnProfile === false 

🤦‍♂ 

### Bug Fixes
fix bug where Fence permissions incorrectly showed on profile page when config had showFenceAuthzOnProfile set to false

