### PR TITLE
Fix(PXP-3514): Correctly handle unicode file uploads

### DIFF
--- a/src/Submission/SubmitTSV.jsx
+++ b/src/Submission/SubmitTSV.jsx
@@ -23,26 +23,6 @@ const SubmitTSV = ({ project, submission, onUploadClick,
   //
   const processUpload = (event) => {
     const f = event.target.files[0];
-    if (FileReader.prototype.readAsBinaryString === undefined) {
-      FileReader.prototype.readAsBinaryString = (fileData) => {
-        let binary = '';
-        const pt = this;
-        const reader = new FileReader();
-        // listener for when all the bytes have been read
-        //  https://developer.mozilla.org/en-US/docs/Web/API/FileReader
-        reader.onload = () => {
-          const bytes = new Uint8Array(reader.result);
-          const length = bytes.byteLength;
-          for (let i = 0; i < length; i += 1) {
-            binary += String.fromCharCode(bytes[i]);
-          }
-          // pt.result  - readonly so assign content to another property
-          pt.content = binary;
-          pt.onload();
-        };
-        reader.readAsArrayBuffer(fileData);
-      };
-    }
     const reader = new FileReader();
     let fileType = f.type;
     if (f.name.endsWith('.tsv')) {
@@ -52,7 +32,7 @@ const SubmitTSV = ({ project, submission, onUploadClick,
       const data = e ? e.target.result : reader.content;
       onUploadClick(data, predictFileType(data, fileType));
     };
-    reader.readAsBinaryString(f);
+    reader.readAsText(f);
   };
 
   const resetFileBeforeUpdate = (e) => {
@@ -105,34 +85,34 @@ const SubmitTSV = ({ project, submission, onUploadClick,
         }
 
       </div>
-      { (submission.file) &&
-      <AceEditor
-        width='100%'
-        height='200px'
-        className='submit-tsv__ace-editor'
-        mode={submission.file_type === 'text/tab-separated-values' ? '' : 'json'}
-        theme='kuroir'
-        value={submission.file}
-        editorProps={{ $blockScrolling: Infinity }} // mutes console warning
-        onChange={onChange}
-        id='uploaded'
-      />
+      {(submission.file) &&
+        <AceEditor
+          width='100%'
+          height='200px'
+          className='submit-tsv__ace-editor'
+          mode={submission.file_type === 'text/tab-separated-values' ? '' : 'json'}
+          theme='kuroir'
+          value={submission.file}
+          editorProps={{ $blockScrolling: Infinity }} // mutes console warning
+          onChange={onChange}
+          id='uploaded'
+        />
       }
       {submission.submit_result &&
-      <div>
-        <p>
-          Submitting chunk {submission.submit_counter} of {submission.submit_total}
-        </p>
-        <SubmissionResult
-          status={submission.submit_status}
-          data={submission.submit_result}
-          dataString={submission.submit_result_string}
-          entityCounts={('submit_entity_counts' in submission) ? submission.submit_entity_counts : {}}
-          counter={submission.submit_counter}
-          total={submission.submit_total}
-          onFinish={onFinishSubmitEvent}
-        />
-      </div>
+        <div>
+          <p>
+            Submitting chunk {submission.submit_counter} of {submission.submit_total}
+          </p>
+          <SubmissionResult
+            status={submission.submit_status}
+            data={submission.submit_result}
+            dataString={submission.submit_result_string}
+            entityCounts={('submit_entity_counts' in submission) ? submission.submit_entity_counts : {}}
+            counter={submission.submit_counter}
+            total={submission.submit_total}
+            onFinish={onFinishSubmitEvent}
+          />
+        </div>
       }
     </form>
   );

--- a/src/Submission/SubmitTSV.test.jsx
+++ b/src/Submission/SubmitTSV.test.jsx
@@ -1,10 +1,11 @@
 import React from 'react';
 import { mount } from 'enzyme';
 import MuiThemeProvider from 'material-ui/styles/MuiThemeProvider';
+import * as testData from "./__test__/data.json"
 
 import SubmitTSV from './SubmitTSV';
 
-describe('the TSV submission componet', () => {
+describe('the TSV submission component', () => {
   const testProjName = 'bogusProject';
   /* Mutes large warning:
   * "Could not load worker TypeError:
@@ -17,15 +18,16 @@ describe('the TSV submission componet', () => {
    *
    * @param {file, submit_result, submit_status} submission property passed through to <SubmitTSV>
    * @param {function} submitCallback invoked by onSubmitClick property on <SubmitTSV>
+   * @param {function} onFileChangeCallback invoked by onFileChange property on <SubmitTSV>
    * @return enzymejs wrapper of <SubmitTSV> with properties from params
    */
-  function buildTest(submission = { file: '', submit_result: '', submit_status: 200 }, submitCallback = () => {}) {
+  function buildTest(submission = { file: '', submit_result: '', submit_status: 200 }, submitCallback = () => { }, uploadCallback = () => { }) {
     const $dom = mount(
       <MuiThemeProvider>
         <SubmitTSV
           project={testProjName}
           submission={submission}
-          onUploadClick={() => { console.log('onUpload'); }}
+          onUploadClick={(newFile, fileType) => { console.log('onUploadClick'); uploadCallback(newFile, fileType); }}
           onSubmitClick={(project) => { console.log('onSubmitClick'); submitCallback(project); }}
           onFileChange={() => { console.log('onFileChange'); }}
         />
@@ -68,5 +70,42 @@ describe('the TSV submission componet', () => {
     expect($dom.find('label[id="cd-submit-tsv__upload-button"]').length).toBe(1);
     expect($dom.find('button[id="cd-submit-tsv__submit-button"]').length).toBe(1);
     expect($dom.find('div[id="cd-submit-tsv__result"]').length).toBe(1);
+  });
+
+  it('correctly handles utf-8 files, without corrupting multi-byte special characters', (done) => {
+    expect.assertions(3);
+    // The 'testData' file contains multi-byte special characters
+    const utf8TestData = JSON.stringify(testData);
+
+    // 2. Compare the contents of the uploaded
+    // file and the file we passed in.
+    const handleUpload = (data, fileType) => {
+      try {
+        expect(fileType).toBe('application/json');
+        // Expect the uploaded file, as a string, to be the same as the test file,
+        // as a string -- ie, for the utf8 encoding to be preserved.
+        expect(data).toEqual(utf8TestData);
+      } catch (err) {
+        // We need to use done.fail(err) because otherwise the exception thrown by
+        // expect will not be caught by this test.
+        done.fail(err);
+      }
+      done();
+    };
+
+    const { $dom } = buildTest(undefined, undefined, handleUpload);
+
+    // 1. Find the file upload button and upload our JSON file with non-ascii characters.
+    // This will trigger the 'handleUpload' callback.
+    const nonAsciiJSONFile = new File([JSON.stringify(testData)], 'test.json');
+    const $input = $dom.find('input[id="file-upload"]');
+    expect($input.length).toBe(1);
+    $input.simulate('change', {
+      target: {
+        files: [
+          nonAsciiJSONFile,
+        ],
+      },
+    });
   });
 });

--- a/src/Submission/SubmitTSV.test.jsx
+++ b/src/Submission/SubmitTSV.test.jsx
@@ -18,7 +18,7 @@ describe('the TSV submission component', () => {
    *
    * @param {file, submit_result, submit_status} submission property passed through to <SubmitTSV>
    * @param {function} submitCallback invoked by onSubmitClick property on <SubmitTSV>
-   * @param {function} onFileChangeCallback invoked by onFileChange property on <SubmitTSV>
+   * @param {function} uploadCallback invoked by onUploadClick property on <SubmitTSV>
    * @return enzymejs wrapper of <SubmitTSV> with properties from params
    */
   function buildTest(submission = { file: '', submit_result: '', submit_status: 200 }, submitCallback = () => { }, uploadCallback = () => { }) {

--- a/src/Submission/__test__/data.json
+++ b/src/Submission/__test__/data.json
@@ -1,99 +1,124 @@
 {
   "records": [
     {
-      "acl": ["QA","test"],
+      "acl": [
+        "QA",
+        "test"
+      ],
       "baseid": "a388afc5-47e3",
-      "created_date":"2018-09-11T20:01:20.055349",
-      "did":"00041e7a",
-      "file_name":"File 1",
-      "form":"object",
-      "hashes":{},
-      "metadata":{},
-      "rev":"8d35",
-      "size":5,
-      "updated_date":"2018-09-11T20:01:20.055358",
-      "urls":[],
-      "urls_metadata":{},
-      "version":null
+      "created_date": "2018-09-11T20:01:20.055349",
+      "did": "00041e7a",
+      "file_name": "File 1",
+      "form": "object",
+      "hashes": {},
+      "metadata": {},
+      "rev": "8d35",
+      "size": 5,
+      "updated_date": "2018-09-11T20:01:20.055358",
+      "urls": [],
+      "urls_metadata": {},
+      "version": null
     },
     {
-      "acl":["DEV","test"],
-      "baseid":"821163158b11",
-      "created_date":"2018-09-11T20:01:20.055349",
-      "did":"0015f105-3292-8d74",
-      "file_name":"File 2",
-      "form":"object",
-      "hashes":{"md5":"6b00a"},
-      "metadata":{},
-      "rev":"6a",
-      "size":6,
-      "updated_date":"2018-08-16T21:15:40.465790",
-      "urls":[],
-      "urls_metadata":{},
-      "version":null
+      "acl": [
+        "DEV",
+        "test"
+      ],
+      "baseid": "821163158b11",
+      "created_date": "2018-09-11T20:01:20.055349",
+      "did": "0015f105-3292-8d74",
+      "file_name": "File 2",
+      "form": "object",
+      "hashes": {
+        "md5": "6b00a"
+      },
+      "metadata": {},
+      "rev": "6a",
+      "size": 6,
+      "updated_date": "2018-08-16T21:15:40.465790",
+      "urls": [],
+      "urls_metadata": {},
+      "version": null
     },
     {
-      "acl":["DEV","test"],
-      "baseid":"183f568a-7ab9",
-      "created_date":"2018-08-16T20:11:38.322176",
-      "did":"0156d02a",
-      "file_name":"File 3",
-      "form":"object",
-      "hashes":null,
-      "metadata":{},
-      "rev":"20ab",
-      "size":16,
-      "updated_date":"2018-08-16T20:11:38.322186",
-      "urls":[],
-      "urls_metadata":{},
-      "version":null
-    },{
-      "acl":["DEV","test"],
-      "baseid":"18368a-79-4ffa",
-      "created_date":"2018-08-16T20:11:38.322176",
-      "did":"a-2a58-4479567",
-      "file_name":"File 4",
-      "form":"object",
-      "hashes":{"md5":"961e"},
-      "metadata":{},
-      "rev":"20ab",
-      "size":8,
-      "updated_date":"2018-08-16T20:11:38.322186",
-      "urls":[],
-      "urls_metadata":{},
-      "version":null
+      "acl": [
+        "DEV",
+        "test"
+      ],
+      "baseid": "183f568a-7ab9",
+      "created_date": "2018-08-16T20:11:38.322176",
+      "did": "0156d02a",
+      "file_name": "File 3",
+      "form": "object",
+      "hashes": null,
+      "metadata": {},
+      "rev": "20ab",
+      "size": 16,
+      "updated_date": "2018-08-16T20:11:38.322186",
+      "urls": [],
+      "urls_metadata": {},
+      "version": null
     },
     {
-      "acl":["DEV","test"],
-      "baseid":"183f568a000",
-      "created_date":"2018-08-16T20:11:38.322176",
-      "did":"0156d02a-2a5-44798",
-      "file_name":"File 5",
-      "form":"object",
-      "hashes":null,
-      "metadata":{},
-      "rev":"20ab",
-      "size":51,
-      "updated_date":"2018-08-18T20:11:38.322186",
-      "urls":[],
-      "urls_metadata":{},
-      "version":null
+      "acl": [
+        "DEV",
+        "test"
+      ],
+      "baseid": "18368a-79-4ffa",
+      "created_date": "2018-08-16T20:11:38.322176",
+      "did": "a-2a58-4479567",
+      "file_name": "File 4",
+      "form": "object",
+      "hashes": {
+        "md5": "961e"
+      },
+      "metadata": {},
+      "rev": "20ab",
+      "size": 8,
+      "updated_date": "2018-08-16T20:11:38.322186",
+      "urls": [],
+      "urls_metadata": {},
+      "version": null
     },
     {
-      "acl":["QA","test"],
-      "baseid":"a388a5-eb87-e3",
-      "created_date":"2018-09-11T22:50:20.055349",
-      "did":"00041a-3114-4d9f00344",
-      "file_name":"File 6",
-      "form":"object",
-      "hashes":{"md5":"d8c430de73"},
-      "metadata":{},
-      "rev":"8d35",
-      "size":5,
-      "updated_date":"2018-09-11T22:50:20.055358",
-      "urls":[],
-      "urls_metadata":{},
-      "version":null
+      "acl": [
+        "DEV",
+        "test"
+      ],
+      "baseid": "183f568a000",
+      "created_date": "2018-08-16T20:11:38.322176",
+      "did": "0156d02a-2a5-44798",
+      "file_name": "File 5",
+      "form": "object",
+      "hashes": null,
+      "metadata": {},
+      "rev": "20ab",
+      "size": 51,
+      "updated_date": "2018-08-18T20:11:38.322186",
+      "urls": [],
+      "urls_metadata": {},
+      "version": null
+    },
+    {
+      "acl": [
+        "QA",
+        "test"
+      ],
+      "baseid": "a388a5-eb87-e3",
+      "created_date": "2018-09-11T22:50:20.055349",
+      "did": "00041a-3114-4d9f00344",
+      "file_name": "File 6 - With a special character: 💩",
+      "form": "object",
+      "hashes": {
+        "md5": "d8c430de73"
+      },
+      "metadata": {},
+      "rev": "8d35",
+      "size": 5,
+      "updated_date": "2018-09-11T22:50:20.055358",
+      "urls": [],
+      "urls_metadata": {},
+      "version": null
     }
   ]
 }


### PR DESCRIPTION
Jira: https://ctds-planx.atlassian.net/browse/PXP-3514

Unicode files were handled incorrectly in the 'Upload File' view of the node explorer. This was due to the uploaded files being read using FileReader.readAsBinaryString(), which does not preserve unicode encoding -- this results in non-ascii characters, like 'š', being displayed as each individual byte, like 'Å¡'. Fixed by using FileReader.readAsTextString(). (Also automatically formatted the code.)

Deployed in my dev commons at https://mpingram.planx-pla.net. Steps to test:
0. Create a .tsv file with these contents:
```
type	project_id	submitter_id	acknowledgee	projects.id#1	projects.code#1
acknowledgement	DEV-mpingram-test	Tešt2	Tešt2	d288d790-2019-592e-a067-add692828d09	mpingram-test
```
1. Click on 'Submit Data' in the top navbar
2. Click on the 'Submit Data' button for project 'DEV-mpingram-test'
3. Click 'Upload File' and upload the .tsv file.
_Old behavior:_ special characters are corrupted. _New behavior_: special characters are preserved.

### Bug Fixes
- Fixed a bug where special characters in uploaded files, such as accents or diacriticals, would not be preserved.
