### PR TITLE
PXP-4535 Fix/get access button

### DIFF
--- a/src/GuppyDataExplorer/ExplorerFilter/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerFilter/index.jsx
@@ -14,7 +14,7 @@ class ExplorerFilter extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
-      selectedAccessFilter: 'with-access', // default value of selectedAccessFilter
+      selectedAccessFilter: 'all-data', // default value of selectedAccessFilter
       showTierAccessSelector: false,
     };
   }
@@ -33,14 +33,6 @@ class ExplorerFilter extends React.Component {
         )) {
           // don't show this selector if user have full access, or none access
           this.setState({ showTierAccessSelector: false });
-          // if user don't have access to any projects
-          // apply 'all-data' filter so agg data is available
-          if (checkForNoAccessibleProject(
-            this.props.accessibleFieldObject,
-            this.props.guppyConfig.accessibleValidationField,
-          )) {
-            this.setState({ selectedAccessFilter: 'all-data' });
-          }
         } else {
           this.setState({ showTierAccessSelector: true });
         }
@@ -121,6 +113,14 @@ class ExplorerFilter extends React.Component {
       disabledTooltipMessage: this.props.tierAccessLevel === 'regular' ? `This resource is currently disabled because you are exploring restricted data. When exploring restricted data you are limited to exploring cohorts of ${this.props.tierAccessLimit} ${this.props.guppyConfig.nodeCountTitle.toLowerCase() || this.props.guppyConfig.dataType} or more.` : '',
       accessibleFieldCheckList: this.props.accessibleFieldCheckList,
     };
+    // if user don't have access to any projects
+    // apply 'all-data' filter so agg data is available
+    if (checkForNoAccessibleProject(
+      this.props.accessibleFieldObject,
+      this.props.guppyConfig.accessibleValidationField,
+    ) && this.state.selectedAccessFilter !== 'all-data') {
+      this.setState({ selectedAccessFilter: 'all-data' });
+    }
     let filterFragment;
     switch (this.state.selectedAccessFilter) {
     case 'all-data':
@@ -158,6 +158,7 @@ class ExplorerFilter extends React.Component {
             <TierAccessSelector
               onSelectorChange={this.handleAccessSelectorChange}
               getAccessButtonLink={this.props.getAccessButtonLink}
+              hideGetAccessButton={this.props.hideGetAccessButton}
             />
           ) : (<React.Fragment />)
         }
@@ -182,6 +183,7 @@ ExplorerFilter.propTypes = {
   adminAppliedPreFilters: PropTypes.object, // inherit from GuppyWrapper
   accessibleFieldCheckList: PropTypes.arrayOf(PropTypes.string), // inherit from GuppyWrapper
   getAccessButtonLink: PropTypes.string,
+  hideGetAccessButton: PropTypes.bool,
 };
 
 ExplorerFilter.defaultProps = {
@@ -198,6 +200,7 @@ ExplorerFilter.defaultProps = {
   adminAppliedPreFilters: {},
   accessibleFieldCheckList: [],
   getAccessButtonLink: undefined,
+  hideGetAccessButton: false,
 };
 
 export default ExplorerFilter;

--- a/src/GuppyDataExplorer/ExplorerFilter/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerFilter/index.jsx
@@ -14,21 +14,9 @@ class ExplorerFilter extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
-      selectedAccessFilter: 'with-access',
+      selectedAccessFilter: 'with-access', // default value of selectedAccessFilter
       showTierAccessSelector: false,
     };
-  }
-
-  static getDerivedStateFromProps(props) {
-    if (checkForNoAccessibleProject(
-      props.accessibleFieldObject,
-      props.guppyConfig.accessibleValidationField,
-    )) {
-      return {
-        selectedAccessFilter: 'all-data',
-      };
-    }
-    return null;
   }
 
   getSnapshotBeforeUpdate(prevProps) {
@@ -45,6 +33,14 @@ class ExplorerFilter extends React.Component {
         )) {
           // don't show this selector if user have full access, or none access
           this.setState({ showTierAccessSelector: false });
+          // if user don't have access to any projects
+          // apply 'all-data' filter so agg data is available
+          if (checkForNoAccessibleProject(
+            this.props.accessibleFieldObject,
+            this.props.guppyConfig.accessibleValidationField,
+          )) {
+            this.setState({ selectedAccessFilter: 'all-data' });
+          }
         } else {
           this.setState({ showTierAccessSelector: true });
         }

--- a/src/GuppyDataExplorer/ExplorerFilter/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerFilter/index.jsx
@@ -14,9 +14,21 @@ class ExplorerFilter extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
-      selectedAccessFilter: 'all-data', // default value of selectedAccessFilter
+      selectedAccessFilter: 'with-access',
       showTierAccessSelector: false,
     };
+  }
+
+  static getDerivedStateFromProps(props) {
+    if (checkForNoAccessibleProject(
+      props.accessibleFieldObject,
+      props.guppyConfig.accessibleValidationField,
+    )) {
+      return {
+        selectedAccessFilter: 'all-data',
+      };
+    }
+    return null;
   }
 
   getSnapshotBeforeUpdate(prevProps) {
@@ -113,14 +125,6 @@ class ExplorerFilter extends React.Component {
       disabledTooltipMessage: this.props.tierAccessLevel === 'regular' ? `This resource is currently disabled because you are exploring restricted data. When exploring restricted data you are limited to exploring cohorts of ${this.props.tierAccessLimit} ${this.props.guppyConfig.nodeCountTitle.toLowerCase() || this.props.guppyConfig.dataType} or more.` : '',
       accessibleFieldCheckList: this.props.accessibleFieldCheckList,
     };
-    // if user don't have access to any projects
-    // apply 'all-data' filter so agg data is available
-    if (checkForNoAccessibleProject(
-      this.props.accessibleFieldObject,
-      this.props.guppyConfig.accessibleValidationField,
-    ) && this.state.selectedAccessFilter !== 'all-data') {
-      this.setState({ selectedAccessFilter: 'all-data' });
-    }
     let filterFragment;
     switch (this.state.selectedAccessFilter) {
     case 'all-data':

--- a/src/GuppyDataExplorer/ExplorerTopMessageBanner/ExplorerTopMessageBanner.css
+++ b/src/GuppyDataExplorer/ExplorerTopMessageBanner/ExplorerTopMessageBanner.css
@@ -1,6 +1,7 @@
 .top-message-banner {
-  margin-top: 10px;
+  padding-bottom: 10px;
   display: flex;
+  border-bottom: 2px solid var(--g3-color__silver);
 }
 
 .top-message-banner__space-column {
@@ -20,7 +21,6 @@
 .top-message-banner__button{
   margin-right: 20px;
   background-color: var(--g3-color__white);
-  border-top: 1px solid var(--g3-color__silver);
   text-align: center;
   display: inline;
 }

--- a/src/GuppyDataExplorer/ExplorerTopMessageBanner/ExplorerTopMessageBanner.css
+++ b/src/GuppyDataExplorer/ExplorerTopMessageBanner/ExplorerTopMessageBanner.css
@@ -1,15 +1,26 @@
 .top-message-banner {
   margin-top: 10px;
-  margin-bottom: 10px;
-  align-content: flex-end;
-  background-color: transparent;
+  display: flex;
+}
+
+.top-message-banner__button-column {
+  width: 20%;
+  display: flex;
+  justify-content: flex-end;
+}
+
+.top-message-banner__text-column {
+  width: 80%;
+  padding-left: 20px;
+  display: flex;
+  align-items: center;
+  white-space: pre-wrap;
 }
 
 .top-message-banner__button-wrapper {
   background-color: var(--g3-color__white);
   border-top: 1px solid var(--g3-color__silver);
   text-align: center;
-  margin-right: 20px;
   display: inline;
 }
 

--- a/src/GuppyDataExplorer/ExplorerTopMessageBanner/ExplorerTopMessageBanner.css
+++ b/src/GuppyDataExplorer/ExplorerTopMessageBanner/ExplorerTopMessageBanner.css
@@ -3,7 +3,7 @@
   display: flex;
 }
 
-.top-message-banner__button-column {
+.top-message-banner__space-column {
   width: 20%;
   display: flex;
   justify-content: flex-end;
@@ -18,10 +18,16 @@
 }
 
 .top-message-banner__button-wrapper {
+  margin-right: 20px;
   background-color: var(--g3-color__white);
   border-top: 1px solid var(--g3-color__silver);
   text-align: center;
   display: inline;
+}
+
+.top-message-banner__text-wrapper {
+  flex-flow: row;
+  flex-wrap: wrap;
 }
 
 .top-message-banner__bold-text {

--- a/src/GuppyDataExplorer/ExplorerTopMessageBanner/ExplorerTopMessageBanner.css
+++ b/src/GuppyDataExplorer/ExplorerTopMessageBanner/ExplorerTopMessageBanner.css
@@ -17,7 +17,7 @@
   white-space: pre-wrap;
 }
 
-.top-message-banner__button-wrapper {
+.top-message-banner__button{
   margin-right: 20px;
   background-color: var(--g3-color__white);
   border-top: 1px solid var(--g3-color__silver);

--- a/src/GuppyDataExplorer/ExplorerTopMessageBanner/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerTopMessageBanner/index.jsx
@@ -13,7 +13,8 @@ class ExplorerTopMessageBanner extends React.Component {
         {
           (this.props.tierAccessLevel === 'regular' && checkForNoAccessibleProject(this.props.accessibleFieldObject, this.props.guppyConfig.accessibleValidationField)) ? (
             <div className='top-message-banner'>
-              <div className='top-message-banner__button-column'>
+              <div className='top-message-banner__space-column' />
+              <div className='top-message-banner__text-column'>
                 <div className='top-message-banner__button-wrapper'>
                   { (hideGetAccessButton) ? (<React.Fragment />) :
                     (
@@ -33,15 +34,15 @@ class ExplorerTopMessageBanner extends React.Component {
                     )
                   }
                 </div>
-              </div>
-              <div className='top-message-banner__text-column'>
-                <span className='top-message-banner__normal-text'>Due to lack of access, you are only able to narrow the cohort down to </span>
-                <span className='top-message-banner__bold-text'>{ this.props.tierAccessLimit } </span>
-                <span className='top-message-banner__normal-text'>
-                  {this.props.guppyConfig.nodeCountTitle.toLowerCase()
+                <div className='top-message-banner__text-wrapper'>
+                  <span className='top-message-banner__normal-text'>Due to lack of access, you are only able to narrow the cohort down to </span>
+                  <span className='top-message-banner__bold-text'>{ this.props.tierAccessLimit } </span>
+                  <span className='top-message-banner__normal-text'>
+                    {this.props.guppyConfig.nodeCountTitle.toLowerCase()
                   || this.props.guppyConfig.dataType}.
                   Please request additional access if necessary.
-                </span>
+                  </span>
+                </div>
               </div>
             </div>
           ) : (<React.Fragment />)

--- a/src/GuppyDataExplorer/ExplorerTopMessageBanner/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerTopMessageBanner/index.jsx
@@ -7,30 +7,53 @@ import { GuppyConfigType } from '../configTypeDef';
 
 class ExplorerTopMessageBanner extends React.Component {
   render() {
+    const hideGetAccessButton = this.props.hideGetAccessButton;
     return (
       <div className={this.props.className}>
         {
           (this.props.tierAccessLevel === 'regular' && checkForNoAccessibleProject(this.props.accessibleFieldObject, this.props.guppyConfig.accessibleValidationField)) ? (
             <div className='top-message-banner'>
-              <div className='top-message-banner__button-wrapper'>
-                <Button
-                  label='Get Access'
-                  className='top-message-banner__button'
-                  buttonType='default'
-                  onClick={
-                    (this.props.getAccessButtonLink) ? (
-                      () => { window.open(this.props.getAccessButtonLink); }
-                    ) : (() => {})
+              <div className='top-message-banner__button-column'>
+                <div className='top-message-banner__button-wrapper'>
+                  { (hideGetAccessButton) ? (
+                    <Button
+                      label='Get Access'
+                      className='top-message-banner__button'
+                      buttonType='default'
+                      onClick={
+                        (this.props.getAccessButtonLink) ? (
+                          () => { window.open(this.props.getAccessButtonLink); }
+                        ) : (() => {})
+                      }
+                    />
+                  ) :
+                    (
+                      <Button
+                        label='Get Access'
+                        className='top-message-banner__button'
+                        buttonType='default'
+                        enabled={false}
+                        tooltipEnabled
+                        tooltipText='Coming soon'
+                        onClick={
+                          (this.props.getAccessButtonLink) ? (
+                            () => { window.open(this.props.getAccessButtonLink); }
+                          ) : (() => {})
+                        }
+                      />
+                    )
                   }
-                />
+                </div>
               </div>
-              <span className='top-message-banner__normal-text'>Due to lack of access, you are only able to narrow the cohort down to </span>
-              <span className='top-message-banner__bold-text'>{ this.props.tierAccessLimit } </span>
-              <span className='top-message-banner__normal-text'>
-                {this.props.guppyConfig.nodeCountTitle.toLowerCase()
+              <div className='top-message-banner__text-column'>
+                <span className='top-message-banner__normal-text'>Due to lack of access, you are only able to narrow the cohort down to </span>
+                <span className='top-message-banner__bold-text'>{ this.props.tierAccessLimit } </span>
+                <span className='top-message-banner__normal-text'>
+                  {this.props.guppyConfig.nodeCountTitle.toLowerCase()
                   || this.props.guppyConfig.dataType}.
                   Please request additional access if necessary.
-              </span>
+                </span>
+              </div>
             </div>
           ) : (<React.Fragment />)
         }
@@ -42,6 +65,7 @@ class ExplorerTopMessageBanner extends React.Component {
 ExplorerTopMessageBanner.propTypes = {
   className: PropTypes.string,
   getAccessButtonLink: PropTypes.string,
+  hideGetAccessButton: PropTypes.bool,
   tierAccessLevel: PropTypes.string.isRequired,
   tierAccessLimit: PropTypes.number,
   accessibleFieldObject: PropTypes.object, // inherit from GuppyWrapper
@@ -53,6 +77,7 @@ ExplorerTopMessageBanner.defaultProps = {
   tierAccessLimit: undefined,
   accessibleFieldObject: {},
   getAccessButtonLink: undefined,
+  hideGetAccessButton: false,
   guppyConfig: {},
 };
 

--- a/src/GuppyDataExplorer/ExplorerTopMessageBanner/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerTopMessageBanner/index.jsx
@@ -15,25 +15,14 @@ class ExplorerTopMessageBanner extends React.Component {
             <div className='top-message-banner'>
               <div className='top-message-banner__button-column'>
                 <div className='top-message-banner__button-wrapper'>
-                  { (hideGetAccessButton) ? (
-                    <Button
-                      label='Get Access'
-                      className='top-message-banner__button'
-                      buttonType='default'
-                      onClick={
-                        (this.props.getAccessButtonLink) ? (
-                          () => { window.open(this.props.getAccessButtonLink); }
-                        ) : (() => {})
-                      }
-                    />
-                  ) :
+                  { (hideGetAccessButton) ? (<React.Fragment />) :
                     (
                       <Button
                         label='Get Access'
                         className='top-message-banner__button'
                         buttonType='default'
-                        enabled={false}
-                        tooltipEnabled
+                        enabled={!!(this.props.getAccessButtonLink)}
+                        tooltipEnabled={!(this.props.getAccessButtonLink)}
                         tooltipText='Coming soon'
                         onClick={
                           (this.props.getAccessButtonLink) ? (

--- a/src/GuppyDataExplorer/GuppyDataExplorer.jsx
+++ b/src/GuppyDataExplorer/GuppyDataExplorer.jsx
@@ -45,11 +45,13 @@ class GuppyDataExplorer extends React.Component {
             tierAccessLimit={this.props.tierAccessLimit}
             guppyConfig={this.props.guppyConfig}
             getAccessButtonLink={this.props.getAccessButtonLink}
+            hideGetAccessButton={this.props.hideGetAccessButton}
           />
           <ExplorerFilter
             className='guppy-data-explorer__filter'
             guppyConfig={this.props.guppyConfig}
             getAccessButtonLink={this.props.getAccessButtonLink}
+            hideGetAccessButton={this.props.hideGetAccessButton}
             tierAccessLevel={this.props.tierAccessLevel}
             tierAccessLimit={this.props.tierAccessLimit}
           />
@@ -83,6 +85,7 @@ GuppyDataExplorer.propTypes = {
   tierAccessLevel: PropTypes.string.isRequired,
   tierAccessLimit: PropTypes.number.isRequired,
   getAccessButtonLink: PropTypes.string,
+  hideGetAccessButton: PropTypes.bool,
   adminAppliedPreFilters: PropTypes.object,
 };
 
@@ -90,6 +93,7 @@ GuppyDataExplorer.defaultProps = {
   heatMapConfig: {},
   nodeCountTitle: undefined,
   getAccessButtonLink: undefined,
+  hideGetAccessButton: false,
   adminAppliedPreFilters: {},
 };
 

--- a/src/GuppyDataExplorer/TierAccessSelector/index.jsx
+++ b/src/GuppyDataExplorer/TierAccessSelector/index.jsx
@@ -90,8 +90,13 @@ class TierAccessSelector extends React.Component {
                       label='Get Access'
                       className='tier-access-selector__button'
                       buttonType='default'
+                      enabled={!!(this.props.getAccessButtonLink)}
+                      tooltipEnabled={!(this.props.getAccessButtonLink)}
+                      tooltipText='Coming soon'
                       onClick={
-                        () => { window.open(this.props.getAccessButtonLink); }
+                        (this.props.getAccessButtonLink) ? (
+                          () => { window.open(this.props.getAccessButtonLink); }
+                        ) : (() => {})
                       }
                     />
                   </div>

--- a/src/GuppyDataExplorer/TierAccessSelector/index.jsx
+++ b/src/GuppyDataExplorer/TierAccessSelector/index.jsx
@@ -84,7 +84,7 @@ class TierAccessSelector extends React.Component {
                 </div>
               </div>
               {
-                this.state.selected !== 'with-access' && (
+                this.state.selected !== 'with-access' && !this.props.hideGetAccessButton && (
                   <div className='tier-access-selector__button-wrapper'>
                     <Button
                       label='Get Access'
@@ -110,11 +110,13 @@ TierAccessSelector.propTypes = {
   // paramter will be one of: 'with-access', 'without-access', or 'all-data'
   onSelectorChange: PropTypes.func,
   getAccessButtonLink: PropTypes.string,
+  hideGetAccessButton: PropTypes.bool,
 };
 
 TierAccessSelector.defaultProps = {
   onSelectorChange: () => {},
-  getAccessButtonLink: 'https://gen3.org/',
+  getAccessButtonLink: undefined,
+  hideGetAccessButton: false,
 };
 
 export default TierAccessSelector;

--- a/src/GuppyDataExplorer/index.jsx
+++ b/src/GuppyDataExplorer/index.jsx
@@ -109,6 +109,7 @@ class Explorer extends React.Component {
             tierAccessLevel={tierAccessLevel}
             tierAccessLimit={tierAccessLimit}
             getAccessButtonLink={config.dataExplorerConfig.getAccessButtonLink}
+            hideGetAccessButton={config.dataExplorerConfig.hideGetAccessButton}
           />
         </div>
       </div>


### PR DESCRIPTION
This PR fulfills https://ctds-planx.atlassian.net/browse/PXP-4535

A new `hideGetAccessButton` field is added to portal config, in the `dataExplorerConfig` section, the default value is false.

If `hideGetAccessButton` is ture, Get Access buttons is removed from data explorer.

If `hideGetAccessButton` is false and if no `getAccessButtonLink` has been specified in portal config, Get Access buttons is disabled with a tooltip saying “Coming soon“

Deployed in https://mingfei.planx-pla.net/ (with no `getAccessButtonLink` and `hideGetAccessButton` in portal config)

### New Features
- New `hideGetAccessButton` field to hide the Get Access button in data explorer

### Improvements
- Get Access button in data explorer will be disabled and showing a tooltip if there is no `getAccessButtonLink` in portal config and `hideGetAccessButton` is missing or false
- Appearance update for data explorer top message bar
