### PR TITLE
fiix/set filter to all-data for libre commons

### DIFF
--- a/src/GuppyDataExplorer/ExplorerFilter/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerFilter/index.jsx
@@ -23,6 +23,10 @@ class ExplorerFilter extends React.Component {
     if (prevProps.accessibleFieldObject !== this.props.accessibleFieldObject ||
       prevProps.unaccessibleFieldObject !== this.props.unaccessibleFieldObject
     ) {
+      if (this.props.tierAccessLevel === 'libre') {
+        this.setState({ selectedAccessFilter: 'all-data' });
+        return null;
+      }
       if (this.props.tierAccessLevel === 'regular') {
         if (checkForNoAccessibleProject(
           this.props.accessibleFieldObject,


### PR DESCRIPTION
For commons configured to `libre` tier access level, filters should change to `all-data`


### Bug Fixes
- Fixed a bug causing weired filter behaviors in `libre` commons

