### PR TITLE
fix(offset): remove offset to make chart look better

### DIFF
--- a/src/components/charts/IndexBarChart/IndexBarChart.less
+++ b/src/components/charts/IndexBarChart/IndexBarChart.less
@@ -4,7 +4,6 @@
   width: 770px;
   min-width: 300px;
   height: 340px;
-  margin-top: -30px;
 }
 
 @media screen and (max-width: 1290px) {


### PR DESCRIPTION
The number in the landing page chart got cut a little bit. There's a CSS offset and I don't know the reason why it was there at the first place. This PR fixes this by removing that offset 

### Bug Fixes
  - Fix a UI bug that the landing page chart got cut at the top. 