### PR TITLE
Make Terra Export Warning title configurable

### DIFF
--- a/src/GuppyDataExplorer/ExplorerButtonGroup/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerButtonGroup/index.jsx
@@ -521,7 +521,10 @@ class ExplorerButtonGroup extends React.Component {
                 ? terraExportWarning.message
                 : `Warning: You have selected more subjects than are currently supported. The import may not succeed. Terra recommends slicing your data into segments of no more than ${terraExportWarning.subjectThreshold.toLocaleString()} subjects and exporting each separately. Would you like to continue anyway?`
               }
-              title='Warning: Export May Fail'
+              title={terraExportWarning.title
+                ? terraExportWarning.title
+                : 'Warning: Export May Fail'
+              }
               rightButtons={[
                 {
                   caption: 'Yes, Export Anyway',


### PR DESCRIPTION
Makes title configurable for Terra Export Warning (https://github.com/uc-cdis/data-portal/pull/642)

### Improvements
- Title in Terra Export Warning is now configurable

### Deployment changes
- New optional `title` parameter in Terra Export Warning configuration: `terraExportWarning: { subjectThreshold: int, title: string(optional), message: string(optional) }`

