### PR TITLE
[PXP-4583] Fix program/project submission UI

### DIFF
--- a/TECHDEBT.md
+++ b/TECHDEBT.md
@@ -1,0 +1,37 @@
+# Tech debt
+
+### Arborist auth mapping
+Observed: October 2019
+Impact: (if this tech debt affected your work somehow, add a +1 here with a
+date and optionally a note)
++1 Zoe 2020 Feb 20 This is an example of a +1
+##### Problem:
+The ArboristUI features rely on hitting Arborist /auth/mapping one time to get
+the auth mapping, and then consult the auth mapping to decide which components
+should be rendered and which should not.
+##### Why it was done this way:
+This was done to avoid having to make many (tens?) of calls to Arborist upon
+each page load, for example upon loading the profile page.
+##### Why this way is problematic:
+The auth mapping returns a bunch of resource paths, and the resource paths are
+part of a hierarchy. When Arborist resolves auth requests it understands the
+resource hierarchy, so for example if a user has a policy granting them access
+to /programA then Arborist knows the user has access to /programA/project1.
+Windmill, being the front-end service, should not need to understand the
+resource hierarchy. But if it is to receive the raw auth mapping from Arborist
+and do logic on that, instead of hitting /auth/request, then in order to
+correctly make authz decisions for resource paths, it has to understand the
+resource hierarchy. Currently it just does the wrong thing. But our resource
+hierarchy is not too complex yet, mostly just program-project, so for now it
+doesn't happen very often.
+##### What the solution might be:
+Call /auth/request for every authz-protected component that loads.
+##### Why we aren't already doing the above:
+That's a lot of requests to Arborist all at once.
+##### Next steps:
+Just try it the other way?? Figure out how to chunk requests to Arborist?
+Redis cache...????????
+##### Other notes:
+Tube has a similar problem, where each document is associated with a resource
+path, but Tube just tries to do a simple match on the resource path and the
+auth mapping keys.

--- a/src/Submission/ProjectSubmission.jsx
+++ b/src/Submission/ProjectSubmission.jsx
@@ -29,15 +29,20 @@ const ProjectSubmission = (props) => {
     }
     return <MyDataModelGraph project={props.project} />;
   };
-  const displaySubmissionUIComponents = () => {
+  const displaySubmissionUIComponents = (project, userAuthMapping) => {
     if (
       !useArboristUI
-      || (isRootUrl(props.project) && userHasSheepdogProgramAdmin(props.userAuthMapping))
-      || (isProgramUrl(props.project) && userHasSheepdogProjectAdmin(props.userAuthMapping))
-      || userHasMethodOnProject('create', props.project, props.userAuthMapping)
-      || userHasMethodOnProject('update', props.project, props.userAuthMapping)
+      || (isRootUrl(project) && userHasSheepdogProgramAdmin(userAuthMapping))
+      || (isProgramUrl(project) && userHasSheepdogProjectAdmin(userAuthMapping))
+      || userHasMethodOnProject('create', project, userAuthMapping)
+      || userHasMethodOnProject('update', project, userAuthMapping)
     ) {
-      return <><MySubmitForm /><MySubmitTSV project={props.project} /></>;
+      return (
+        <React.Fragment>
+          <MySubmitForm />
+          <MySubmitTSV project={project} />
+        </React.Fragment>
+      );
     }
     return null;
   };
@@ -48,7 +53,7 @@ const ProjectSubmission = (props) => {
       {
         <Link className='project-submission__link' to={`/${props.project}/search`}>browse nodes</Link>
       }
-      { displaySubmissionUIComponents() }
+      { displaySubmissionUIComponents(props.project, props.userAuthMapping) }
       { displayData() }
     </div>
   );

--- a/src/Submission/ProjectSubmission.jsx
+++ b/src/Submission/ProjectSubmission.jsx
@@ -7,7 +7,7 @@ import SubmitForm from './SubmitForm';
 import Spinner from '../components/Spinner';
 import './ProjectSubmission.less';
 import { useArboristUI } from '../configs';
-import { userHasMethodOnProject } from '../authMappingUtils';
+import { userHasMethodOnProject, isRootUrl, isProgramUrl, userHasSheepdogProgramAdmin, userHasSheepdogProjectAdmin } from '../authMappingUtils';
 
 const ProjectSubmission = (props) => {
   // hack to detect if dictionary data is available, and to trigger fetch if not
@@ -29,9 +29,18 @@ const ProjectSubmission = (props) => {
     }
     return <MyDataModelGraph project={props.project} />;
   };
-
-  const userHasCreateOrUpdateOnProject = (projectID, userAuthMapping) => (userHasMethodOnProject('create', projectID, userAuthMapping)
-      || userHasMethodOnProject('update', projectID, userAuthMapping));
+  const displaySubmissionUIComponents = () => {
+    if (
+      !useArboristUI
+      || (isRootUrl(props.project) && userHasSheepdogProgramAdmin(props.userAuthMapping))
+      || (isProgramUrl(props.project) && userHasSheepdogProjectAdmin(props.userAuthMapping))
+      || userHasMethodOnProject('create', props.project, props.userAuthMapping)
+      || userHasMethodOnProject('update', props.project, props.userAuthMapping)
+    ) {
+      return <><MySubmitForm /><MySubmitTSV project={props.project} /></>;
+    }
+    return null;
+  };
 
   return (
     <div className='project-submission'>
@@ -39,16 +48,7 @@ const ProjectSubmission = (props) => {
       {
         <Link className='project-submission__link' to={`/${props.project}/search`}>browse nodes</Link>
       }
-      {
-        (useArboristUI && !userHasCreateOrUpdateOnProject(props.project, props.userAuthMapping)) ?
-          null :
-          <MySubmitForm />
-      }
-      {
-        (useArboristUI && !userHasCreateOrUpdateOnProject(props.project, props.userAuthMapping)) ?
-          null :
-          <MySubmitTSV project={props.project} />
-      }
+      { displaySubmissionUIComponents() }
       { displayData() }
     </div>
   );

--- a/src/Submission/SubmitTSV.jsx
+++ b/src/Submission/SubmitTSV.jsx
@@ -129,7 +129,7 @@ SubmitTSV.propTypes = {
     submit_counter: PropTypes.number,
     submit_total: PropTypes.number,
     submit_entity_counts: PropTypes.number,
-    nodeTypes: PropTypes.array,
+    nodeTypes: PropTypes.string,
     dictionary: PropTypes.object,
   }),
   onUploadClick: PropTypes.func.isRequired,

--- a/src/Submission/SubmitTSV.jsx
+++ b/src/Submission/SubmitTSV.jsx
@@ -129,7 +129,7 @@ SubmitTSV.propTypes = {
     submit_counter: PropTypes.number,
     submit_total: PropTypes.number,
     submit_entity_counts: PropTypes.number,
-    nodeTypes: PropTypes.string,
+    nodeTypes: PropTypes.array,
     dictionary: PropTypes.object,
   }),
   onUploadClick: PropTypes.func.isRequired,

--- a/src/authMappingUtils.js
+++ b/src/authMappingUtils.js
@@ -13,6 +13,27 @@ const resourcePathFromProjectID = (projectID) => {
 };
 
 
+// Used by ProjectSubmission to determine whether the user is creating a program.
+// To create a program the user needs access to the resource
+// /services/sheepdog/submission/program, usually granted via Sheepdog admin policy.
+export const isRootUrl = (urlFragment) => urlFragment === '_root';
+
+
+// Used by ProjectSubmission to determine whether the user is creating a project.
+// To create a project the user needs access to the resource
+// /services/sheepdog/submission/project, usually granted via Sheepdog admin policy.
+// A dash delimits the project code if there is one
+export const isProgramUrl = (urlFragment) => urlFragment !== '_root' && !urlFragment.includes('-');
+
+
+export const userHasSheepdogProgramAdmin = (userAuthMapping = {}) =>
+  userAuthMapping['/services/sheepdog/submission/program'] !== undefined;
+
+
+export const userHasSheepdogProjectAdmin = (userAuthMapping = {}) =>
+  userAuthMapping['/services/sheepdog/submission/project'] !== undefined;
+
+
 export const projectCodeFromResourcePath = (resourcePath) => {
   // If resourcePath is anything other than /programs/foo/projects/bar[/morestuff],
   // e.g. /gen3/programs/foo/projects/bar or /workspace or /programs/foo/bar/projects/baz,

--- a/src/authMappingUtils.js
+++ b/src/authMappingUtils.js
@@ -16,14 +16,14 @@ const resourcePathFromProjectID = (projectID) => {
 // Used by ProjectSubmission to determine whether the user is creating a program.
 // To create a program the user needs access to the resource
 // /services/sheepdog/submission/program, usually granted via Sheepdog admin policy.
-export const isRootUrl = (urlFragment) => urlFragment === '_root';
+export const isRootUrl = urlFragment => urlFragment === '_root';
 
 
 // Used by ProjectSubmission to determine whether the user is creating a project.
 // To create a project the user needs access to the resource
 // /services/sheepdog/submission/project, usually granted via Sheepdog admin policy.
 // A dash delimits the project code if there is one
-export const isProgramUrl = (urlFragment) => urlFragment !== '_root' && !urlFragment.includes('-');
+export const isProgramUrl = urlFragment => urlFragment !== '_root' && !urlFragment.includes('-');
 
 
 export const userHasSheepdogProgramAdmin = (userAuthMapping = {}) =>


### PR DESCRIPTION
Related sheepdog PR https://github.com/uc-cdis/sheepdog/pull/319 
Related commons-users PR https://github.com/uc-cdis/commons-users/pull/810

Fixes submission UI in the program/project submission case. Previously the ArboristUI logic did not differentiate between when a user was submitting program/project nodes and when they were submitting other nodes. CRUD on program/project nodes requires different authz; pre-centralized auth it required `admin: true` in the jwt; post-centralized auth it requires the `services/sheepdog/submission/[program,project]` resources. This PR changes ArboristUI so that it renders the submission UI components ("upload file" button, "use form submission" toggle) on program/project creation only when the user has permissions on the new resources. When ArboristUI is not enabled, the submission UI is always shown regardless of the user's permissions.

Also adds TECHDEBT.md per discussion in Engineering Retro a while ago. (To clarify, the thing described in the document was not introduced here.)

Tested on dev env:
- Old per-project ArboristUI still works as expected (submission UI appears only on projects where I have create or update)
- Program/project ArboristUI works as expected (for program and project submission pages, submission UI only appears if I have sheepdog program/project admin respectively)
- Turning off Arborist UI still works (submission UI will appear)

nodeType fix reverted because more issues were found. The bug is unrelated to this PR. Opening a separate ticket for it.

### New Features
Implement ArboristUI for program/project submission

### Improvements
Adds TECHDEBT.md so we can track tech debt