### PR TITLE
(PXP-5571) Allow contact to be a link on login page

### DIFF
--- a/src/Login/Login.jsx
+++ b/src/Login/Login.jsx
@@ -17,27 +17,6 @@ const getLoginUrl = (providerLoginUrl, next) => {
 };
 
 class Login extends React.Component {
-  static propTypes = {
-    providers: PropTypes.arrayOf(
-      PropTypes.objectOf(PropTypes.any),
-    ),
-    location: PropTypes.object.isRequired,
-    data: PropTypes.object.isRequired,
-  };
-
-  static defaultProps = {
-    providers: [
-      {
-        idp: 'google',
-        name: 'Google OAuth',
-        urls: [{
-          name: 'Google OAuth',
-          url: `${loginPath}google/`,
-        }],
-      },
-    ],
-  };
-
   constructor(props) {
     super(props);
     this.resetState = this.resetState.bind(this);
@@ -174,9 +153,18 @@ class Login extends React.Component {
           }
           <div>
             {this.props.data.contact}
-            <a href={`mailto:${this.props.data.email}`}>
-              {this.props.data.email}
-            </a>{'.'}
+            { (this.props.data.email && !this.props.data.contact_link) &&
+              <a href={`mailto:${this.props.data.email}`}>
+                {this.props.data.email}
+              </a>
+            }
+            {
+              this.props.data.contact_link &&
+              <a href={this.props.data.contact_link.href}>
+                {this.props.data.contact_link.text}
+              </a>
+            }
+            {'.'}
           </div>
         </div>
         <div className='login-page__side-box login-page__side-box--right' style={customImageStyle} />
@@ -184,5 +172,36 @@ class Login extends React.Component {
     );
   }
 }
+
+Login.propTypes = {
+  providers: PropTypes.arrayOf(
+    PropTypes.objectOf(PropTypes.any),
+  ),
+  location: PropTypes.object.isRequired,
+  data: PropTypes.shape({
+    title: PropTypes.string.isRequired,
+    subTitle: PropTypes.string.isRequired,
+    text: PropTypes.string.isRequired,
+    contact: PropTypes.shape.isRequired,
+    email: PropTypes.string, // deprecated; use contact_link instead
+    contact_link: PropTypes.shape({
+      text: PropTypes.string.isRequired,
+      href: PropTypes.string.isRequired,
+    }),
+  }).isRequired,
+};
+
+Login.defaultProps = {
+  providers: [
+    {
+      idp: 'google',
+      name: 'Google OAuth',
+      urls: [{
+        name: 'Google OAuth',
+        url: `${loginPath}google/`,
+      }],
+    },
+  ],
+};
 
 export default Login;

--- a/src/Login/Login.jsx
+++ b/src/Login/Login.jsx
@@ -161,7 +161,9 @@ class Login extends React.Component {
             {
               this.props.data.contact_link &&
               <a href={this.props.data.contact_link.href}>
-                {this.props.data.contact_link.text}
+                {this.props.data.contact_link.text
+                  ? this.props.data.contact_link.text
+                  : this.props.data.contact_link.href}
               </a>
             }
             {'.'}
@@ -185,7 +187,7 @@ Login.propTypes = {
     contact: PropTypes.shape.isRequired,
     email: PropTypes.string, // deprecated; use contact_link instead
     contact_link: PropTypes.shape({
-      text: PropTypes.string.isRequired,
+      text: PropTypes.string,
       href: PropTypes.string.isRequired,
     }),
   }).isRequired,


### PR DESCRIPTION
https://ctds-planx.atlassian.net/browse/PXP-5571

Add a new configurable contact link to the login page, which can be used in place of the contact email. This allows us to specify email links (by using `mailto:email` as the link) as well as normal URLs. This is needed for BDCat as we want to use https://biodatacatalyst.nhlbi.nih.gov/contact as the Login page contact form.

Deployed in https://mpingram.planx-pla.net/login -- try using the contact link.

### New Features
- Allow use of any link for a contact on the Login page, rather than only emails.

### Deployment changes
- Added a new property to gitops.json: `components.login.contact_link: { text: string, href: string }`. If `login.contact_link` is present, it will be displayed instead of `login.email`. Email links can be represented in `contact_link` using "mailto:email@address" as the "href".