### PR TITLE
(PXP-5648): Enable PFB export buttons when 0 files selected.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Windmill data portal
 
+Revert this
+
 A generic data portal that supports some basic interaction with Gen3 services like [peregrine](https://github.com/uc-cdis/peregrine), [sheepdog](https://github.com/uc-cdis/sheepdog) and [fence](https://github.com/uc-cdis/fence).
 
 ## Get Started
@@ -138,8 +140,8 @@ The configurations of Homepage charts are specified data/config/<common-name>.js
 - `chartCounts` are the counts that you want to display in the bar chart of dashboard's
 - `projectDetails` are the counts that you want to display in the list of projects. It could be same as `boardCounts`, in this case, you only need to point to `boardCounts`.
 
-Except the default case/file count charts, you could add more to the homepage, and those customized charts will be added to a carousel. 
-We support categorical horizontal grouped bar charts, and the chart will be using data from Guppy, so make sure you correctly ETL them to your Elasticsearch database. The new added charts are configured in portal config's components.index.customHomepageChartConfig config, make sure configurations are correct. Example config (notice the comments won't work for JSON): 
+Except the default case/file count charts, you could add more to the homepage, and those customized charts will be added to a carousel.
+We support categorical horizontal grouped bar charts, and the chart will be using data from Guppy, so make sure you correctly ETL them to your Elasticsearch database. The new added charts are configured in portal config's components.index.customHomepageChartConfig config, make sure configurations are correct. Example config (notice the comments won't work for JSON):
 
 ```
 "customHomepageChartConfig": [

--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # Windmill data portal
 
-Revert this
-
 A generic data portal that supports some basic interaction with Gen3 services like [peregrine](https://github.com/uc-cdis/peregrine), [sheepdog](https://github.com/uc-cdis/sheepdog) and [fence](https://github.com/uc-cdis/fence).
 
 ## Get Started
@@ -140,8 +138,8 @@ The configurations of Homepage charts are specified data/config/<common-name>.js
 - `chartCounts` are the counts that you want to display in the bar chart of dashboard's
 - `projectDetails` are the counts that you want to display in the list of projects. It could be same as `boardCounts`, in this case, you only need to point to `boardCounts`.
 
-Except the default case/file count charts, you could add more to the homepage, and those customized charts will be added to a carousel.
-We support categorical horizontal grouped bar charts, and the chart will be using data from Guppy, so make sure you correctly ETL them to your Elasticsearch database. The new added charts are configured in portal config's components.index.customHomepageChartConfig config, make sure configurations are correct. Example config (notice the comments won't work for JSON):
+Except the default case/file count charts, you could add more to the homepage, and those customized charts will be added to a carousel. 
+We support categorical horizontal grouped bar charts, and the chart will be using data from Guppy, so make sure you correctly ETL them to your Elasticsearch database. The new added charts are configured in portal config's components.index.customHomepageChartConfig config, make sure configurations are correct. Example config (notice the comments won't work for JSON): 
 
 ```
 "customHomepageChartConfig": [

--- a/src/GuppyDataExplorer/ExplorerButtonGroup/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerButtonGroup/index.jsx
@@ -447,13 +447,11 @@ class ExplorerButtonGroup extends React.Component {
       return this.state.manifestEntryCount > 0;
     }
     if (buttonConfig.type === 'export-to-pfb') {
-      return this.state.manifestEntryCount > 0 && !this.state.exportingToCloud;
+      return !this.state.exportingToCloud;
     }
     if (buttonConfig.type === 'export') {
-      if (!this.state.exportingToCloud) {
-        return this.state.manifestEntryCount > 0 && !this.isPFBRunning();
-      }
-      return this.state.manifestEntryCount > 0;
+      // if exportingToCloud is true or the PFB job is running, the button is not enabled.
+      return !(this.state.exportingToCloud || this.isPFBRunning());
     }
     if (buttonConfig.type === 'export-to-workspace') {
       return this.state.manifestEntryCount > 0;


### PR DESCRIPTION
Link to Jira: https://ctds-planx.atlassian.net/browse/PXP-5648

Bug: When a cohort with 0 data files is selected in the data explorer, the export to workspace,
export to pfb, and export to Terra buttons were disabled. This PR enables the export to Terra and export to PFB buttons unless a network request for guppy data is in flight.

To test this fix, checkout this branch and run portal locally against BDCat Preprod with: 
```
HOSTNAME=preprod.gen3.biodatacatalyst.nhlbi.nih.gov NODE_ENV=auto bash ./runWebpack.sh
```

Manual test plan:
1. Select a cohort with no data files (in BDC, can do this by selecting ‘no data’ under Subject > Data Type)
2. Export to Workspace button should be greyed out, but Export to Terra Button and Export to PFB Button should be enabled
3. Click Export to Terrra: Export to PFB button and Export to Terra buttons should be disabled.
4. Click Export to PFB: Export to PFB button and Export to Terra Buttons should be disabled.

### Bug Fixes
- Fixed bug in which Export to PFB and Export to Terra buttons were disabled if a cohort of subjects contained 0 associated data files.
