### PR TITLE
Navbar tooltip on hover

### DIFF
--- a/data/config/default.json
+++ b/data/config/default.json
@@ -79,38 +79,38 @@
         {
           "icon": "dictionary",
           "link": "/DD",
-          "color": "#a2a2a2",
-          "name": "Dictionary"
+          "name": "Dictionary",
+          "tooltip": ""
         },
         {
           "icon": "exploration",
           "link": "/explorer",
-          "color": "#a2a2a2",
-          "name": "Exploration"
+          "name": "Exploration",
+          "tooltip": ""
         },
         {
           "icon": "files",
           "link": "/files",
-          "color": "#a2a2a2",
-          "name": "Files"
+          "name": "Files",
+          "tooltip": ""
         },
         {
           "icon": "query",
           "link": "/query",
-          "color": "#a2a2a2",
-          "name": "Query"
+          "name": "Query",
+          "tooltip": ""
         },
         {
           "icon": "workspace",
           "link": "#hostname#workspace/",
-          "color": "#a2a2a2",
-          "name": "Workspace"
+          "name": "Workspace",
+          "tooltip": ""
         },
         {
           "icon": "profile",
           "link": "/identity",
-          "color": "#a2a2a2",
-          "name": "Profile"
+          "name": "Profile",
+          "tooltip": ""
         }
       ]
     },

--- a/src/ResourceBrowser/ResourceBrowser.css
+++ b/src/ResourceBrowser/ResourceBrowser.css
@@ -1,5 +1,6 @@
 .resource-browser {
   width: 100%;
+  padding: 20px;
   min-height: inherit;
   background: inherit;
   display: flex;
@@ -7,8 +8,16 @@
   align-items: center;
 }
 
+.resource-browser__title {
+  padding: 10px 20px;
+}
+
+.resource-browser__description {
+  padding: 10px 20px;
+}
+
 .resource-browser__resources {
-  padding: 20px;
+  padding: 10px 0 20px 0;
   display: flex;
   flex-flow: wrap;
 }

--- a/src/ResourceBrowser/index.jsx
+++ b/src/ResourceBrowser/index.jsx
@@ -20,7 +20,9 @@ class ResourceBrowser extends React.Component {
           {settings.title}
         </h2>
         {settings.description ?
-          settings.description
+          <p className='resource-browser__description'>
+            {settings.description}
+          </p>
           : null}
         <div className='resource-browser__resources'>
           {resources.map((resource, i) =>

--- a/src/components/layout/NavBar.less
+++ b/src/components/layout/NavBar.less
@@ -7,6 +7,7 @@
 .nav-bar__nav--info {
   float: left;
   display: inline-flex;
+  height: 0;
 }
 
 @media screen and (max-width: 1090px) {

--- a/src/components/layout/NavBarTooltip.css
+++ b/src/components/layout/NavBarTooltip.css
@@ -1,0 +1,42 @@
+.navbar-tooltip {
+  position: absolute;
+  z-index: 1000;
+}
+
+.navbar-tooltip__wrapper {
+  position: relative;
+  background-color: var(--g3-color__white);
+  vertical-align: middle;
+  text-align: center;
+  padding: 10px 0;
+  left: -120px; /* tooltipWidth / 2 */
+  width: 240px; /* tooltipWidth = 240 */
+  top: 5px;
+  border: 1px solid var(--g3-color__gray);
+  border-radius: 4px;
+}
+
+.navbar-tooltip__arrow {
+  width: 0;
+  height: 0;
+  position: absolute;
+  top: -10px;
+  left: calc(50% - 10px);
+  border-left: 10px solid transparent;
+  border-right: 10px solid transparent;
+  border-bottom: 10px solid var(--g3-color__gray); /* gap = 10px */
+}
+
+.navbar-tooltip__arrow--inner {
+  top: -9px;
+  border-bottom: 10px solid var(--g3-color__white);
+}
+
+.navbar-tooltip__content {
+  position: relative;
+  font-size: 14px;
+  font-weight: normal;
+  line-height: 1.6em;
+  letter-spacing: .02rem;
+  text-align: unset;
+}

--- a/src/components/layout/NavBarTooltip.css
+++ b/src/components/layout/NavBarTooltip.css
@@ -7,8 +7,7 @@
   position: relative;
   background-color: var(--g3-color__white);
   vertical-align: middle;
-  text-align: center;
-  padding: 10px 0;
+  padding: 10px;
   left: -120px; /* tooltipWidth / 2 */
   width: 240px; /* tooltipWidth = 240 */
   top: 5px;

--- a/src/components/layout/NavBarTooltip.jsx
+++ b/src/components/layout/NavBarTooltip.jsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import './NavBarTooltip.css';
+
+class NavBarTooltip extends React.Component {
+  render() {
+    const popupLeft = this.props.x;
+    const popupTop = this.props.y;
+    return (
+      <div
+        className='navbar-tooltip'
+        style={{
+          top: popupTop,
+          left: popupLeft,
+        }}
+      >
+        {
+          <div className='navbar-tooltip__wrapper'>
+            <div className='navbar-tooltip__content'>
+              {this.props.content}
+            </div>
+            <span className='navbar-tooltip__arrow navbar-tooltip__arrow--outer' />
+            <span className='navbar-tooltip__arrow navbar-tooltip__arrow--inner' />
+          </div>
+        }
+      </div>
+    );
+  }
+}
+
+NavBarTooltip.propTypes = {
+  content: PropTypes.string.isRequired,
+  x: PropTypes.number.isRequired,
+  y: PropTypes.number.isRequired,
+};
+
+export default NavBarTooltip;


### PR DESCRIPTION
![Screen Shot 2020-04-16 at 5 42 43 PM](https://user-images.githubusercontent.com/4224001/79515406-28c33280-800e-11ea-9562-f2130d327c01.png)
Jira Ticket: COV-98 (OCC Jira)
Allows us to display tooltips on hover instead of (or in addition to 🤷) the usual homepage cards

```
"navigation": {
  "items": [
    {
      "name": "Notebook Browser",
      "link": "/resource-browser",
      "icon": "query",
      "tooltip": "The notebooks pull data from various external sources to generate and output useful tables, charts, graphs, and models."
    }
  ]
}
```

Currently deployed at https://pauline.planx-pla.net

\+ add `tooltip` to the default config, and remove `color` because as far as i can tell it's not used anywhere... let me know if i shouldn't
\+ small fix for a 5px empty space displayed under navbar buttons when the text is a bit long
\+ add padding around the Resource Browser description

### New Features
- Navigation bar display a tooltip on hover for each button
