### PR TITLE
fix menu responsive CSS

### DIFF
--- a/src/components/layout/NavBar.less
+++ b/src/components/layout/NavBar.less
@@ -114,7 +114,7 @@
 }
 
 .nav-bar__logo {
-  padding-top: 8px;
+  padding: 8px 0;
   display: inline-block;
 }
 

--- a/src/components/layout/NavBar.less
+++ b/src/components/layout/NavBar.less
@@ -7,7 +7,6 @@
 .nav-bar__nav--info {
   float: left;
   display: inline-flex;
-  height: 0;
 }
 
 @media screen and (max-width: 1090px) {
@@ -115,7 +114,7 @@
 }
 
 .nav-bar__logo {
-  padding: 8px 0;
+  padding-top: 8px;
   display: inline-block;
 }
 


### PR DESCRIPTION
My previous change https://github.com/uc-cdis/data-portal/pull/669/commits/e588a0cfab76206c9dfa6e1cda4d2774fa7c2129 fixed a CSS issue but created a new one on mobile screens:

![Screen Shot 2020-04-17 at 4 45 33 PM](https://user-images.githubusercontent.com/4224001/79616822-941f0a00-80cb-11ea-9046-f20666ba0452.png)

This change is to fix it:

![Screen Shot 2020-04-17 at 4 48 32 PM](https://user-images.githubusercontent.com/4224001/79616821-93867380-80cb-11ea-8f51-2ccced124465.png)

The original change was to fix an annoying extra empty space under the navbar buttons - it turns out we just need to reduce the `.nav-bar__logo` bottom padding, and I need to remove the CSS override in covid19's `gitops.css`

### Bug Fixes
- Fix responsive main menu
