### PR TITLE
COV-78 Feat/multi tab explorer

### DIFF
--- a/docs/data_availability_tool.md
+++ b/docs/data_availability_tool.md
@@ -2,7 +2,7 @@
 
 The DAT is a heatmap in the exploration page.
 
-It can be used to show data availability accross projects. It works well both for categorical data and for longitudinal data.
+It can be used to show data availability across projects. It works well both for categorical data and for longitudinal data.
 
 Example of a DAT for longitudinal data:
 ![DAT example](data_availability_tool_example.png)

--- a/docs/multi_tab_explorer.md
+++ b/docs/multi_tab_explorer.md
@@ -6,7 +6,7 @@ This feature is available from Portal 2.26.0, and is backward compatible with ex
 
 ## Configuration
 
-The multi-tab explorer requires a new configuration field, called `explorerConfig`, to be placed in the config file of Portal. The `explorerConfig` is an array with can hold multiple configuration objects, one for each tab. Each individual configuration object has a similar format as the old `dataExplorerConfig` and/or `fileExplorerConfig`, which means it should contains a set of fields like `charts`, `filters`, `table`, `buttons`, `guppyConfig` and other optional fields. Each tab serves the information from one single ES index, as have been defined in `guppyConfig.dataType`.
+The multi-tab explorer requires a new configuration field, called `explorerConfig`, to be placed in the config file of Portal. The `explorerConfig` is an array which can hold multiple configuration objects, one for each tab. Each individual configuration object has a similar format as the old `dataExplorerConfig` and/or `fileExplorerConfig`, which means it should contains a set of fields like `charts`, `filters`, `table`, `buttons`, `guppyConfig` and other optional fields. Each tab serves the information from one single ES index, as have been defined in `guppyConfig.dataType`.
 
 An example of this new `explorerConfig` is (some contents are omitted for conciseness):
 

--- a/docs/multi_tab_explorer.md
+++ b/docs/multi_tab_explorer.md
@@ -1,0 +1,164 @@
+# Multi-tab Explorer
+
+The multi-tab explorer is an enhancement to Windmill's data and file explorer feature. The enhancement includes a configuration format change to support rendering multiple tabs in the explorer, each tab will serves contents from one ES index. This enhancement allows the original file explorer to be decoupled with data explorer, and customize each tabs in the explorer.
+
+This feature is available from Portal 2.26.0, and is backward compatible with existing data/file explorer configurations. For more information about the old configuration format for data/file explorer, please refer to [this document](https://github.com/uc-cdis/cdis-wiki/blob/master/dev/gen3/guides/ui_etl_configuration.md).
+
+## Configuration
+
+The multi-tab explorer requires a new configuration field, called `explorerConfig`, to be placed in the config file of Portal. The `explorerConfig` is an array with can hold multiple configuration objects, one for each tab. Each individual configuration object has a similar format as the old `dataExplorerConfig` and/or `fileExplorerConfig`, which means it should contains a set of fields like `charts`, `filters`, `table`, `buttons`, `guppyConfig` and other optional fields. Each tab serves the information from one single ES index, as have been defined in `guppyConfig.dataType`.
+
+An example of this new `explorerConfig` is (some contents are omitted for conciseness):
+
+```
+"explorerConfig":[
+    {                                       ---> 1st tab
+      "tabTitle": "Data",
+      "charts": {
+        "project_id": {
+          "chartType": "count",
+          "title": "Projects"
+        },
+        ...
+      },
+      "filters": {
+        "tabs": [
+          {
+            "title": "Case",
+            "fields": [
+              "project_id",
+              ...
+            ]
+          }
+        ]
+      },
+      "table": {
+        "enabled": true,
+        "fields": [
+          "project_id",
+          ...
+        ]
+      },
+      "guppyConfig": {
+        "dataType": "case",
+        "nodeCountTitle": "Cases",
+        "fieldMapping": [
+          {"field": "_aliquots_count", "name": "Aliquots Count"},
+          ....
+        ],
+        "manifestMapping": {
+          "resourceIndexType": "file",
+          "resourceIdField": "object_id",
+          "referenceIdFieldInResourceIndex": "case_id",
+          "referenceIdFieldInDataIndex": "case_id"
+        },
+        "accessibleFieldCheckList": ["project_id"],
+        "accessibleValidationField": "project_id"
+      },
+      "buttons": [
+         ....
+      ]
+    },
+    {                                                  ---> 2nd tab
+      "charts": {
+        "data_type": {
+          "chartType": "stackedBar",
+          "title": "File Type"
+        },
+        ...
+      },
+      "filters": {
+        ...
+      },
+      "table": {
+        "enabled": true,
+        "fields": [
+          "project_id",
+          ...
+        ]
+      },
+      "guppyConfig": {
+        "dataType": "file",
+        "fieldMapping": [
+          { "field": "object_id", "name": "GUID" }
+        ],
+        "nodeCountTitle": "Files",
+        "manifestMapping": {
+          "resourceIndexType": "case",
+          "resourceIdField": "case_id",
+          "referenceIdFieldInResourceIndex": "object_id",
+          "referenceIdFieldInDataIndex": "object_id"
+        },
+        "accessibleFieldCheckList": ["project_id"],
+        "accessibleValidationField": "project_id",
+        "downloadAccessor": "object_id"
+      },
+      "buttons": [
+        {
+          "enabled": true,
+          "type": "file-manifest",
+          "title": "Download Manifest",
+          "leftIcon": "datafile",
+          "rightIcon": "download",
+          "fileName": "file-manifest.json"
+        }
+      ],
+      "dropdowns": {}
+    },
+    {                                     ---> 3rd tab
+      "charts": {
+           ...
+      },
+      "filters": {
+        "tabs": [
+          {
+            "title": "Subject",
+            "fields": [
+              "project_id",
+              "subject_id"
+            ]
+          }
+        ]
+      },
+      "table": {
+        "enabled": true,
+        "fields": [
+          "project_id",
+          "subject_id"
+        ]
+      },
+      "guppyConfig": {
+        "dataType": "subject",
+        "fieldMapping": [
+        ],
+        "nodeCountTitle": "Subjects",
+        "manifestMapping": {
+        },
+        "accessibleFieldCheckList": ["project_id"],
+        "accessibleValidationField": "project_id"
+      },
+      "buttons": [
+      ],
+      "dropdowns": {}
+    }
+  ]
+```
+
+### Notable fields
+
+- `tabTitle`: Optional. If omitted, will default to use the value of `guppyConfig.dataType` of this tab.
+- `filters`: Required.
+- `guppyConfig`: Required.
+  - `dataType`: Required. Must match the index “type” in the guppy configuration block in the manifest.json.
+  - `nodeCountTitle`: Required. Plural of root node.
+
+For a complete list of required and optional fields for a tab configuration object, please refer to [Portal Config](https://github.com/uc-cdis/cdis-wiki/blob/master/dev/gen3/guides/ui_etl_configuration.md#portal-folder).
+
+### Converting from old `dataExplorerConfig` or `fileExplorerConfig` to `explorerConfig`
+
+The multi-tab explorer is backward compatible so it would work with existing `dataExplorerConfig` and `fileExplorerConfig`. But in case of moving existing configuration into the new `explorerConfig`, steps are easy to follow:
+
+1. In Portal's configuration file (such as `gitops.json`), create a `explorerConfig` array object `"explorerConfig":[]`.
+2. Copy all the values from the existing `dataExplorerConfig` as a whole object, and place it in the `explorerConfig` array. Add a `tabTitle` into it if needed.
+3. Repeat for the existing `fileExplorerConfig` if needed.
+4. Delete the old `dataExplorerConfig` and `fileExplorerConfig` on finish.

--- a/docs/multi_tab_explorer.md
+++ b/docs/multi_tab_explorer.md
@@ -2,7 +2,7 @@
 
 The multi-tab explorer is an enhancement to Windmill's data and file explorer feature. The enhancement includes a configuration format change to support rendering multiple tabs in the explorer, each tab will serves contents from one ES index. This enhancement allows the original file explorer to be decoupled with data explorer, and customize each tabs in the explorer.
 
-This feature is available from Portal 2.26.0, and is backward compatible with existing data/file explorer configurations. For more information about the old configuration format for data/file explorer, please refer to [this document](https://github.com/uc-cdis/cdis-wiki/blob/master/dev/gen3/guides/ui_etl_configuration.md).
+This feature is available from Portal 2.26.0, and is backward compatible with existing data/file explorer configurations. For more information about the old configuration format for data/file explorer, please refer to [Portal Config](https://github.com/uc-cdis/data-portal/blob/master/docs/portal_config.md).
 
 ## Configuration
 
@@ -56,7 +56,7 @@ An example of this new `explorerConfig` is (some contents are omitted for concis
         "accessibleValidationField": "project_id"
       },
       "buttons": [
-         ....
+         ...
       ]
     },
     {                                                  ---> 2nd tab
@@ -152,13 +152,82 @@ An example of this new `explorerConfig` is (some contents are omitted for concis
   - `dataType`: Required. Must match the index “type” in the guppy configuration block in the manifest.json.
   - `nodeCountTitle`: Required. Plural of root node.
 
-For a complete list of required and optional fields for a tab configuration object, please refer to [Portal Config](https://github.com/uc-cdis/cdis-wiki/blob/master/dev/gen3/guides/ui_etl_configuration.md#portal-folder).
+For a complete list of required and optional fields for a tab configuration object, please refer to [Portal Config](https://github.com/uc-cdis/data-portal/blob/master/docs/portal_config.md).
 
 ### Converting from old `dataExplorerConfig` or `fileExplorerConfig` to `explorerConfig`
 
-The multi-tab explorer is backward compatible so it would work with existing `dataExplorerConfig` and `fileExplorerConfig`. But in case of moving existing configuration into the new `explorerConfig`, steps are easy to follow:
+The multi-tab explorer is backward compatible so it would work with existing `dataExplorerConfig` and `fileExplorerConfig`.
+
+:warning: **Backward compatibility will only works if there is NO `explorerConfig` configuration exists in the Portal config file.** If you do have a new `explorerConfig` configuration exists in the Portal config file, any existing `dataExplorerConfig` and `fileExplorerConfig` will be ignored. If you intend to use the new `explorerConfig` configuration, please migrate existing `dataExplorerConfig` and `fileExplorerConfig` as described below.
+
+In case of migrating existing configuration into the new `explorerConfig`, steps are easy to follow:
 
 1. In Portal's configuration file (such as `gitops.json`), create a `explorerConfig` array object `"explorerConfig":[]`.
 2. Copy all the values from the existing `dataExplorerConfig` as a whole object, and place it in the `explorerConfig` array. Add a `tabTitle` into it if needed.
 3. Repeat for the existing `fileExplorerConfig` if needed.
 4. Delete the old `dataExplorerConfig` and `fileExplorerConfig` on finish.
+
+:information_source: Handling migration of the Data Availability Tool (DAT) configs
+
+The Data Availability Tool (DAT) is a visualization tool to show data availability across projects. For more information about this tool, please read [Data Availability Tool](https://github.com/uc-cdis/data-portal/blob/master/docs/data_availability_tool.md)
+
+In the past, in order to enable the DAT in data explorer, the portal config file must contain a `dataAvailabilityToolConfig` block. To migrate this DAT config so it can work with the new `explorerConfig`, simple copy the entire `dataAvailabilityToolConfig` block into the configuration block of the tab what the DAT will be put into.
+
+Example:
+```
+"explorerConfig":[
+    {                                       ---> 1st tab (with DAT)
+      "tabTitle": "Data",
+      "charts": {
+        ...
+      },
+      "filters": {
+        ...
+      },
+      "table": {
+        ...
+      },
+      "dataAvailabilityToolConfig": {       ---> DAT configs
+        "guppyConfig": {
+          "dataType": "follow_up",
+          "mainField": "visit_number",
+          "mainFieldTitle": "Visit number",
+          "mainFieldIsNumeric": true,
+          "aggFields": [
+              "age_at_visit",
+              ...
+          ],
+          "fieldMapping": [
+            { "field": "abcv", "name": "Abcavir Use" },
+            ...
+          ],
+        "colorRange": ["#EBF7FB", "#1769A3"]
+        }
+      },
+      "guppyConfig": {
+        ...
+      },
+      "buttons": [
+         ...
+      ]
+    },
+    {                                          ---> 2nd tab (no DAT)
+      "charts": {
+        ...
+      },
+      "filters": {
+        ...
+      },
+      "table": {
+        ...
+      },
+      "guppyConfig": {
+        ...
+      },
+      "buttons": [
+        ...
+      ],
+      "dropdowns": {}
+    }
+  ]
+```

--- a/docs/portal_config.md
+++ b/docs/portal_config.md
@@ -1,0 +1,369 @@
+# Portal Configurations
+
+> Contents duplicated from https://github.com/uc-cdis/cdis-wiki/blob/master/dev/gen3/guides/ui_etl_configuration.md#portal-folder for public access
+
+## The "portal config" file
+
+Each Gen3 Commons has a JSON file which details what UI features should be deployed for a commons, and what the configuration for these features should be. This is commonly referred to as the "portal config" file. A "portal config" file usually locates at `/portal/gitops.json` in the manifest directory of a Commons. Portal also has some default config files under `/data/config` but most of them are legacy configurations.
+
+Below is an example, with inline comments describing what each JSON block configures, as well as which properties are optional and which are required (if you are looking to copy/paste configuration as a start, please use something in the Github repo as the inline comments below will become an issue):
+
+```
+{
+  "gaTrackingId": "xx-xxxxxxxxx-xxx", // required; the Google Analytics ID to track statistics
+  "graphql": { // required; start of query section - these attributes must be in the dictionary
+    "boardCounts": [ // required; graphQL fields to query for the homepage chart
+      {
+        "graphql": "_case_count", // required; graphQL field name for aggregate count
+        "name": "Case", // required; human readable name of field
+        "plural": "Cases" // required; human readable plural name of field
+      },
+      {
+        "graphql": "_study_count",
+        "name": "Study",
+        "plural": "Studies"
+      },
+      {
+        "graphql": "_aliquot_count",
+        "name": "Aliquot",
+        "plural": "Aliquots"
+      }
+    ],
+    "chartCounts": [ // required;
+      {
+        "graphql": "_case_count",
+        "name": "Case"
+      },
+      {
+        "graphql": "_study_count",
+        "name": "Study"
+      }
+    ],
+    "projectDetails": "boardCounts" // required; which JSON block above to use for displaying aggregate properties on the submission page (www.project.io/submission)
+  },
+  "components": {
+    "appName": "Gen3 Generic Data Commons", // required; title of commons that appears on the homepage
+    "index": { // required; relates to the homepage
+      "introduction": { // optional; text on homepage
+        "heading": "", // optional; title of introduction
+        "text": "This is an example Gen3 Data Commons", // optional; text of homepage
+        "link": "/submission" // optional; link for button underneath the text
+      },
+      "buttons": [ // optional; button “cards” displayed on the bottom of the homepage
+        {
+          "name": "Define Data Field", // required; title of card
+          "icon": "planning", // required; name of icon to display on card located in /img/icons
+          "body": "Please study the dictionary before you start browsing.", // required; card text
+          "link": "/DD", // required; link for button
+          "label": "Learn more" // required; title of button that leads to link above
+        },
+        {
+          "name": "Explore Data",
+          "icon": "explore",
+          "body": "Explore data interactively.",
+          "link": "/explorer",
+          "label": "Explore data"
+        },
+        {
+          "name": "Analyze Data",
+          "icon": "analyze",
+          "body": "Analyze your selected cases using Jupyter Notebooks in our secure cloud environment.",
+          "link": "/workspace",
+          "label": "Run analysis"
+        }
+      ],
+      "homepageChartNodes": [ // optional; used for tiered access on the homepage. This means that the charts on the homepage will be available to the public.
+        {
+          "node": "case", // required; GraphQL field name of node to show a chart for
+          "name": "Cases" // required; plural human readable name of node
+        },
+        {
+          "node": "study",
+          "name": "Studies"
+        },
+        {
+          "node": "aliquot",
+          "name": "Aliquots"
+        }
+      ]
+    },
+    "navigation": { // required; details what should be in the navigation bar
+      "items": [ // required; the buttons in the navigation bar
+        {
+          "icon": "dictionary", // required; icon from /img/icons for the button
+          "link": "/DD", // required; the link for the button
+          "color": "#a2a2a2", // optional; hex color of the icon
+          "name": "Dictionary" // required; text for the button
+        },
+        {
+          "icon": "exploration",
+          "link": "/explorer",
+          "color": "#a2a2a2",
+          "name": "Exploration"
+        },
+        {
+          "icon": "workspace",
+          "link": "/workspace",
+          "color": "#a2a2a2",
+          "name": "Workspace"
+        },
+        {
+          "icon": "profile",
+          "link": "/identity",
+          "color": "#a2a2a2",
+          "name": "Profile"
+        }
+      ]
+    },
+    "topBar": { // required if useArboristUI is true, else optional
+      "items": [
+        {
+          "icon": "upload",
+          "link": "/submission",
+          "name": "Submit Data"
+        },
+        {
+          "link": "https://gen3.org/resources/user/",
+          "name": "Documentation"
+        }
+      ]
+    },
+    "login": { // required; what is displayed on the login page (/login)
+      "title": "Gen3 Generic Data Commons", // optional; title for the login page
+      "subTitle": "Explore, Analyze, and Share Data", // optional; subtitle for login page
+      "text": "This is a generic Gen3 data commons.", // optional; text on the login page
+      "contact": "If you have any questions about access or the registration process, please contact ", // optional; text for the contact section of the login page
+      "email": "support@datacommons.io", // optional; email for contact
+      "image": "gene" // optional; images displayed on the login page
+    },
+    "footerLogos": [ // optional; logos to be displayed in the footer, usually sponsors
+      {
+        "src": "/src/img/gen3.png", // required; src path for the image
+        "href": "https://ctds.uchicago.edu/gen3", // required; link for image
+        "alt": "Gen3 Data Commons" // required; alternate text if image won’t load
+      },
+      {
+        "src": "/src/img/createdby.png",
+        "href": "https://ctds.uchicago.edu/",
+        "alt": "Center for Translational Data Science at the University of Chicago"
+      }
+    ],
+    "categorical9Colors": ["#c02f42", "#175676", "#59CD90", "#F2DC5D", "#40476D", "#FFA630", "#AE8799", "#1A535C", "#462255"], // optional; colors for the graphs both on the homepage and on the explorer page (will be used in order)
+    "categorical2Colors": ["#6d6e70", "#c02f42"] // optional; colors for the graphs when there are only 2 colors (bar and pie graphs usually)
+  },
+  "requiredCerts": [], // optional; do users need to take a quiz or agree to something before they can access the site?
+  "featureFlags": { // optional; will hide certain parts of the site if needed
+    "explorer": true // required; indicates the flag and whether to hide it or not
+  },
+  "dataExplorerConfig": { // required; configuration for the Data Explorer (/explorer)
+    "charts": { // optional; indicates which charts to display in the Data Explorer
+      "project_id": { // required; GraphQL field to query for a chart (ex: this one will display the number of projects, based on the project_id)
+        "chartType": "count", // required; indicates this chart will display a “count”
+        "title": "Projects" // required; title to display on the chart
+      },
+      "case_id": {
+        "chartType": "count",
+        "title": "Cases"
+      },
+      "gender": {
+        "chartType": "pie", // required; pie chart type
+        "title": "Gender"
+      },
+      "race": {
+        "chartType": "bar", // required; bar chart type
+        "title": "Race"
+      },
+    },
+    "filters": { // required; details facet configuration for the Data Explorer
+      "tabs": [ // required; divides facets into tabs
+        {
+          "title": "Diagnosis", // required; title of the tab
+          "fields": [ // GraphQL fields (node attributes) to list out facets
+            "diastolic_blood_pressure",
+            "systolic_blood_pressure",
+          ]
+        },
+        {
+          "title": "Case",
+          "fields": [
+            "project_id",
+            "race",
+            "ethnicity",
+            "gender",
+            "bmi",
+            "age_at_index"
+          ]
+        }
+      ]
+    },
+    "table": { // required; configuration for Data Explorer table
+      "enabled": true, // required; indicates if the table should be enabled or not by default
+      "fields": [ // required; fields (node attributes) to include to be displayed in the table
+        "project_id",
+        "race",
+        "ethnicity",
+        "gender",
+        "bmi",
+        "age_at_index",
+        "diastolic_blood_pressure",
+        "systolic_blood_pressure",
+      ]
+    },
+    "dropdowns": { // optional; lists dropdowns if you want to combine multiple buttons into one dropdown (ie. Download dropdown has Download Manifest and Download Clinical Data as options)
+      "download": { // required; id of dropdown button
+        "title": "Download" // required; title of dropdown button
+      }
+    },
+    "buttons": [ // required; buttons for Data Explorer
+      {
+        "enabled": true, // required; if the button is enabled or disabled
+        "type": "data", // required; button type - what should it do? Data = downloading clinical data
+        "title": "Download All Clinical", // required; title of button
+        "leftIcon": "user", // optional; icon on left from /img/icons
+        "rightIcon": "download", // optional; icon on right from /img/icons
+        "fileName": "clinical.json", // required; file name when it is downloaded
+        "dropdownId": "download" // optional; if putting into a dropdown, the dropdown id
+      },
+      {
+        "enabled": true,
+        "type": "manifest", // required; manifest = create file manifest type
+        "title": "Download Manifest",
+        "leftIcon": "datafile",
+        "rightIcon": "download",
+        "fileName": "manifest.json",
+        "dropdownId": "download"
+      },
+      {
+        "enabled": true,
+        "type": "export", // required; export = export to Terra type
+        "title": "Export All to Terra",
+        "rightIcon": "external-link"
+      },
+      {
+        "enabled": true,
+        "type": "export-to-pfb", // required; export-to-pfb = export to PFB type
+        "title": "Export to PFB",
+        "leftIcon": "datafile",
+        "rightIcon": "download"
+      },
+      {
+        "enabled": true,
+        "type": "export-to-workspace", // required; export-to-workspace = export to workspace type
+        "title": "Export to Workspace",
+        "leftIcon": "datafile",
+        "rightIcon": "download"
+      }
+    ],
+    "guppyConfig": { // required; how to configure Guppy to work with the Data Explorer
+      "dataType": "case", // required; must match the index “type” in the guppy configuration block in the manifest.json
+      "nodeCountTitle": "Cases", // required; plural of root node
+      "fieldMapping": [ // optional; a way to rename GraphQL fields to be more human readable
+        { "field": "consent_codes", "name": "Data Use Restriction" },
+        { "field": "bmi", "name": "BMI" }
+      ],
+      "manifestMapping": { // optional; how to configure the mapping between cases/subjects/participants and files. This is used to export or download files that are associated with a cohort. It is basically joining two indices on specific GraphQL fields
+        "resourceIndexType": "file", // required; what is the type of the index (must match the guppy config block in manifest.json) that contains the resources you want a manifest of?
+        "resourceIdField": "object_id", // required; what is the identifier in the manifest index that you want to grab?
+        "referenceIdFieldInResourceIndex": "case_id", // required; what is the field in the manifest index you want to make sure matches a field in the cohort?
+        "referenceIdFieldInDataIndex": "case_id" // required; what is the field in the case/subject/participant index you are using to match with a field in the manifest index?
+      },
+      "accessibleFieldCheckList": ["project_id"], // optional; only useful when tiered access is enabled (tier_access_level=regular). When tiered access is on, portal needs to perform some filtering to display data explorer UI components according to user’s accessibility. Guppy will make queries for each of the fields listed in this array and figure out for each fields, what values are accessible to the current user and what values are not.
+      "accessibleValidationField": "project_id" // optional; only useful when tiered access is enabled (tier_access_level=regular). This value should be selected from the “accessibleFieldCheckList” variable. Portal will use this field to check against the result returned from Guppy with “accessibleFieldCheckList” to determine if user has selected any unaccessible values on the UI, and changes UI appearance accordingly.
+    },
+    "getAccessButtonLink": "https://dbgap.ncbi.nlm.nih.gov/", // optional; for tiered access, if a user wants to get access to the data sets what site should they visit?
+    "terraExportURL": "https://bvdp-saturn-dev.appspot.com/#import-data" // optional; if exporting to Terra which URL should we use?
+  },
+  "fileExplorerConfig": { // optional; configuration for the File Explorer
+    "charts": { // optional; indicates which charts to display in the File Explorer
+      "data_type": { // required; GraphQL field to query for a chart (ex: this one will display a bar chart for data types of the files in the cohort)
+        "chartType": "stackedBar", // required; chart type of stack bar
+        "title": "File Type" // required; title of chart
+      },
+      "data_format": {
+        "chartType": "stackedBar",
+        "title": "File Format"
+      }
+    },
+    "filters": { // required; details facet configuration for the File Explorer
+      "tabs": [ // required; divides facets into tabs
+        {
+          "title": "File", // required; title of the tab
+          "fields": [ // required; GraphQL fields (node attributes) to list out facets
+            "project_id",
+            "data_type",
+            "data_format"
+          ]
+        }
+      ]
+    },
+    "table": { // required; configuration for File Explorer table
+      "enabled": true, // required; indicates if the table should be enabled by default
+      "fields": [ // required; fields (node attributes) to include to be displayed in the table
+        "project_id",
+        "file_name",
+        "file_size",
+        "object_id"
+      ]
+    },
+    "guppyConfig": { // required; how to configure Guppy to work with the File Explorer
+      "dataType": "file", // required; must match the index “type” in the guppy configuration block in the manifest.json
+      "fieldMapping": [ // optional; a way to rename GraphQL fields to be more human readable
+        { "field": "object_id", "name": "GUID" } // required; the file index should always include this one
+      ],
+      "nodeCountTitle": "Files", // required; plural of root node
+      "manifestMapping": { // optional; how to configure the mapping between cases/subjects/participants and files. This is used to export or download files that are associated with a cohort. It is basically joining two indices on specific GraphQL fields
+        "resourceIndexType": "case", // required; joining this index with the case index
+        "resourceIdField": "case_id", // required; which field should is the main identifier in the other index?
+        "referenceIdFieldInResourceIndex": "object_id", // required; which field should we join on in the other index?
+        "referenceIdFieldInDataIndex": "object_id" // required; which field should we join on in the current index?
+      },
+      "accessibleFieldCheckList": ["project_id"],
+      "accessibleValidationField": "project_id",
+      "downloadAccessor": "object_id" // required; for downloading a file, what is the GUID? This should probably not change
+    },
+    "buttons": [ // required; buttons for File Explorer
+      {
+        "enabled": true, // required; determines if the button is enabled or disabled
+        "type": "file-manifest", // required; button type - file-manifest is for downloading a manifest from the file index
+        "title": "Download Manifest", // required; title of the button
+        "leftIcon": "datafile", // optional; button’s left icon
+        "rightIcon": "download", // optional; button’s right icon
+        "fileName": "file-manifest.json", // required; name of downloaded file
+      },
+      {
+        "enabled": true,
+        "type": "export-files-to-workspace", // required; this type is for export files to the workspace from the File Explorer
+        "title": "Export to Workspace",
+        "leftIcon": "datafile",
+        "rightIcon": "download"
+      }
+    ],
+    "dropdowns": {} // optional; dropdown groupings for buttons
+  },
+  "useArboristUI": false, // optional; set true to enable arborist UI; defaults to false if absent
+  "showArboristAuthzOnProfile": false, // optional; set true to list arborist resources on profile page
+  "showFenceAuthzOnProfile": true, // optional; set false to not list fence project access on profile page
+  "componentToResourceMapping": { // optional; configure some parts of arborist UI
+    "Workspace": { // name of component as defined in this file
+      "resource": "/workspace", // ABAC fields defining permissions required to see this component
+      "method": "access",
+      "service": "jupyterhub"
+    },
+    "Analyze Data": {
+      "resource": "/workspace",
+      "method": "access",
+      "service": "jupyterhub"
+    },
+    "Query": {
+      "resource": "/query_page",
+      "method": "access",
+      "service": "query_page"
+    },
+    "Query Data": {
+      "resource": "/query_page",
+      "method": "access",
+      "service": "query_page"
+    }
+  }
+}
+```

--- a/src/GuppyDataExplorer/GuppyExplorer.css
+++ b/src/GuppyDataExplorer/GuppyExplorer.css
@@ -4,6 +4,7 @@
 
 .guppy-explorer__tabs {
   display: flex;
+  flex-wrap: wrap-reverse;
 }
 
 .guppy-explorer__tab {

--- a/src/GuppyDataExplorer/index.jsx
+++ b/src/GuppyDataExplorer/index.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import _ from 'lodash';
 import PropTypes from 'prop-types';
 import GuppyDataExplorer from './GuppyDataExplorer';
 import { guppyUrl, tierAccessLevel, tierAccessLimit, explorerConfig, dataAvailabilityToolConfig } from '../localconf';
@@ -8,8 +9,15 @@ import './GuppyExplorer.css';
 class Explorer extends React.Component {
   constructor(props) {
     super(props);
+    const tabIndex = (props.location.pathname === '/files') ? _.findIndex(explorerConfig, (config) => {
+      // find file tab index from config array using guppyConfig.dataType
+      if (config.guppyConfig && config.guppyConfig.dataType) {
+        return config.guppyConfig.dataType === 'file';
+      }
+      return false;
+    }) : 0;
     this.state = {
-      tab: 0,
+      tab: tabIndex,
     };
     this.onTabClick = this.onTabClick.bind(this);
   }
@@ -19,7 +27,8 @@ class Explorer extends React.Component {
   }
 
   render() {
-    if (explorerConfig.length === 0) {
+    // if no configs or comes from '/files' but there is no file tab
+    if (explorerConfig.length === 0 || this.state.tab === -1) {
       return <React.Fragment />;
     }
 
@@ -88,6 +97,7 @@ class Explorer extends React.Component {
 
 Explorer.propTypes = {
   history: PropTypes.object.isRequired, // inherited from ProtectedContent
+  location: PropTypes.object.isRequired,
 };
 
 export default Explorer;

--- a/src/GuppyDataExplorer/index.jsx
+++ b/src/GuppyDataExplorer/index.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import _ from 'lodash';
 import PropTypes from 'prop-types';
 import GuppyDataExplorer from './GuppyDataExplorer';
-import { guppyUrl, tierAccessLevel, tierAccessLimit, explorerConfig, dataAvailabilityToolConfig } from '../localconf';
+import { guppyUrl, tierAccessLevel, tierAccessLimit, explorerConfig, dataAvailabilityToolConfig, useNewExplorerConfigFormat } from '../localconf';
 import { capitalizeFirstLetter } from '../utils';
 import './GuppyExplorer.css';
 
@@ -60,6 +60,17 @@ class Explorer extends React.Component {
       </React.Fragment>
     );
 
+    let heatMapConfig = null;
+    // new explorer config format, DAT config should ships with each tab
+    if (useNewExplorerConfigFormat
+      && explorerConfig[this.state.tab].dataAvailabilityToolConfig) {
+      heatMapConfig = explorerConfig[this.state.tab].dataAvailabilityToolConfig;
+    }
+    // old explorer config format, standalone DAT config
+    if (!useNewExplorerConfigFormat && dataAvailabilityToolConfig) {
+      heatMapConfig = this.state.tab === 0 ? dataAvailabilityToolConfig : null;
+    }
+
     return (
       <div className='guppy-explorer'>
         {
@@ -73,7 +84,7 @@ class Explorer extends React.Component {
             chartConfig={explorerConfig[this.state.tab].charts}
             filterConfig={explorerConfig[this.state.tab].filters}
             tableConfig={explorerConfig[this.state.tab].table}
-            heatMapConfig={this.state.tab === 0 ? dataAvailabilityToolConfig : null}
+            heatMapConfig={heatMapConfig}
             guppyConfig={{ path: guppyUrl, ...explorerConfig[this.state.tab].guppyConfig }}
             buttonConfig={{
               buttons: explorerConfig[this.state.tab].buttons,

--- a/src/GuppyDataExplorer/index.jsx
+++ b/src/GuppyDataExplorer/index.jsx
@@ -5,58 +5,6 @@ import { guppyUrl, tierAccessLevel, tierAccessLimit, explorerConfig, dataAvailab
 import { capitalizeFirstLetter } from '../utils';
 import './GuppyExplorer.css';
 
-// const defaultConfig = {
-//   charts: {},
-//   filters: { tabs: [] },
-//   table: {
-//     enabled: true,
-//     fields: [],
-//   },
-//   guppyConfig: {
-//     dataType: 'subject',
-//     fieldMapping: [],
-//     manifestMapping: {
-//       resourceIndexType: 'file',
-//       resourceIdField: 'file_id', // TODO: change to object_id
-//       referenceIdFieldInResourceIndex: 'subject_id',
-//       referenceIdFieldInDataIndex: 'subject_id', // TODO: change to node_id
-//     },
-//   },
-//   buttons: [],
-//   dropdowns: {},
-// };
-
-// const defaultFileConfig = {
-//   charts: {},
-//   filters: { tabs: [] },
-//   table: {
-//     enabled: true,
-//     fields: [],
-//   },
-//   guppyConfig: {
-//     dataType: 'file',
-//     fieldMapping: [],
-//     manifestMapping: {
-//       resourceIndexType: 'subject',
-//       resourceIdField: 'subject_id',
-//       referenceIdFieldInResourceIndex: 'file_id', // TODO: change to object_id
-//       referenceIdFieldInDataIndex: 'file_id', // TODO: change to object_id
-//     },
-//   },
-//   buttons: [],
-//   dropdowns: {},
-// };
-
-// const guppyExplorerConfig = [
-//   _.merge(defaultConfig, config.dataExplorerConfig),
-//   _.merge(defaultFileConfig, config.fileExplorerConfig),
-// ];
-
-// const routes = [
-//   '/explorer',
-//   '/files',
-// ];
-
 class Explorer extends React.Component {
   constructor(props) {
     super(props);

--- a/src/GuppyDataExplorer/index.jsx
+++ b/src/GuppyDataExplorer/index.jsx
@@ -100,6 +100,7 @@ class Explorer extends React.Component {
             );
           })}
         </div>
+        <div className={'guppy-explorer__main'} />
       </React.Fragment>
     );
 
@@ -110,29 +111,27 @@ class Explorer extends React.Component {
             tabFragment
             : null
         }
-        <div className={'guppy-explorer__main'}>
-          <GuppyDataExplorer
-            adminAppliedPreFilters={explorerConfig[this.state.tab].adminAppliedPreFilters}
-            chartConfig={explorerConfig[this.state.tab].charts}
-            filterConfig={explorerConfig[this.state.tab].filters}
-            tableConfig={explorerConfig[this.state.tab].table}
-            heatMapConfig={this.state.tab === 0 ? dataAvailabilityToolConfig : null}
-            guppyConfig={{ path: guppyUrl, ...explorerConfig[this.state.tab].guppyConfig }}
-            buttonConfig={{
-              buttons: explorerConfig[this.state.tab].buttons,
-              dropdowns: explorerConfig[this.state.tab].dropdowns,
-              terraExportURL: explorerConfig[this.state.tab].terraExportURL,
-              terraTemplate: explorerConfig[this.state.tab].terraTemplate,
-            }}
-            history={this.props.history}
-            tierAccessLevel={tierAccessLevel}
-            tierAccessLimit={tierAccessLimit}
-            getAccessButtonLink={explorerConfig[this.state.tab].getAccessButtonLink}
-            hideGetAccessButton={explorerConfig[this.state.tab].hideGetAccessButton}
-            // the "fully uncontrolled component with a key" trick
-            key={this.state.tab}
-          />
-        </div>
+        <GuppyDataExplorer
+          adminAppliedPreFilters={explorerConfig[this.state.tab].adminAppliedPreFilters}
+          chartConfig={explorerConfig[this.state.tab].charts}
+          filterConfig={explorerConfig[this.state.tab].filters}
+          tableConfig={explorerConfig[this.state.tab].table}
+          heatMapConfig={this.state.tab === 0 ? dataAvailabilityToolConfig : null}
+          guppyConfig={{ path: guppyUrl, ...explorerConfig[this.state.tab].guppyConfig }}
+          buttonConfig={{
+            buttons: explorerConfig[this.state.tab].buttons,
+            dropdowns: explorerConfig[this.state.tab].dropdowns,
+            terraExportURL: explorerConfig[this.state.tab].terraExportURL,
+            terraTemplate: explorerConfig[this.state.tab].terraTemplate,
+          }}
+          history={this.props.history}
+          tierAccessLevel={tierAccessLevel}
+          tierAccessLimit={tierAccessLimit}
+          getAccessButtonLink={explorerConfig[this.state.tab].getAccessButtonLink}
+          hideGetAccessButton={explorerConfig[this.state.tab].hideGetAccessButton}
+          // the "fully uncontrolled component with a key" trick
+          key={this.state.tab}
+        />
       </div>
     );
   }

--- a/src/GuppyDataExplorer/index.jsx
+++ b/src/GuppyDataExplorer/index.jsx
@@ -100,7 +100,6 @@ class Explorer extends React.Component {
             );
           })}
         </div>
-        <div className={'guppy-explorer__main'} />
       </React.Fragment>
     );
 
@@ -111,27 +110,29 @@ class Explorer extends React.Component {
             tabFragment
             : null
         }
-        <GuppyDataExplorer
-          adminAppliedPreFilters={explorerConfig[this.state.tab].adminAppliedPreFilters}
-          chartConfig={explorerConfig[this.state.tab].charts}
-          filterConfig={explorerConfig[this.state.tab].filters}
-          tableConfig={explorerConfig[this.state.tab].table}
-          heatMapConfig={this.state.tab === 0 ? dataAvailabilityToolConfig : null}
-          guppyConfig={{ path: guppyUrl, ...explorerConfig[this.state.tab].guppyConfig }}
-          buttonConfig={{
-            buttons: explorerConfig[this.state.tab].buttons,
-            dropdowns: explorerConfig[this.state.tab].dropdowns,
-            terraExportURL: explorerConfig[this.state.tab].terraExportURL,
-            terraTemplate: explorerConfig[this.state.tab].terraTemplate,
-          }}
-          history={this.props.history}
-          tierAccessLevel={tierAccessLevel}
-          tierAccessLimit={tierAccessLimit}
-          getAccessButtonLink={explorerConfig[this.state.tab].getAccessButtonLink}
-          hideGetAccessButton={explorerConfig[this.state.tab].hideGetAccessButton}
-          // the "fully uncontrolled component with a key" trick
-          key={this.state.tab}
-        />
+        <div className={(explorerConfig.length > 1) ? 'guppy-explorer__main' : ''}>
+          <GuppyDataExplorer
+            adminAppliedPreFilters={explorerConfig[this.state.tab].adminAppliedPreFilters}
+            chartConfig={explorerConfig[this.state.tab].charts}
+            filterConfig={explorerConfig[this.state.tab].filters}
+            tableConfig={explorerConfig[this.state.tab].table}
+            heatMapConfig={this.state.tab === 0 ? dataAvailabilityToolConfig : null}
+            guppyConfig={{ path: guppyUrl, ...explorerConfig[this.state.tab].guppyConfig }}
+            buttonConfig={{
+              buttons: explorerConfig[this.state.tab].buttons,
+              dropdowns: explorerConfig[this.state.tab].dropdowns,
+              terraExportURL: explorerConfig[this.state.tab].terraExportURL,
+              terraTemplate: explorerConfig[this.state.tab].terraTemplate,
+            }}
+            history={this.props.history}
+            tierAccessLevel={tierAccessLevel}
+            tierAccessLimit={tierAccessLimit}
+            getAccessButtonLink={explorerConfig[this.state.tab].getAccessButtonLink}
+            hideGetAccessButton={explorerConfig[this.state.tab].hideGetAccessButton}
+            // the "fully uncontrolled component with a key" trick
+            key={this.state.tab}
+          />
+        </div>
       </div>
     );
   }

--- a/src/localconf.js
+++ b/src/localconf.js
@@ -100,11 +100,9 @@ function buildConfig(opts) {
   }
 
   let useGuppyForExplorer = false;
-  if (config.dataExplorerConfig.guppyConfig) {
-    useGuppyForExplorer = true;
-  }
 
   let explorerConfig = [];
+  let useNewExplorerConfigFormat = false;
   // for backward compatibilities
   if (config.dataExplorerConfig) {
     explorerConfig.push(
@@ -113,6 +111,9 @@ function buildConfig(opts) {
         ...config.dataExplorerConfig,
       },
     );
+    if (config.dataExplorerConfig.guppyConfig) {
+      useGuppyForExplorer = true;
+    }
   }
   if (config.fileExplorerConfig) {
     explorerConfig.push(
@@ -121,11 +122,13 @@ function buildConfig(opts) {
         ...config.fileExplorerConfig,
       },
     );
+    useGuppyForExplorer = true;
   }
 
   // new explorer config format
   if (config.explorerConfig) {
     useGuppyForExplorer = true;
+    useNewExplorerConfigFormat = true;
     explorerConfig = config.explorerConfig;
   }
 
@@ -334,6 +337,7 @@ function buildConfig(opts) {
     enableResourceBrowser,
     resourceBrowserPublic,
     explorerConfig,
+    useNewExplorerConfigFormat,
     dataAvailabilityToolConfig,
   };
 }

--- a/src/localconf.js
+++ b/src/localconf.js
@@ -104,6 +104,33 @@ function buildConfig(opts) {
     useGuppyForExplorer = true;
   }
 
+  let explorerConfig = [];
+  // for backward compatibilities
+  if (config.dataExplorerConfig) {
+    explorerConfig.push(
+      {
+        tabTitle: 'Data',
+        ...config.dataExplorerConfig,
+      },
+    );
+  }
+  if (config.fileExplorerConfig) {
+    explorerConfig.push(
+      {
+        tabTitle: 'File',
+        ...config.fileExplorerConfig,
+      },
+    );
+  }
+
+  // new explorer config format
+  if (config.explorerConfig) {
+    useGuppyForExplorer = true;
+    explorerConfig = config.explorerConfig;
+  }
+
+  const dataAvailabilityToolConfig = config.dataAvailabilityToolConfig;
+
   let showArboristAuthzOnProfile = false;
   if (config.showArboristAuthzOnProfile) {
     showArboristAuthzOnProfile = config.showArboristAuthzOnProfile;
@@ -306,6 +333,8 @@ function buildConfig(opts) {
     authzMappingPath,
     enableResourceBrowser,
     resourceBrowserPublic,
+    explorerConfig,
+    dataAvailabilityToolConfig,
   };
 }
 


### PR DESCRIPTION
This PR fulfills https://occ-data.atlassian.net/browse/COV-78

Allow Guppy Data Explorer to render multiple tabs as configured in the configuration file, each tab will be serving from one ES index

Deployed at https://mingfei.planx-pla.net/explorer

Added new config `explorerConfig` to repleace existing `dataExplorerConfig` and `fileExplorerConfig`

`explorerConfig` is an array which contains multiple configs (one for each explorer tab), e.g.:

``` 
"explorerConfig":[
    {                                       ---> 1st tab
      "tabTitle": "Data",         ---> optional tab title, if omitted, will default to use the value of guppyConfig.dataType of this tab
      "charts": {
        "project_id": {
          "chartType": "count",
          "title": "Projects"
        },
        ...
      },
      "filters": {
        "tabs": [
          {
            "title": "Case",
            "fields": [
              "project_id",
              ...
            ]
          }
        ]
      },
      "table": {
        "enabled": true,
        "fields": [
          "project_id",
          ...
        ]
      },
      "guppyConfig": {
        "dataType": "case",
        "nodeCountTitle": "Cases",
        "fieldMapping": [
          {"field": "_aliquots_count", "name": "Aliquots Count"},
          ....
        ],
        "manifestMapping": {
          "resourceIndexType": "file",
          "resourceIdField": "object_id",
          "referenceIdFieldInResourceIndex": "case_id",
          "referenceIdFieldInDataIndex": "case_id"
        },
        "accessibleFieldCheckList": ["project_id"],
        "accessibleValidationField": "project_id"
      },
      "buttons": [
         ....
      ]
    },
    {                                                  ---> 2nd tab
      "charts": {
        "data_type": {
          "chartType": "stackedBar",
          "title": "File Type"
        },
        ...
      },
      "filters": {
        ...
      },
      "table": {
        "enabled": true,
        "fields": [
          "project_id",
          ...
        ]
      },
      "guppyConfig": {
        "dataType": "file",
        "fieldMapping": [
          { "field": "object_id", "name": "GUID" }
        ],
        "nodeCountTitle": "Files",
        "manifestMapping": {
          "resourceIndexType": "case",
          "resourceIdField": "case_id",
          "referenceIdFieldInResourceIndex": "object_id",
          "referenceIdFieldInDataIndex": "object_id"
        },
        "accessibleFieldCheckList": ["project_id"],
        "accessibleValidationField": "project_id",
        "downloadAccessor": "object_id"
      },
      "buttons": [
        {
          "enabled": true,
          "type": "file-manifest",
          "title": "Download Manifest",
          "leftIcon": "datafile",
          "rightIcon": "download",
          "fileName": "file-manifest.json"
        }
      ],
      "dropdowns": {}
    },
    {                                     ---> 3rd tab
      "charts": {
           ...
      },
      "filters": {
        "tabs": [
          {
            "title": "Subject",
            "fields": [
              "project_id",
              "subject_id"
            ]
          }
        ]
      },
      "table": {
        "enabled": true,
        "fields": [
          "project_id",
          "subject_id"
        ]
      },
      "guppyConfig": {
        "dataType": "subject",
        "fieldMapping": [
        ],
        "nodeCountTitle": "Subjects",
        "manifestMapping": {
        },
        "accessibleFieldCheckList": ["project_id"],
        "accessibleValidationField": "project_id"
      },
      "buttons": [
      ],
      "dropdowns": {}
    }
  ]
```

### New Features
- Multi-tab data explorer

### Deployment Changes
- New `explorerConfig` which can take configs for multiple tabs, backward compatiable with current `dataExplorerConfig` and `fileExplorerConfig`

### Improvements
- Updated format for data explorer config 
- Decoupled file explorer from data explorer
