### PR TITLE
Feat/explorerlink

### DIFF
--- a/docs/multi_tab_explorer.md
+++ b/docs/multi_tab_explorer.md
@@ -36,8 +36,10 @@ An example of this new `explorerConfig` is (some contents are omitted for concis
         "enabled": true,
         "fields": [
           "project_id",
+          "url",
           ...
-        ]
+        ],
+        "linkFields": [ "url" ]
       },
       "guppyConfig": {
         "dataType": "case",

--- a/docs/portal_config.md
+++ b/docs/portal_config.md
@@ -207,6 +207,10 @@ Below is an example, with inline comments describing what each JSON block config
         "age_at_index",
         "diastolic_blood_pressure",
         "systolic_blood_pressure",
+        "url"
+      ],
+      "linkFields": [ // optional; fields (must exist in "field" list above) to display as clickable buttons
+        "url"
       ]
     },
     "dropdowns": { // optional; lists dropdowns if you want to combine multiple buttons into one dropdown (ie. Download dropdown has Download Manifest and Download Clinical Data as options)

--- a/src/GuppyDataExplorer/ExplorerTable/ExplorerTable.css
+++ b/src/GuppyDataExplorer/ExplorerTable/ExplorerTable.css
@@ -48,3 +48,35 @@
 .explorer-table .ReactTable .rt-tbody .rt-td:first-child {
   padding-left: 20px;
 }
+
+.explorer-table-link-button svg {
+  width: 15px;
+  height: 15px;
+  top: -7px;
+  position: relative;
+}
+
+.explorer-table-link-button svg, .explorer-table-link-button svg path {
+  color: #606060;
+  fill: #606060;
+  transition: color .2s, fill.2s;
+  --webkit-transition: color .2s, fill.2s;
+  display: block;
+  margin: auto;
+}
+
+.explorer-table-link-button {
+  border: solid #606060 1px;
+  transition: border-color .2s;
+  --webkit-transition: border-color .2s;
+  width: 40px;
+}
+
+.explorer-table-link-button:hover {
+  border-color: #3283c8;
+}
+
+.explorer-table-link-button:hover svg path, .explorer-table-link-button:hover svg {
+  color: #3283c8;
+  fill: #3283c8;
+}

--- a/src/GuppyDataExplorer/ExplorerTable/ExplorerTable.css
+++ b/src/GuppyDataExplorer/ExplorerTable/ExplorerTable.css
@@ -50,8 +50,6 @@
 }
 
 .explorer-table-link-button svg {
-  width: 15px;
-  height: 15px;
   top: -7px;
   position: relative;
 }
@@ -70,6 +68,7 @@
   transition: border-color .2s;
   --webkit-transition: border-color .2s;
   width: 40px;
+  height: auto;
 }
 
 .explorer-table-link-button:hover {

--- a/src/GuppyDataExplorer/ExplorerTable/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerTable/index.jsx
@@ -2,10 +2,12 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import ReactTable from 'react-table';
 import 'react-table/react-table.css';
+import IconicLink from '../../components/buttons/IconicLink';
 import { GuppyConfigType, TableConfigType } from '../configTypeDef';
 import { capitalizeFirstLetter, humanFileSize } from '../../utils';
 import './ExplorerTable.css';
 import LockIcon from '../../img/icons/lock.svg';
+import dictIcons from '../../img/icons/index';
 
 class ExplorerTable extends React.Component {
   constructor(props) {
@@ -18,6 +20,10 @@ class ExplorerTable extends React.Component {
   }
 
   getWidthForColumn = (field, columnName) => {
+    if (this.props.tableConfig.linkFields.includes(field)) {
+      return 80;
+    }
+
     // some magic numbers that work fine for table columns width
     const minWidth = 100;
     const maxWidth = 400;
@@ -61,7 +67,10 @@ class ExplorerTable extends React.Component {
   };
 
   render() {
-    if (!this.props.tableConfig.fields || this.props.tableConfig.fields.length === 0) return null;
+    if (!this.props.tableConfig.fields || this.props.tableConfig.fields.length === 0) {
+      return null;
+    }
+
     const columnsConfig = this.props.tableConfig.fields.map((field) => {
       const fieldMappingEntry = this.props.guppyConfig.fieldMapping
         && this.props.guppyConfig.fieldMapping.find(i => i.field === field);
@@ -77,6 +86,19 @@ class ExplorerTable extends React.Component {
             return (<div><span title={row.value}><a href={`/files/${row.value}`}>{row.value}</a></span></div>);
           case 'file_size':
             return (<div><span title={row.value}>{humanFileSize(row.value)}</span></div>);
+          case this.props.tableConfig.linkFields.includes(field) && field:
+            return row.value ?
+              <IconicLink
+                link={row.value}
+                className='explorer-table-link'
+                buttonClassName='explorer-table-link-button'
+                icon='exit'
+                dictIcons={dictIcons}
+                iconColor='#606060'
+                target='_blank'
+                isExternal
+              />
+              : null;
           default:
             return (<div><span title={row.value}>{row.value}</span></div>);
           }

--- a/src/GuppyDataExplorer/ExplorerVisualization/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerVisualization/index.jsx
@@ -225,7 +225,10 @@ class ExplorerVisualization extends React.Component {
           this.props.tableConfig.enabled && (
             <ExplorerTable
               className='guppy-explorer-visualization__table'
-              tableConfig={{ fields: tableColumns }}
+              tableConfig={{
+                fields: tableColumns,
+                linkFields: this.props.tableConfig.linkFields || [],
+              }}
               fetchAndUpdateRawData={this.props.fetchAndUpdateRawData}
               rawData={this.props.rawData}
               totalCount={this.props.totalCount}

--- a/src/components/buttons/IconicLink.jsx
+++ b/src/components/buttons/IconicLink.jsx
@@ -5,11 +5,9 @@ import IconComponent from '../Icon';
 
 
 class IconicLink extends React.Component {
-  render() {
-    let styles = {};
-    if (this.props.iconColor && this.props.iconColor !== '') { styles = { fill: this.props.iconColor }; }
+  renderButton(styles) {
     return (
-      <Link className={this.props.className} to={this.props.link}>
+      <React.Fragment>
         {
           this.props.dictIcons !== undefined ?
             <button className={this.props.buttonClassName}>
@@ -25,6 +23,23 @@ class IconicLink extends React.Component {
               {this.props.caption}
             </button>
         }
+      </React.Fragment>
+    );
+  }
+
+  render() {
+    let styles = {};
+    if (this.props.iconColor && this.props.iconColor !== '') { styles = { fill: this.props.iconColor }; }
+    if (this.props.isExternal) {
+      return (
+        <a href={this.props.link} target={this.props.target} className={this.props.className}>
+          { this.renderButton(styles) }
+        </a>
+      );
+    }
+    return (
+      <Link className={this.props.className} to={this.props.link} target={this.props.target}>
+        { this.renderButton(styles) }
       </Link>
     );
   }
@@ -38,6 +53,8 @@ IconicLink.propTypes = {
   caption: PropTypes.string,
   buttonClassName: PropTypes.string,
   className: PropTypes.string,
+  target: PropTypes.string,
+  isExternal: PropTypes.bool,
 };
 
 IconicLink.defaultProps = {
@@ -47,6 +64,8 @@ IconicLink.defaultProps = {
   caption: '',
   buttonClassName: 'button-primary-white',
   className: '',
+  target: '',
+  isExternal: false,
 };
 
 export default IconicLink;


### PR DESCRIPTION
![Screen Shot 2020-05-06 at 5 49 34 PM](https://user-images.githubusercontent.com/4224001/81236146-24ad8380-8fc2-11ea-8fa3-ca2f33ef1204.png)

Reused code written for the NDE dataset browser (see https://github.com/uc-cdis/data-ecosystem-portal and https://niaiddata.org/datasets), except a bit more general to allow configuring multiple fields as links

### New Features
- Ability to display clickable buttons in an Explorer table ("explorerConfig.table.linkFields" configuration variable)

