### PR TITLE
fix: use date + time instead of just date

### DIFF
--- a/src/Covid19Dashboard/IllinoisMapChart/index.jsx
+++ b/src/Covid19Dashboard/IllinoisMapChart/index.jsx
@@ -84,7 +84,12 @@ class IllinoisMapChart extends React.Component { // eslint-disable-line react/no
       hoverInfo: null,
       selectedDate: props.rawData && props.rawData[0] ?
         new Date(Math.max.apply(
-          null, props.rawData[0].date.map(date => new Date(date)),
+          null, props.rawData[0].date.map((date) => {
+            if (date.includes('T')) {
+              return new Date(date);
+            }
+            return new Date(date.concat('T00:00:00'));
+          }),
         ))
         : null,
       selectedLocation: null,
@@ -101,7 +106,12 @@ class IllinoisMapChart extends React.Component { // eslint-disable-line react/no
         {
           selectedDate: nextProps.rawData && nextProps.rawData[0] ?
             new Date(Math.max.apply(
-              null, nextProps.rawData[0].date.map(date => new Date(date)),
+              null, nextProps.rawData[0].date.map((date) => {
+                if (date.includes('T')) {
+                  return new Date(date);
+                }
+                return new Date(date.concat('T00:00:00'));
+              }),
             ))
             : null,
         },

--- a/src/Covid19Dashboard/WorldMapChart/index.jsx
+++ b/src/Covid19Dashboard/WorldMapChart/index.jsx
@@ -113,7 +113,12 @@ class WorldMapChart extends React.Component {
       },
       hoverInfo: null,
       selectedDate: props.rawData && props.rawData[0] ?
-        new Date(Math.max.apply(null, props.rawData[0].date.map(date => new Date(date))))
+        new Date(Math.max.apply(null, props.rawData[0].date.map((date) => {
+          if (date.includes('T')) {
+            return new Date(date);
+          }
+          return new Date(date.concat('T00:00:00'));
+        })))
         : null,
     };
   }
@@ -127,7 +132,12 @@ class WorldMapChart extends React.Component {
       this.setState({
         selectedDate: nextProps.rawData && nextProps.rawData[0] ?
           new Date(Math.max.apply(
-            null, nextProps.rawData[0].date.map(date => new Date(date)),
+            null, nextProps.rawData[0].date.map((date) => {
+              if (date.includes('T')) {
+                return new Date(date);
+              }
+              return new Date(date.concat('T00:00:00'));
+            }),
           ))
           : null,
       });

--- a/src/Covid19Dashboard/index.jsx
+++ b/src/Covid19Dashboard/index.jsx
@@ -68,7 +68,12 @@ class Covid19Dashboard extends React.Component {
     let selectedDate = new Date();
     if (this.props.rawData.length > 0) {
       selectedDate = new Date(Math.max.apply(
-        null, this.props.rawData[0].date.map(date => new Date(date)),
+        null, this.props.rawData[0].date.map((date) => {
+          if (date.includes('T')) {
+            return new Date(date);
+          }
+          return new Date(date.concat('T00:00:00'));
+        }),
       ));
     }
     const confirmedCount = {


### PR DESCRIPTION
Fixed an error caused by parsing Date incorrectly, which leads to a blank homepage

When creating a Date with no time values, the computed date will be relative to browser's time zone. Which means `new Date("2020-05-10")` will yield `Sat May 09 2020 19:00:00 GMT-0500 (Central Daylight Time)`, in here `2020-05-10` is be treated as a UTC time.

But if a time is giving in date/time pair, the computed date woill NOT do time zone conversion under the table, so `new Date("2020-05-10T00:00:00")` yields `Sun May 10 2020 00:00:00 GMT-0500 (Central Daylight Time)`

Ref: https://www.w3schools.com/js/js_date_formats.asp
https://stackoverflow.com/a/38050824

### Bug Fixes
- Fixed an error caused by parsing Date incorrectly, which leads to a blank homepage



