### PR TITLE
(PXP-5597) Export to Seven Bridges

### DIFF
--- a/src/GuppyDataExplorer/ExplorerButtonGroup/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerButtonGroup/index.jsx
@@ -50,7 +50,7 @@ class ExplorerButtonGroup extends React.Component {
               toasterOpen: false,
               exportingToCloud: false,
             }, () => {
-              this.sendPFBToCloud();
+              this.sendPFBToTerra();
             });
           } else if (this.state.exportingToSevenBridges) {
             this.setState({
@@ -94,10 +94,10 @@ class ExplorerButtonGroup extends React.Component {
       // REMOVE THIS CODE WHEN TERRA EXPORT WORKS
       // =======================================
       if (terraExportWarning) {
-        clickFunc = this.exportToCloudWithTerraWarning;
+        clickFunc = this.exportToTerraWithWarning;
       } else {
       // =======================================
-        clickFunc = this.exportToCloud;
+        clickFunc = this.exportToTerra;
       }
     }
     if (buttonConfig.type === 'export-to-seven-bridges') {
@@ -304,20 +304,19 @@ class ExplorerButtonGroup extends React.Component {
   // (Warn user about Terra entitiy threshold). This code should be removed when
   // Terra is no longer limited to importing <165,000 entities. (~14k subjects).
   // This file is the only file that contains code for this feature.
-  exportToCloudWithTerraWarning = () => {
+  exportToTerraWithWarning = () => {
     // If the number of subjects is over the threshold, warn the user that their
     // export to Terra job might fail.
     if (this.props.totalCount >= terraExportWarning.subjectThreshold) {
       this.setState({ enableTerraWarningPopup: true });
     } else {
       // If the number is below the threshold, proceed as normal
-      this.exportToCloud();
+      this.exportToTerra();
     }
   }
   // ==========================================
 
-  // NOTE(@mpingram) -- rename to `exportToTerra`
-  exportToCloud = () => {
+  exportToTerra = () => {
     this.setState({ exportingToCloud: true }, () => {
       this.exportToPFB();
     });
@@ -329,7 +328,7 @@ class ExplorerButtonGroup extends React.Component {
     });
   }
 
-  sendPFBToCloud = () => {
+  sendPFBToTerra = () => {
     const url = encodeURIComponent(this.state.exportPFBURL);
     let templateParam = '';
     if (typeof this.props.buttonConfig.terraTemplate !== 'undefined'
@@ -556,7 +555,7 @@ class ExplorerButtonGroup extends React.Component {
                   caption: 'Yes, Export Anyway',
                   fn: () => {
                     this.setState({ enableTerraWarningPopup: false });
-                    this.exportToCloud();
+                    this.exportToTerra();
                   },
                   icon: 'external-link',
                 },

--- a/src/GuppyDataExplorer/ExplorerButtonGroup/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerButtonGroup/index.jsx
@@ -474,8 +474,23 @@ class ExplorerButtonGroup extends React.Component {
       // disable the pfb export button if any other pfb export jobs are running
       return !(this.state.exportingToTerra || this.state.exportingToSevenBridges);
     }
-    if (buttonConfig.type === 'export' || buttonConfig.type === 'export-to-seven-bridges') {
-      // disable the terra export and seven bridges export buttons if any of the
+    if (buttonConfig.type === 'export') {
+      if (!this.props.buttonConfig.terraExportURL) {
+        console.error('Export to Terra button is present, but there is no `terraExportURL` specified in the portal config. Disabling the export to Terra button.');
+        return false;
+      }
+      // disable the terra export button if any of the
+      // pfb export operations are running.
+      return !(this.state.exportingToTerra
+        || this.state.exportingToSevenBridges
+        || this.isPFBRunning());
+    }
+    if (buttonConfig.type === 'export-to-seven-bridges') {
+      if (!this.props.buttonConfig.sevenBridgesExportURL) {
+        console.error('Export to Terra button is present, but there is no `terraExportURL` specified in the portal config. Disabling the export to Terra button.');
+        return false;
+      }
+      // disable the seven bridges export buttons if any of the
       // pfb export operations are running.
       return !(this.state.exportingToTerra
         || this.state.exportingToSevenBridges

--- a/src/GuppyDataExplorer/configTypeDef.js
+++ b/src/GuppyDataExplorer/configTypeDef.js
@@ -41,6 +41,9 @@ export const ButtonConfigType = PropTypes.shape({
     tooltipText: PropTypes.string,
   })),
   dropdowns: PropTypes.object,
+  terraExportURL: PropTypes.string,
+  terraTemplate: PropTypes.arrayOf(PropTypes.string),
+  sevenBridgesExportURL: PropTypes.string,
 });
 
 export const ChartConfigType = PropTypes.object;

--- a/src/GuppyDataExplorer/index.jsx
+++ b/src/GuppyDataExplorer/index.jsx
@@ -105,6 +105,7 @@ class Explorer extends React.Component {
               dropdowns: guppyExplorerConfig[this.state.tab].dropdowns,
               terraExportURL: config.dataExplorerConfig.terraExportURL,
               terraTemplate: config.dataExplorerConfig.terraTemplate,
+              sevenBridgesExportURL: config.dataExplorerConfig.sevenBridgesExportURL,
             }}
             history={this.props.history}
             tierAccessLevel={tierAccessLevel}


### PR DESCRIPTION
Adds Export to Seven Bridges button to explorer, which allows user to export a PFB to Seven Bridges' analysis platform. This feature is configured with the `export-to-seven-bridges` button type and the `sevenBridgesExportURL` parameter in the portal config. 

### New Features
- Added Export to Seven Bridges button, allowing user to export a PFB to Seven Bridges.

### Dependency updates
- Adds new button type `export-to-seven-bridges` to portal config `dataExplorerConfig.buttons.` Example:
```
      {
        "enabled": true,
        "type": "export-to-seven-bridges",
        "title": "Export All to Seven Bridges",
        "rightIcon": "external-link"
      },
``` 
- Adds new parameter `dataExplorerConfig.sevenBridgesExportURL` to portal config, which specifies the URL belonging to Seven Bridges that portal should redirect to. Portal appends the signed url to this URL with a query param (`&PFB=<signed url>`). Example:
```
 "sevenBridgesExportURL": "https://windmill.sbgenomics.com/import/windmill"
```

### Deployment changes

