### PR TITLE
fix(dev-server): allow more space to run webpack-dev-server

### DIFF
--- a/runWebpack.sh
+++ b/runWebpack.sh
@@ -157,6 +157,7 @@ export REACT_APP_DISABLE_SOCKET=true
 # run webpack to generate a static bundle.js
 #
 if [[ "$NODE_ENV" == "dev" || "$NODE_ENV" == "auto" ]]; then
+  export NODE_OPTIONS="--max-old-space-size=4096"
   echo ./node_modules/.bin/webpack-dev-server
   ./node_modules/.bin/webpack-dev-server
 else


### PR DESCRIPTION
This PR allows `webpack-dev-server` to launch successfully without V8 crashing due to JavaScript heap out of memory error.

An alternative to this is adding `NODE_OPTIONS="--max-old-space-size=4096"` to the command when spinning up the dev server. While these two options are functionally equivalent and address the same issue, modifying the build script can lead to a more consistent developer experience in my view.

### Bug Fixes
* Set `--max-old-space-size=4096` in `/runWebpack.sh` when launching `webpack-dev-server`
