### PR TITLE
COV-274 Public data explorer

### DIFF
--- a/docs/portal_config.md
+++ b/docs/portal_config.md
@@ -153,7 +153,8 @@ Below is an example, with inline comments describing what each JSON block config
   },
   "requiredCerts": [], // optional; do users need to take a quiz or agree to something before they can access the site?
   "featureFlags": { // optional; will hide certain parts of the site if needed
-    "explorer": true // required; indicates the flag and whether to hide it or not
+    "explorer": true, // required; indicates the flag and whether to hide it or not
+    "explorerPublic": true // optional; If set to true, the data explorer page would be treated as a public component and can be accessed without login. Data explorer page would be public accessible if 1. tiered access level is set to libre OR 2. this explorerPublic flag is set to true.
   },
   "dataExplorerConfig": { // required; configuration for the Data Explorer (/explorer)
     "charts": { // optional; indicates which charts to display in the Data Explorer

--- a/src/localconf.js
+++ b/src/localconf.js
@@ -159,6 +159,9 @@ function buildConfig(opts) {
   if (tierAccessLevel === 'libre') {
     explorerPublic = true;
   }
+  if (config.featureFlags && config.featureFlags.explorerPublic) {
+    explorerPublic = true;
+  }
 
   const enableResourceBrowser = !!config.resourceBrowser;
   let resourceBrowserPublic = false;


### PR DESCRIPTION
This PR fulfills https://occ-data.atlassian.net/browse/COV-274

Added an optional flag `explorerPublic` in portal config `featureFlags`, e.g.:
>   "featureFlags": {
>     "explorer": true,
>     "explorerPublic": true,
>   }

If set to `true`, the data explorer page would be treated as a public component and can be accessed without login.
Data explorer page would be public accessiable if 1. tiered access level is set to `libre` OR 2. this new `explorerPublic` flag is set to `true`.
Tiered access logics (`libre`, `regular` or `private`) that are set for the env would still apply even if the data explorer page is public.
Backend service should have Guppy 0.4.2+ or 2020.05+ so it can handle user without JWT.

Deployed in https://mingfei.planx-pla.net/

### Improvements
- Added an optional flag `explorerPublic` in portal config `featureFlags`, if set to `true`, data explorer page would be public accessible 

### Dependency updates
- Backend service should have Guppy 0.4.2+ or 2020.05+ so it can handle user without JWT


