### PR TITLE
fix: file core metadata table; remove row when empty

### DIFF
--- a/src/CoreMetadata/CoreMetadataTable.jsx
+++ b/src/CoreMetadata/CoreMetadataTable.jsx
@@ -22,6 +22,7 @@ class CoreMetadataTable extends Component {
     Object.keys(metadata)
       .sort() // alphabetical order
       .filter(key => fieldInTable(key))
+      .filter(key => metadata[key]) // do not display row if empty
       .map(key => [
         <div className='core-metadata-table__title-cell'>{firstCharToUppercase(key)}</div>,
         metadata[key],
@@ -29,13 +30,16 @@ class CoreMetadataTable extends Component {
     : []);
 
   render() {
+    const tableData = this.dataTransform(this.props.metadata);
     return (
-      <div className='core-metadata-table'>
-        <Table
-          header={[TABLE_TITLE, '']}
-          data={this.dataTransform(this.props.metadata)}
-        />
-      </div>
+      tableData.length > 0 ?
+        <div className='core-metadata-table'>
+          <Table
+            header={[TABLE_TITLE, '']}
+            data={tableData}
+          />
+        </div>
+        : null
     );
   }
 }

--- a/src/CoreMetadata/CoreMetadataTable.less
+++ b/src/CoreMetadata/CoreMetadataTable.less
@@ -14,7 +14,6 @@
 }
 
 .core-metadata-table .base-table__cell:nth-child(1) {
-  padding-left: 0;
   text-align: left;
   width: 15%;
 }


### PR DESCRIPTION
- before:
<img width="1023" alt="Screen Shot 2020-06-08 at 5 34 11 PM" src="https://user-images.githubusercontent.com/4224001/84086949-ac662380-a9ae-11ea-9da5-44eed3fcc82a.png">

- after:
remove empty rows + remove table if completely empty + add left padding
<img width="1022" alt="Screen Shot 2020-06-08 at 5 34 26 PM" src="https://user-images.githubusercontent.com/4224001/84086955-ae2fe700-a9ae-11ea-9a52-abac63c6db78.png">

### Improvements
- File core metadata table: remove empty rows
