### PR TITLE
Fix navbar button descriptions on scroll

### DIFF
--- a/src/components/layout/NavBar.jsx
+++ b/src/components/layout/NavBar.jsx
@@ -58,7 +58,7 @@ class NavBar extends Component {
     let tooltipDetails = { content: '' };
     if (item && item.tooltip) {
       const boundsRect = this.navButtonRefs[item.link].current.getBoundingClientRect();
-      const bottomY = boundsRect.bottom;
+      const bottomY = boundsRect.bottom + window.scrollY;
       const centerX = boundsRect.x + (boundsRect.width / 2);
       tooltipDetails = {
         content: item.tooltip,


### PR DESCRIPTION
- before:
<img width="366" alt="Screen Shot 2020-06-10 at 5 46 27 PM" src="https://user-images.githubusercontent.com/4224001/84326358-55915300-ab42-11ea-9d41-aadb1220abc1.png">

- after:
<img width="403" alt="Screen Shot 2020-06-10 at 5 45 38 PM" src="https://user-images.githubusercontent.com/4224001/84326324-44484680-ab42-11ea-8554-29f7c045e5d2.png">

### Bug Fixes
- Fix navigation bar buttons descriptions when the page is scrolled
