### PR TITLE
Feat/peregrine request chunk

### DIFF
--- a/data/config/gtex.json
+++ b/data/config/gtex.json
@@ -68,6 +68,7 @@
           "label": "Run analysis"
         }
       ],
+      "homepageChartNodesChunkSize": 14,
       "homepageChartNodes": [
         {
           "node": "subject",

--- a/src/Index/utils.js
+++ b/src/Index/utils.js
@@ -1,6 +1,6 @@
 import _ from 'underscore';
 import { fetchWithCreds } from '../actions';
-import { homepageChartNodes, datasetUrl } from '../localconf';
+import { homepageChartNodes, homepageChartNodesChunkSize, datasetUrl } from '../localconf';
 import getReduxStore from '../reduxStore';
 import getHomepageChartProjectsList from './relayer';
 
@@ -19,13 +19,12 @@ const updateRedux = async projectNodeCounts => getReduxStore().then(
   },
 );
 
-// Chunk into groups of 15
+// Chunk into groups of homepageChartNodesChunkSize
 // Chunking is necessary to avoid hitting Postgres limits
 export const getChunkedPeregrineRequestUrls = (nodesToRequest) => {
   const requestUrls = [];
 
   let k = 0;
-  const chunkSize = 15;
   const n = nodesToRequest.length;
 
   if (n === 0) {
@@ -33,11 +32,11 @@ export const getChunkedPeregrineRequestUrls = (nodesToRequest) => {
   }
 
   while (k < n) {
-    const listRightBound = Math.min(k + chunkSize, n);
+    const listRightBound = Math.min(k + homepageChartNodesChunkSize, n);
     const nodeChunk = nodesToRequest.slice(k, listRightBound);
     const chunkRequestUrl = `${datasetUrl}?nodes=${nodeChunk.join(',')}`;
     requestUrls.push(chunkRequestUrl);
-    k += chunkSize;
+    k += homepageChartNodesChunkSize;
   }
 
   return requestUrls;

--- a/src/Index/utils.js
+++ b/src/Index/utils.js
@@ -120,9 +120,6 @@ export const loadHomepageChartDataFromDatasets = async (callback) => {
     }
     return;
   }
-  if (query401) {
-    return;
-  }
 
   const mergedChartData = mergeChunkedChartData(fullResult);
 

--- a/src/Index/utils.js
+++ b/src/Index/utils.js
@@ -118,6 +118,7 @@ export const loadHomepageChartDataFromDatasets = async (callback) => {
         callback(resultStatus);
       }
     }
+    return;
   }
   if (query401) {
     return;

--- a/src/Index/utils.js
+++ b/src/Index/utils.js
@@ -94,11 +94,13 @@ export const loadHomepageChartDataFromDatasets = async (callback) => {
   const nodesToRequest = _.union(fileNodes, nodesForIndexChart);
   const requestUrls = getChunkedPeregrineRequestUrls(nodesToRequest);
 
-  const fullResult = [];
+  const fullResultPromise = [];
   for (let k = 0; k < requestUrls.length; k += 1) {
-    const chunkResult = await makePeregrineRequestForNode(requestUrls[k]);
-    fullResult.push(chunkResult);
+    const chunkResult = makePeregrineRequestForNode(requestUrls[k]);
+    fullResultPromise.push(chunkResult);
   }
+
+  const fullResult = await Promise.all(fullResultPromise);
 
   const queryFailure = fullResult.some(element => element[1] !== 200);
   const query401 = fullResult.some(element => element[1] === 401);
@@ -113,7 +115,7 @@ export const loadHomepageChartDataFromDatasets = async (callback) => {
     if (query401 || query403 || query404) {
       resultStatus.needLogin = true;
       if (callback) {
-        return callback(resultStatus);
+        callback(resultStatus);
       }
     }
   }
@@ -125,7 +127,7 @@ export const loadHomepageChartDataFromDatasets = async (callback) => {
 
   updateRedux(mergedChartData);
   if (callback) {
-    return callback(resultStatus);
+    callback(resultStatus);
   }
 };
 

--- a/src/Index/utils.js
+++ b/src/Index/utils.js
@@ -19,9 +19,9 @@ const updateRedux = async projectNodeCounts => getReduxStore().then(
   },
 );
 
-// Chunk into groups of homepageChartNodesChunkSize
+// Chunk into groups of chunkSize
 // Chunking is necessary to avoid hitting Postgres limits
-export const getChunkedPeregrineRequestUrls = (nodesToRequest) => {
+export const getChunkedPeregrineRequestUrls = (nodesToRequest, chunkSize) => {
   const requestUrls = [];
 
   let k = 0;
@@ -32,11 +32,11 @@ export const getChunkedPeregrineRequestUrls = (nodesToRequest) => {
   }
 
   while (k < n) {
-    const listRightBound = Math.min(k + homepageChartNodesChunkSize, n);
+    const listRightBound = Math.min(k + chunkSize, n);
     const nodeChunk = nodesToRequest.slice(k, listRightBound);
     const chunkRequestUrl = `${datasetUrl}?nodes=${nodeChunk.join(',')}`;
     requestUrls.push(chunkRequestUrl);
-    k += homepageChartNodesChunkSize;
+    k += chunkSize;
   }
 
   return requestUrls;
@@ -91,7 +91,7 @@ export const loadHomepageChartDataFromDatasets = async (callback) => {
   const fileNodes = store.getState().submission.file_nodes;
   const nodesForIndexChart = homepageChartNodes.map(item => item.node);
   const nodesToRequest = _.union(fileNodes, nodesForIndexChart);
-  const requestUrls = getChunkedPeregrineRequestUrls(nodesToRequest);
+  const requestUrls = getChunkedPeregrineRequestUrls(nodesToRequest, homepageChartNodesChunkSize);
 
   const fullResultPromise = [];
   for (let k = 0; k < requestUrls.length; k += 1) {

--- a/src/Index/utils.js
+++ b/src/Index/utils.js
@@ -22,54 +22,51 @@ const updateRedux = async projectNodeCounts => getReduxStore().then(
 // Chunk into groups of 15
 // Chunking is necessary to avoid hitting Postgres limits
 export const getChunkedPeregrineRequestUrls = (nodesToRequest) => {
-  let requestUrls = [];
+  const requestUrls = [];
 
   let k = 0;
-  let chunkSize = 15;
-  let n = nodesToRequest.length;
+  const chunkSize = 15;
+  const n = nodesToRequest.length;
 
-  if(n == 0) {
+  if (n === 0) {
     return [`${datasetUrl}?nodes=`];
   }
-  
-  while(k < n) {
-    let listRightBound = Math.min(k + chunkSize, n)
-    let nodeChunk = nodesToRequest.slice(k, listRightBound);
-    let chunkRequestUrl = `${datasetUrl}?nodes=${nodeChunk.join(',')}`;
-    requestUrls.push(chunkRequestUrl);
-    k = k + chunkSize;
 
+  while (k < n) {
+    const listRightBound = Math.min(k + chunkSize, n);
+    const nodeChunk = nodesToRequest.slice(k, listRightBound);
+    const chunkRequestUrl = `${datasetUrl}?nodes=${nodeChunk.join(',')}`;
+    requestUrls.push(chunkRequestUrl);
+    k += chunkSize;
   }
 
   return requestUrls;
-}
+};
 
-const makePeregrineRequestForNode = async (url) => {
-  return fetchWithCreds({
-    path: url,
-  }).then((res) => {
-    if(res.status == 200) {
-      return [res.data, 200];
-    }
-    return [null, res.status];
-  })
-    .catch((err) => {
-      console.log(err);
-    });
-}
+const makePeregrineRequestForNode = async url => fetchWithCreds({
+  path: url,
+}).then((res) => {
+  if (res.status === 200) {
+    return [res.data, 200];
+  }
+  return [null, res.status];
+})
+  .catch((err) => {
+    console.log(err);
+  });
 
 export const mergeChunkedChartData = (chartDataArray) => {
-  let mergedChartData = {};
-  var projects;
-  var projectKeys;
+  const mergedChartData = {};
+  let projects;
+  let projectKeys;
   for (let y = 0; y < chartDataArray.length; y += 1) {
     projects = chartDataArray[y][0];
     projectKeys = Object.keys(projects);
 
     for (let z = 0; z < projectKeys.length; z += 1) {
       if (mergedChartData[projectKeys[z]]) {
-        let nodes = projects[projectKeys[z]];
-        let nodeNames = Object.keys(nodes);
+        const nodes = projects[projectKeys[z]];
+        const nodeNames = Object.keys(nodes);
         for (let w = 0; w < nodeNames.length; w += 1) {
           mergedChartData[projectKeys[z]][nodeNames[w]] = nodes[nodeNames[w]];
         }
@@ -80,7 +77,7 @@ export const mergeChunkedChartData = (chartDataArray) => {
   }
 
   return mergedChartData;
-}
+};
 
 // loadHomepageChartdataFromDatasets queries Peregrine's /datasets endpoint for
 // summary data (counts of projects, counts of subjects, etc).
@@ -97,40 +94,38 @@ export const loadHomepageChartDataFromDatasets = async (callback) => {
   const nodesToRequest = _.union(fileNodes, nodesForIndexChart);
   const requestUrls = getChunkedPeregrineRequestUrls(nodesToRequest);
 
-  let fullResult = [];
+  const fullResult = [];
   for (let k = 0; k < requestUrls.length; k += 1) {
-    let chunkResult = await makePeregrineRequestForNode(requestUrls[k]);
+    const chunkResult = await makePeregrineRequestForNode(requestUrls[k]);
     fullResult.push(chunkResult);
   }
 
-  const queryFailure = fullResult.some((element) => element[1] !== 200);
-  const query401 =  fullResult.some((element) => element[1] === 401);
-  const query403 =  fullResult.some((element) => element[1] === 403);
-  const query404 =  fullResult.some((element) => element[1] === 404);
-  
-  if(queryFailure) {
-    if(query404) {
+  const queryFailure = fullResult.some(element => element[1] !== 200);
+  const query401 = fullResult.some(element => element[1] === 401);
+  const query403 = fullResult.some(element => element[1] === 403);
+  const query404 = fullResult.some(element => element[1] === 404);
+
+  if (queryFailure) {
+    if (query404) {
       // Shouldn't happen, this means peregrine datasets endpoint not enabled
       console.error(`REST endpoint ${datasetUrl} not enabled in Peregrine yet.`);
     }
-    if(query401 || query403 || query404) {
+    if (query401 || query403 || query404) {
       resultStatus.needLogin = true;
       if (callback) {
         return callback(resultStatus);
       }
     }
   }
-  if(query401) {
+  if (query401) {
     return;
   }
 
-  let mergedChartData = mergeChunkedChartData(fullResult);
-  console.log(fullResult);
-  console.log(mergedChartData);
+  const mergedChartData = mergeChunkedChartData(fullResult);
 
   updateRedux(mergedChartData);
   if (callback) {
-    callback(resultStatus);
+    return callback(resultStatus);
   }
 };
 

--- a/src/Index/utils.test.js
+++ b/src/Index/utils.test.js
@@ -1,48 +1,47 @@
-import { 
-  loadHomepageChartDataFromDatasets, 
-  getChunkedPeregrineRequestUrls, 
-  mergeChunkedChartData 
+import {
+  getChunkedPeregrineRequestUrls,
+  mergeChunkedChartData,
 } from './utils';
-import { homepageChartNodes, datasetUrl } from '../localconf';
+import { datasetUrl } from '../localconf';
 
-var urlPrefix = datasetUrl + '?nodes=';
+const urlPrefix = `${datasetUrl}?nodes=`;
 
 describe('the load homepage chart data flow', () => {
   it('provides accurate non-chunked queries', () => {
-    let testList1 = [];
-    let testList2 = ['aliquot'];
-    let testList3 = ['aliquot', 'sample_snp_array'];
-    
+    const testList1 = [];
+    const testList2 = ['aliquot'];
+    const testList3 = ['aliquot', 'sample_snp_array'];
+
     expect(getChunkedPeregrineRequestUrls(testList1)).toEqual([urlPrefix]);
-    expect(getChunkedPeregrineRequestUrls(testList2)).toEqual([urlPrefix + 'aliquot']);
-    expect(getChunkedPeregrineRequestUrls(testList3)).toEqual([urlPrefix + 'aliquot,sample_snp_array']);
-  })
+    expect(getChunkedPeregrineRequestUrls(testList2)).toEqual([`${urlPrefix}aliquot`]);
+    expect(getChunkedPeregrineRequestUrls(testList3)).toEqual([`${urlPrefix}aliquot,sample_snp_array`]);
+  });
 
   it('provides accurate chunked queries', () => {
-    let testList4 = ['aggregated_snp_array', 'aligned_reads', 'allele_expression', 'copy_number_variation', 'exon_expression', 'gene_expression,imaging_file', 'reference_file', 'simple_germline_variation', 'snp_array_variation', 'submitted_aligned_reads', 'submitted_cnv_array', 'submitted_snp_array', 'submitted_unaligned_reads', 'transcript_expression', 'subject', 'study', 'aliquot']
-    let testList5 = ['1', '2', '3', '4', '5', '6', '7', '8', '9', '10', '11', '12', '13', '14', '15', '16', '17', '18', '19', '20', '21', '22', '23', '24', '25', '26', '27', '28', '29', '30', '31', '32', '33', '34', '35'];
-    
+    const testList4 = ['aggregated_snp_array', 'aligned_reads', 'allele_expression', 'copy_number_variation', 'exon_expression', 'gene_expression,imaging_file', 'reference_file', 'simple_germline_variation', 'snp_array_variation', 'submitted_aligned_reads', 'submitted_cnv_array', 'submitted_snp_array', 'submitted_unaligned_reads', 'transcript_expression', 'subject', 'study', 'aliquot'];
+    const testList5 = ['1', '2', '3', '4', '5', '6', '7', '8', '9', '10', '11', '12', '13', '14', '15', '16', '17', '18', '19', '20', '21', '22', '23', '24', '25', '26', '27', '28', '29', '30', '31', '32', '33', '34', '35'];
+
     // testList4 is of length 17; chunk size is 15
     expect(getChunkedPeregrineRequestUrls(testList4)).toEqual([
-      urlPrefix + 'aggregated_snp_array,aligned_reads,allele_expression,copy_number_variation,exon_expression,gene_expression,imaging_file,reference_file,simple_germline_variation,snp_array_variation,submitted_aligned_reads,submitted_cnv_array,submitted_snp_array,submitted_unaligned_reads,transcript_expression,subject',
-      urlPrefix + 'study,aliquot'
+      `${urlPrefix}aggregated_snp_array,aligned_reads,allele_expression,copy_number_variation,exon_expression,gene_expression,imaging_file,reference_file,simple_germline_variation,snp_array_variation,submitted_aligned_reads,submitted_cnv_array,submitted_snp_array,submitted_unaligned_reads,transcript_expression,subject`,
+      `${urlPrefix}study,aliquot`,
     ]);
 
     // testList5 is of length 35
     expect(getChunkedPeregrineRequestUrls(testList5)).toEqual([
-      urlPrefix + '1,2,3,4,5,6,7,8,9,10,11,12,13,14,15',
-      urlPrefix + '16,17,18,19,20,21,22,23,24,25,26,27,28,29,30',
-      urlPrefix + '31,32,33,34,35'
+      `${urlPrefix}1,2,3,4,5,6,7,8,9,10,11,12,13,14,15`,
+      `${urlPrefix}16,17,18,19,20,21,22,23,24,25,26,27,28,29,30`,
+      `${urlPrefix}31,32,33,34,35`,
     ]);
-  })
+  });
 
   it('correctly merges chunked chart data results', () => {
-    let chunk1 = [{'project-a': {'node-1': 17, 'node-2': 9}, 'project-b': {'node-1': 2, 'node-2': 0}}];
-    let chunk2 = [{'project-a': {'node-3': 3, 'node-4': 13}, 'project-b': {'node-3': 6, 'node-4': 2}}];
-    
+    const chunk1 = [{ 'project-a': { 'node-1': 17, 'node-2': 9 }, 'project-b': { 'node-1': 2, 'node-2': 0 } }];
+    const chunk2 = [{ 'project-a': { 'node-3': 3, 'node-4': 13 }, 'project-b': { 'node-3': 6, 'node-4': 2 } }];
+
     expect(mergeChunkedChartData([chunk1, chunk2])).toEqual({
-      'project-a': {'node-1': 17, 'node-2': 9, 'node-3': 3, 'node-4': 13}, 
-      'project-b': {'node-1': 2, 'node-2': 0, 'node-3': 6, 'node-4': 2}
+      'project-a': { 'node-1': 17, 'node-2': 9, 'node-3': 3, 'node-4': 13 },
+      'project-b': { 'node-1': 2, 'node-2': 0, 'node-3': 6, 'node-4': 2 },
     });
-  })
+  });
 });

--- a/src/Index/utils.test.js
+++ b/src/Index/utils.test.js
@@ -1,0 +1,21 @@
+import { loadHomepageChartDataFromDatasets } from './utils';
+
+
+describe('the load homepage chart data flow', () => {
+  it('provides accurate chunked queries', () => {
+    expect(sortCompare('123', '123')).toBe(0);
+    expect(sortCompare('123', '234')).toBe(-1);
+    expect(sortCompare('234', '123')).toBe(1);
+    expect(sortCompare('11', '2')).toBe(-1);
+    expect(sortCompare(123, 123)).toBe(0);
+    expect(sortCompare(123, 234)).toBe(-1);
+    expect(sortCompare(234, 123)).toBe(1);
+    expect(sortCompare(11, 2)).toBe(1);
+  });
+
+  it('predicts mime-type based on text shape', () => {
+    expect(predictFileType(JSON.stringify({ a: 1, b: 2 }), 'unknown')).toBe('application/json');
+    expect(predictFileType('a\tb\n1\t2\n', 'unknown')).toBe('text/tab-separated-values');
+    expect(predictFileType('', 'unknown')).toBe('unknown');
+  });
+});

--- a/src/Index/utils.test.js
+++ b/src/Index/utils.test.js
@@ -12,9 +12,9 @@ describe('the load homepage chart data flow', () => {
     const testList2 = ['aliquot'];
     const testList3 = ['aliquot', 'sample_snp_array'];
 
-    expect(getChunkedPeregrineRequestUrls(testList1)).toEqual([urlPrefix]);
-    expect(getChunkedPeregrineRequestUrls(testList2)).toEqual([`${urlPrefix}aliquot`]);
-    expect(getChunkedPeregrineRequestUrls(testList3)).toEqual([`${urlPrefix}aliquot,sample_snp_array`]);
+    expect(getChunkedPeregrineRequestUrls(testList1, 15)).toEqual([urlPrefix]);
+    expect(getChunkedPeregrineRequestUrls(testList2, 15)).toEqual([`${urlPrefix}aliquot`]);
+    expect(getChunkedPeregrineRequestUrls(testList3, 15)).toEqual([`${urlPrefix}aliquot,sample_snp_array`]);
   });
 
   it('provides accurate chunked queries', () => {
@@ -22,17 +22,24 @@ describe('the load homepage chart data flow', () => {
     const testList5 = ['1', '2', '3', '4', '5', '6', '7', '8', '9', '10', '11', '12', '13', '14', '15', '16', '17', '18', '19', '20', '21', '22', '23', '24', '25', '26', '27', '28', '29', '30', '31', '32', '33', '34', '35'];
 
     // testList4 is of length 17; chunk size is 15
-    expect(getChunkedPeregrineRequestUrls(testList4)).toEqual([
+    expect(getChunkedPeregrineRequestUrls(testList4, 15)).toEqual([
       `${urlPrefix}aggregated_snp_array,aligned_reads,allele_expression,copy_number_variation,exon_expression,gene_expression,imaging_file,reference_file,simple_germline_variation,snp_array_variation,submitted_aligned_reads,submitted_cnv_array,submitted_snp_array,submitted_unaligned_reads,transcript_expression,subject`,
       `${urlPrefix}study,aliquot`,
     ]);
 
     // testList5 is of length 35
-    expect(getChunkedPeregrineRequestUrls(testList5)).toEqual([
+    expect(getChunkedPeregrineRequestUrls(testList5, 15)).toEqual([
       `${urlPrefix}1,2,3,4,5,6,7,8,9,10,11,12,13,14,15`,
       `${urlPrefix}16,17,18,19,20,21,22,23,24,25,26,27,28,29,30`,
       `${urlPrefix}31,32,33,34,35`,
     ]);
+
+    // Try out a different chunk size
+    expect(getChunkedPeregrineRequestUrls(testList5, 30)).toEqual([
+      `${urlPrefix}1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30`,
+      `${urlPrefix}31,32,33,34,35`,
+    ]);
+
   });
 
   it('correctly merges chunked chart data results', () => {

--- a/src/Index/utils.test.js
+++ b/src/Index/utils.test.js
@@ -1,21 +1,34 @@
-import { loadHomepageChartDataFromDatasets } from './utils';
+import { loadHomepageChartDataFromDatasets, getChunkedPeregrineRequestUrls } from './utils';
+import { homepageChartNodes, datasetUrl } from '../localconf';
 
+var urlPrefix = datasetUrl + '?nodes=';
 
 describe('the load homepage chart data flow', () => {
-  it('provides accurate chunked queries', () => {
-    expect(sortCompare('123', '123')).toBe(0);
-    expect(sortCompare('123', '234')).toBe(-1);
-    expect(sortCompare('234', '123')).toBe(1);
-    expect(sortCompare('11', '2')).toBe(-1);
-    expect(sortCompare(123, 123)).toBe(0);
-    expect(sortCompare(123, 234)).toBe(-1);
-    expect(sortCompare(234, 123)).toBe(1);
-    expect(sortCompare(11, 2)).toBe(1);
-  });
+  it('provides accurate non-chunked queries', () => {
+    let testList1 = [];
+    let testList2 = ['aliquot'];
+    let testList3 = ['aliquot', 'sample_snp_array'];
+    
+    expect(getChunkedPeregrineRequestUrls(testList1)).toEqual([urlPrefix]);
+    expect(getChunkedPeregrineRequestUrls(testList2)).toEqual([urlPrefix + 'aliquot']);
+    expect(getChunkedPeregrineRequestUrls(testList3)).toEqual([urlPrefix + 'aliquot,sample_snp_array']);
+  })
 
-  it('predicts mime-type based on text shape', () => {
-    expect(predictFileType(JSON.stringify({ a: 1, b: 2 }), 'unknown')).toBe('application/json');
-    expect(predictFileType('a\tb\n1\t2\n', 'unknown')).toBe('text/tab-separated-values');
-    expect(predictFileType('', 'unknown')).toBe('unknown');
-  });
+  it('provides accurate chunked queries', () => {
+    let testList4 = ['aggregated_snp_array', 'aligned_reads', 'allele_expression', 'copy_number_variation', 'exon_expression', 'gene_expression,imaging_file', 'reference_file', 'simple_germline_variation', 'snp_array_variation', 'submitted_aligned_reads', 'submitted_cnv_array', 'submitted_snp_array', 'submitted_unaligned_reads', 'transcript_expression', 'subject', 'study', 'aliquot']
+    let testList5 = ['1', '2', '3', '4', '5', '6', '7', '8', '9', '10', '11', '12', '13', '14', '15', '16', '17', '18', '19', '20', '21', '22', '23', '24', '25', '26', '27', '28', '29', '30', '31', '32', '33', '34', '35'];
+    
+    // testList4 is of length 17; chunk size is 15
+    expect(getChunkedPeregrineRequestUrls(testList4)).toEqual([
+      urlPrefix + 'aggregated_snp_array,aligned_reads,allele_expression,copy_number_variation,exon_expression,gene_expression,imaging_file,reference_file,simple_germline_variation,snp_array_variation,submitted_aligned_reads,submitted_cnv_array,submitted_snp_array,submitted_unaligned_reads,transcript_expression,subject',
+      urlPrefix + 'study,aliquot'
+    ]);
+
+    // testList5 is of length 35
+    expect(getChunkedPeregrineRequestUrls(testList5)).toEqual([
+      urlPrefix + '1,2,3,4,5,6,7,8,9,10,11,12,13,14,15',
+      urlPrefix + '16,17,18,19,20,21,22,23,24,25,26,27,28,29,30',
+      urlPrefix + '31,32,33,34,35'
+    ]);
+  })
 });

--- a/src/Index/utils.test.js
+++ b/src/Index/utils.test.js
@@ -1,4 +1,8 @@
-import { loadHomepageChartDataFromDatasets, getChunkedPeregrineRequestUrls } from './utils';
+import { 
+  loadHomepageChartDataFromDatasets, 
+  getChunkedPeregrineRequestUrls, 
+  mergeChunkedChartData 
+} from './utils';
 import { homepageChartNodes, datasetUrl } from '../localconf';
 
 var urlPrefix = datasetUrl + '?nodes=';
@@ -30,5 +34,15 @@ describe('the load homepage chart data flow', () => {
       urlPrefix + '16,17,18,19,20,21,22,23,24,25,26,27,28,29,30',
       urlPrefix + '31,32,33,34,35'
     ]);
+  })
+
+  it('correctly merges chunked chart data results', () => {
+    let chunk1 = [{'project-a': {'node-1': 17, 'node-2': 9}, 'project-b': {'node-1': 2, 'node-2': 0}}];
+    let chunk2 = [{'project-a': {'node-3': 3, 'node-4': 13}, 'project-b': {'node-3': 6, 'node-4': 2}}];
+    
+    expect(mergeChunkedChartData([chunk1, chunk2])).toEqual({
+      'project-a': {'node-1': 17, 'node-2': 9, 'node-3': 3, 'node-4': 13}, 
+      'project-b': {'node-1': 2, 'node-2': 0, 'node-3': 6, 'node-4': 2}
+    });
   })
 });

--- a/src/Index/utils.test.js
+++ b/src/Index/utils.test.js
@@ -39,7 +39,6 @@ describe('the load homepage chart data flow', () => {
       `${urlPrefix}1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30`,
       `${urlPrefix}31,32,33,34,35`,
     ]);
-
   });
 
   it('correctly merges chunked chart data results', () => {

--- a/src/Indexing/Indexing.jsx
+++ b/src/Indexing/Indexing.jsx
@@ -105,8 +105,10 @@ class Indexing extends React.Component {
       thisPointer.setState({
         indexingFilesPopupMessage: 'Preparing indexing job...',
       });
-      return thisPointer.retrievePresignedURLForDownload(0, 10);
-    }).catch(() => {
+      return thisPointer.retrievePresignedURLForDownload(0, 150);
+    }).catch((err) => {
+      // eslint-disable-next-line no-console
+      console.log(err);
       thisPointer.setState({
         indexingFilesStatus: 'error',
         indexingFilesStatusLastUpdated: thisPointer.getCurrentTime(),
@@ -134,7 +136,7 @@ class Indexing extends React.Component {
         thisPointer.setState({
           indexingFilesStatus: 'error',
           indexingFilesStatusLastUpdated: thisPointer.getCurrentTime(),
-          indexingFilesPopupMessage: `There was a problem uploading the indexing file to s3 (${response.status})`,
+          indexingFilesPopupMessage: `There was a problem uploading the indexing file to s3 (${response.status}). The upload timed out.`,
           indexFilesButtonEnabled: false,
         });
         return;

--- a/src/localconf.js
+++ b/src/localconf.js
@@ -154,6 +154,11 @@ function buildConfig(opts) {
     terraExportWarning = config.terraExportWarning;
   }
 
+  let homepageChartNodesChunkSize = 15;
+  if(components.index.homepageChartNodesChunkSize) {
+    homepageChartNodesChunkSize = components.index.homepageChartNodesChunkSize;
+  }
+
   // for "libre" data commons, explorer page is public
   let explorerPublic = false;
   if (tierAccessLevel === 'libre') {
@@ -315,6 +320,7 @@ function buildConfig(opts) {
     workspaceLaunchUrl,
     workspaceTerminateUrl,
     homepageChartNodes: components.index.homepageChartNodes,
+    homepageChartNodesChunkSize,
     customHomepageChartConfig: components.index.customHomepageChartConfig,
     datasetUrl,
     indexPublic,


### PR DESCRIPTION
This PR splits the query for homepage chart nodes into multiple queries when more than 15 nodes are requested. The chunked query results are combined and rendered. You can run my unit tests with 
`npm test src/Index/utils.test.js`

Deployed in https://zakir.planx-pla.net/

Fulfills https://ctds-planx.atlassian.net/browse/PXP-6235

### Improvements
- Homepage chart data request is now chunked to respect Postgres query limits

### Deployment Changes
- New optional config field in the index section of gitops.json called homepageChartNodeChunkSize. Sets the value for paritioning requests to Peregrine for the homepage chart. Defaults to 15 if not provided.