### PR TITLE
Fix issue loading dictionary viewer for null props

### DIFF
--- a/src/DataDictionary/highlightHelper.jsx
+++ b/src/DataDictionary/highlightHelper.jsx
@@ -17,7 +17,8 @@ const escapeReturnChar = (str, newlineClassName) => {
 
 const addHighlightingSpans = (str, indices, spanClassName) => {
   if (typeof str !== 'string') {
-    str = String(str);
+    // non-string `str` should not happen, but don't crash if it does
+    str = String(str); // eslint-disable-line no-param-reassign
   }
 
   let cursor = 0;

--- a/src/DataDictionary/highlightHelper.jsx
+++ b/src/DataDictionary/highlightHelper.jsx
@@ -16,6 +16,10 @@ const escapeReturnChar = (str, newlineClassName) => {
 };
 
 const addHighlightingSpans = (str, indices, spanClassName) => {
+  if (typeof str !== 'string') {
+    str = String(str);
+  }
+
   let cursor = 0;
   let currentIndices = 0;
   const resultFragments = [];


### PR DESCRIPTION
fix `Cannot read property 'length' of null` error at line 61 `if (cursor < str.length)` 
example https://github.com/uc-cdis/covid19_datadictionary/commit/afb325a2889d2753fe245fd3edc913f7c3de7864#
`null` should not be a value in the dictionary (we're removing it), but the dd viewer should not crash anyway

### Bug Fixes
- Fix issue loading dictionary viewer for null props
