### PR TITLE
fix: data upload auth check

### DIFF
--- a/src/authMappingUtils.js
+++ b/src/authMappingUtils.js
@@ -53,8 +53,8 @@ export const listifyMethodsFromMapping = (actions) => {
 
 
 export const userHasDataUpload = (userAuthMapping = {}) => {
-  // data_upload policy is resource data_file, method file_upload, service fence
-  const actionIsFileUpload = x => x.method === 'file_upload' && x.service === 'fence';
+  // data_upload policy is resource data_file, method file_upload
+  const actionIsFileUpload = x => x.method === 'file_upload';
   const resource = userAuthMapping['/data_file'];
   return resource !== undefined && resource.some(actionIsFileUpload);
 };


### PR DESCRIPTION
Fixed a bug cause `submission` page not correctly displaying `Map My Files` component if 1. `useArboristUI` is on AND 2.  service in `file_upload` has been changed from `fence` to `*` (which is intruduced in Indexd 2.12.0 or 2020.07)

Related PR: https://github.com/uc-cdis/indexd/pull/275 (see `Deployment changes`)


### Bug Fixes
- Fixed a bug cause `submission` page not correctly displaying `Map My Files` component

### Deployment changes
- Portal sould be updated to include this fix if `Indexd` is above `2.12.0` or `2020.07` and user want to use Arborist UI
