### PR TITLE
Dictionary categories refactoring

### DIFF
--- a/data/dictionaryHelper.js
+++ b/data/dictionaryHelper.js
@@ -4,7 +4,11 @@
  * @return {experimentType, fileTypeList} gqlSetup object used by data/gqlSetup.js
  */
 function dictToGQLSetup(dict) {
-  const fileTypeList = Object.keys(dict).filter(key => typeof dict[key] === 'object' && dict[key].category === 'data_file');
+  const fileTypeList = Object.keys(dict).filter(key =>
+    typeof dict[key] === 'object' &&
+    dict[key].category &&
+    dict[key].category.endsWith('_file'),
+  );
   // admin types that link to the 'project' level and are not project or program
   const adminTypeList = Object.keys(dict).filter(
     (key) => {

--- a/src/DataDictionary/NodeCategories/helper.js
+++ b/src/DataDictionary/NodeCategories/helper.js
@@ -1,4 +1,4 @@
-import * as d3 from 'd3-scale';
+import { schemeCategory20 } from 'd3-scale';
 
 import IconAdministrative from './icons/icon_administrative.svg';
 import IconAnalysis from './icons/icon_analysis.svg';
@@ -79,19 +79,19 @@ const nodeCategoryDict = {
   },
   satellite: {
     icon: IconDefault,
-    color: d3.schemeCategory20[11],
+    color: schemeCategory20[11],
   },
   radar: {
     icon: IconDefault,
-    color: d3.schemeCategory20[16],
+    color: schemeCategory20[16],
   },
   stream_gauge: {
     icon: IconDefault,
-    color: d3.schemeCategory20[19],
+    color: schemeCategory20[19],
   },
   weather_station: {
     icon: IconDefault,
-    color: d3.schemeCategory20[10],
+    color: schemeCategory20[10],
   },
 };
 

--- a/src/DataDictionary/NodeCategories/helper.js
+++ b/src/DataDictionary/NodeCategories/helper.js
@@ -108,7 +108,7 @@ export const getCategoryIconSVG = (category) => {
   // look for a category name that's a suffix of
   // the category we're looking for
   const suffixCategory = Object.keys(nodeCategoryDict).find(
-    key => category.endsWith(key),
+    key => category && category.endsWith(key),
   );
   if (suffixCategory) {
     return nodeCategoryDict[suffixCategory].icon;
@@ -125,7 +125,7 @@ export const getCategoryColor = (category) => {
   // look for a category name that's a suffix of
   // the category we're looking for
   const suffixCategory = Object.keys(nodeCategoryDict).find(
-    key => category.endsWith(key),
+    key => category && category.endsWith(key),
   );
   if (suffixCategory) {
     return nodeCategoryDict[suffixCategory].color;

--- a/src/DataDictionary/NodeCategories/helper.js
+++ b/src/DataDictionary/NodeCategories/helper.js
@@ -14,7 +14,7 @@ import IconSubjectCharacteristics from './icons/icon_subject_characteristics.svg
 import IconImaging from './icons/icon_imaging.svg';
 import IconStudyAdministration from './icons/icon_study_administration.svg';
 
-const nodeCategoryList = {
+const nodeCategoryDict = {
   clinical: {
     icon: IconClinical,
     color: '#05B8EE',
@@ -83,16 +83,34 @@ const defaultCategory = {
 };
 
 export const getCategoryIconSVG = (category) => {
-  if (nodeCategoryList[category]) {
-    return nodeCategoryList[category].icon;
+  if (nodeCategoryDict[category]) {
+    return nodeCategoryDict[category].icon;
+  }
+
+  // look for a category name that's a suffix of
+  // the category we're looking for
+  const suffixCategory = Object.keys(nodeCategoryDict).find(
+    key => category.endsWith(key),
+  );
+  if (suffixCategory) {
+    return nodeCategoryDict[suffixCategory].icon;
   }
 
   return defaultCategory.icon;
 };
 
 export const getCategoryColor = (category) => {
-  if (nodeCategoryList[category]) {
-    return nodeCategoryList[category].color;
+  if (nodeCategoryDict[category]) {
+    return nodeCategoryDict[category].color;
+  }
+
+  // look for a category name that's a suffix of
+  // the category we're looking for
+  const suffixCategory = Object.keys(nodeCategoryDict).find(
+    key => category.endsWith(key),
+  );
+  if (suffixCategory) {
+    return nodeCategoryDict[suffixCategory].color;
   }
 
   return defaultCategory.color;

--- a/src/DataDictionary/NodeCategories/helper.js
+++ b/src/DataDictionary/NodeCategories/helper.js
@@ -1,3 +1,5 @@
+import * as d3 from 'd3-scale';
+
 import IconAdministrative from './icons/icon_administrative.svg';
 import IconAnalysis from './icons/icon_analysis.svg';
 import IconBiospecimen from './icons/icon_biospecimen.svg';
@@ -74,6 +76,22 @@ const nodeCategoryDict = {
   study_administration: {
     icon: IconStudyAdministration,
     color: '#733EA3',
+  },
+  satellite: {
+    icon: IconDefault,
+    color: d3.schemeCategory20[11],
+  },
+  radar: {
+    icon: IconDefault,
+    color: d3.schemeCategory20[16],
+  },
+  stream_gauge: {
+    icon: IconDefault,
+    color: d3.schemeCategory20[19],
+  },
+  weather_station: {
+    icon: IconDefault,
+    color: d3.schemeCategory20[10],
   },
 };
 

--- a/src/DataModelGraph/SvgGraph.jsx
+++ b/src/DataModelGraph/SvgGraph.jsx
@@ -4,7 +4,8 @@ import { select, selectAll } from 'd3-selection';
 import { forceSimulation, forceLink } from 'd3-force';
 import { extent } from 'd3-array';
 
-import { getCategoryColor, legendCreator, addArrows, addLinks, calculatePosition } from '../utils';
+import { getCategoryColor } from '../DataDictionary/NodeCategories/helper';
+import { legendCreator, addArrows, addLinks, calculatePosition } from '../utils';
 import { assignNodePositions } from '../GraphUtils/utils';
 
 const d3 = {

--- a/src/Explorer/__test__/data.json
+++ b/src/Explorer/__test__/data.json
@@ -1,6 +1,8 @@
 {
   "data": {
     "viewer": {
+      "fileData_aligned_reads_index": [],
+      "fileData_experimental_metadata": [],
       "fileData_slide_image": [],
       "fileData_cell_image": [],
       "fileData_mass_cytometry_assay": [],

--- a/src/Explorer/__test__/expected.json
+++ b/src/Explorer/__test__/expected.json
@@ -1,6 +1,8 @@
 {
   "explorer": {
     "filesMap": {
+      "aligned_reads_index": [],
+      "experimental_metadata": [],
       "slide_image": [],
       "submitted_aligned_reads": [
         {
@@ -389,6 +391,8 @@
       "submitted_unaligned_reads": []
     },
     "lastPageSizes": {
+      "aligned_reads_index": 0,
+      "experimental_metadata": 0,
       "slide_image": 0,
       "submitted_aligned_reads": 1,
       "submitted_copy_number": 0,
@@ -397,6 +401,8 @@
       "submitted_unaligned_reads": 0
     },
     "currentPages": {
+      "aligned_reads_index": 0,
+      "experimental_metadata": 0,
       "slide_image": 0,
       "submitted_aligned_reads": 0,
       "submitted_copy_number": 0,
@@ -405,6 +411,8 @@
       "submitted_unaligned_reads": 0
     },
     "cursors": {
+      "aligned_reads_index": 0,
+      "experimental_metadata": 0,
       "slide_image": 0,
       "submitted_aligned_reads": 21,
       "submitted_copy_number": 0,
@@ -413,6 +421,8 @@
       "submitted_unaligned_reads": 0
     },
     "queriedCursors": {
+      "aligned_reads_index": 0,
+      "experimental_metadata": 0,
       "slide_image": 0,
       "submitted_aligned_reads": 0,
       "submitted_copy_number": 0,

--- a/src/GuppyDataExplorer/ExplorerButtonGroup/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerButtonGroup/index.jsx
@@ -482,7 +482,7 @@ class ExplorerButtonGroup extends React.Component {
     }
     if (buttonConfig.type === 'export') {
       if (!this.props.buttonConfig.terraExportURL) {
-        console.error('Export to Terra button is present, but there is no `terraExportURL` specified in the portal config. Disabling the export to Terra button.');
+        console.error('Export to Terra button is present, but there is no `terraExportURL` specified in the portal config. Disabling the export to Terra button.'); // eslint-disable-line no-console
         return false;
       }
       // disable the terra export button if any of the
@@ -493,7 +493,7 @@ class ExplorerButtonGroup extends React.Component {
     }
     if (buttonConfig.type === 'export-to-seven-bridges') {
       if (!this.props.buttonConfig.sevenBridgesExportURL) {
-        console.error('Export to Terra button is present, but there is no `terraExportURL` specified in the portal config. Disabling the export to Terra button.');
+        console.error('Export to Terra button is present, but there is no `terraExportURL` specified in the portal config. Disabling the export to Terra button.'); // eslint-disable-line no-console
         return false;
       }
       // disable the seven bridges export buttons if any of the

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,6 +1,5 @@
-import * as d3 from 'd3-scale';
-
 import { submissionApiPath } from './localconf';
+import { getCategoryColor } from './DataDictionary/NodeCategories/helper';
 
 export const humanFileSize = (size) => {
   if (typeof size !== 'number') {
@@ -73,33 +72,6 @@ export async function asyncSetInterval(lambda, timeoutMs) {
     }, timeoutMs,
   );
 }
-
-
-export const getCategoryColor = (category) => {
-  const colorMap = {
-    clinical: '#05B8EE',
-    biospecimen: '#27AE60',
-    data_file: '#7EC500',
-    metadata_file: '#F4B940',
-    analysis: '#FF7ABC',
-    administrative: '#AD91FF',
-    notation: '#E74C3C',
-    index_file: '#26D9B1',
-    clinical_assessment: '#3283C8',
-    medical_history: '#05B8EE',
-    satellite: d3.schemeCategory20[11],
-    radar: d3.schemeCategory20[16],
-    stream_gauge: d3.schemeCategory20[19],
-    weather_station: d3.schemeCategory20[10],
-    data_observations: d3.schemeCategory20[3],
-    experimental_methods: d3.schemeCategory20[4],
-    Imaging: d3.schemeCategory20[5],
-    study_administration: d3.schemeCategory20[6],
-    subject_characteristics: d3.schemeCategory20[7],
-  };
-  const defaultColor = '#9B9B9B';
-  return colorMap[category] ? colorMap[category] : defaultColor;
-};
 
 export function legendCreator(legendGroup, nodes, legendWidth) {
   // Find all unique categories


### PR DESCRIPTION
Ticket COV-377

- **Current behavior for unknown categories:**
<img width="1149" alt="Screen Shot 2020-07-06 at 3 54 23 PM" src="https://user-images.githubusercontent.com/4224001/86641740-fc7dd900-bfa0-11ea-8788-f62e2ae4fc8a.png">

For a category such as `genomic_data_file`, we can "guess" match it with `data_file`, which would result in using the same icon and color for `data_file` and `genomic_data_file`:

- **Dictionary viewer table view:**
<img width="1135" alt="Screen Shot 2020-07-06 at 3 50 55 PM" src="https://user-images.githubusercontent.com/4224001/86641282-a446d700-bfa0-11ea-9524-c4e217f78691.png">

- **Dictionary viewer graph view:**
<img width="760" alt="Screen Shot 2020-07-06 at 3 51 09 PM" src="https://user-images.githubusercontent.com/4224001/86641291-a6109a80-bfa0-11ea-8ed2-ae54900009ab.png">

- **Project submission page:**
<img width="475" alt="Screen Shot 2020-07-06 at 3 51 25 PM" src="https://user-images.githubusercontent.com/4224001/86641302-a7da5e00-bfa0-11ea-961b-30c1283d7ace.png">

Alternatively (or in addition to this), we could keep the default icon (or display no icon) and dynamically generate (colorblind-friendly) new colors for new categories, instead of hardcoding which categories are expected and assign colors. I think that would be cool for a future improvement. We can even make it configurable

### Improvements
- Handle icons and colors for new node categories in dictionary viewer and in project submission page by matching them with existing category suffixes
- The project summary table now counts all file nodes instead of only the "data_file" category (e.g. "index_file", "metadata_file") (same behavior as Peregrine/Pidgin)
- Refactor the multiple "getCategoryColor" functions into a single one
