### PR TITLE
fix: no rounding

### DIFF
--- a/src/components/charts/IndexBarChart/index.jsx
+++ b/src/components/charts/IndexBarChart/index.jsx
@@ -53,7 +53,7 @@ const createChartData = (projectList, countNames, sumList) => {
         (count, j) => {
           if (typeof indexChart[j] === 'undefined') return;
           indexChart[j][`count${i}`] = (sumList[j] > 0) ?
-            ((count * 100) / sumList[j]).toFixed(2) : 0;
+            (count * 100) / sumList[j] : 0;
         },
       );
     },


### PR DESCRIPTION
@wangfan860 has found a bug that the index bar chart is not displaying accruate data when the numbers are large, see attachments
![image (1)](https://user-images.githubusercontent.com/2475897/87162842-19a9f480-c28c-11ea-8633-3ea7fcaf901b.png)
![image (2)](https://user-images.githubusercontent.com/2475897/87162856-1ca4e500-c28c-11ea-8806-c0785dbd14d5.png)

Turns out portal was doing some unnecessary roundings for the data, fixed in this PR
![Screen Shot 2020-07-10 at 9 04 05 AM](https://user-images.githubusercontent.com/2475897/87163016-58d84580-c28c-11ea-9d80-befa42b98c4a.png)

Suggest to test locally against anvil internal staging

### Bug Fixes
- Fixed a bug causing index bar chart to display inaccurate data due to rounding

