### PR TITLE
remove forecast images from carousel

### DIFF
--- a/src/Covid19Dashboard/index.jsx
+++ b/src/Covid19Dashboard/index.jsx
@@ -181,9 +181,7 @@ class Covid19Dashboard extends React.Component {
 
     const imgProps = {
       imgCases: `bayes-by-county/${modeledCountyFips}/cases.png`,
-      imgCasesForecast: `bayes-by-county/${modeledCountyFips}/casesForecast.png`,
       imgDeaths: `bayes-by-county/${modeledCountyFips}/deaths.png`,
-      imgDeathsForecast: `bayes-by-county/${modeledCountyFips}/deathsForecast.png`,
       imgRt: `bayes-by-county/${modeledCountyFips}/Rt.png`,
     };
     const imgMetadata = covid19DashboardConfig.chartsConfig.simulations || {};


### PR DESCRIPTION
Description about what this pull request does.

Please make sure to follow the [DEV guidelines](https://gen3.org/resources/developer/dev-introduction/) before asking for review.

### New Features


### Breaking Changes


### Bug Fixes
- remove empty forecast plots from county carousel

### Improvements


### Dependency updates


### Deployment changes

