### PR TITLE
Fixing Safari charts

### DIFF
--- a/src/Covid19Dashboard/PlotChart/index.jsx
+++ b/src/Covid19Dashboard/PlotChart/index.jsx
@@ -11,7 +11,8 @@ import './PlotChart.less';
 class CustomizedAxisTick extends React.Component {
   render() {
     const { x, y, payload } = this.props; // eslint-disable-line react/prop-types
-    const val = payload.value.replace(/-/g, '/'); // eslint-disable-line react/prop-types
+    console.log(x);
+    const val = payload.value; // eslint-disable-line react/prop-types
     const formattedDate = `${moment(val).month() + 1}/${moment(val).date()}`;
     return (
       <g transform={`translate(${x},${y})`}>
@@ -23,17 +24,17 @@ class CustomizedAxisTick extends React.Component {
 
 function getDates(startDate, endDate, days) {
   const dates = [];
-  let currentDate = moment(startDate).replace(/-/g, '/');
-  const endingDate = moment(endDate).replace(/-/g, '/');
+  let currentDate = moment(startDate);
+  const endingDate = moment(endDate);
   const addDaysToDate = (date) => {
-    const newDate = moment(date).valueOf();
-    newDate.set(newDate.date() + days);
+    const newDate = moment(date);
+    newDate.add(days, 'days');
     return newDate;
   };
   while (currentDate <= endingDate) {
     const year = currentDate.year();
-    const month = `${currentDate.month() + 1}`.padStart(2, 0);
-    const day = `${currentDate.date()}`.padStart(2, 0);
+    const month = `${currentDate.month() + 1}`.padStart(2, '0');
+    const day = `${currentDate.date()}`.padStart(2, '0');
     const stringDate = [year, month, day].join('-');
     const fmtDate = `${stringDate} 00:00:00+00:00`;
     dates.push(fmtDate);
@@ -145,7 +146,7 @@ class PlotChart extends PureComponent { // eslint-disable-line react/no-multi-co
             />
             <XAxis
               dataKey='date'
-              tick={<CustomizedAxisTick />}
+              tick={<CustomizedAxisTick/>}
               ticks={chartData.ticks}
               interval={0}
             />

--- a/src/Covid19Dashboard/PlotChart/index.jsx
+++ b/src/Covid19Dashboard/PlotChart/index.jsx
@@ -12,7 +12,7 @@ class CustomizedAxisTick extends React.Component {
   render() {
     const { x, y, payload } = this.props; // eslint-disable-line react/prop-types
     const val = payload.value.replace(/-/g, '/'); // eslint-disable-line react/prop-types
-    const formattedDate = `${new Date(val).getUTCMonth() + 1}/${new Date(val).getUTCDate()}`;
+    const formattedDate = `${moment(val).month() + 1}/${moment(val).date()}`;
     return (
       <g transform={`translate(${x},${y})`}>
         <text x={0} y={0} dy={16} textAnchor='end' fill='#666' transform='rotate(-60)'>{formattedDate}</text>
@@ -23,17 +23,17 @@ class CustomizedAxisTick extends React.Component {
 
 function getDates(startDate, endDate, days) {
   const dates = [];
-  let currentDate = new Date(startDate).replace(/-/g, '/');
-  const endingDate = new Date(endDate).replace(/-/g, '/');
+  let currentDate = moment(startDate).replace(/-/g, '/');
+  const endingDate = moment(endDate).replace(/-/g, '/');
   const addDaysToDate = (date) => {
-    const newDate = new Date(date.valueOf());
-    newDate.setDate(newDate.getUTCDate() + days);
+    const newDate = moment(date).valueOf();
+    newDate.set(newDate.date() + days);
     return newDate;
   };
   while (currentDate <= endingDate) {
-    const year = currentDate.getUTCFullYear();
-    const month = `${currentDate.getUTCMonth() + 1}`.padStart(2, 0);
-    const day = `${currentDate.getUTCDate()}`.padStart(2, 0);
+    const year = currentDate.year();
+    const month = `${currentDate.month() + 1}`.padStart(2, 0);
+    const day = `${currentDate.date()}`.padStart(2, 0);
     const stringDate = [year, month, day].join('-');
     const fmtDate = `${stringDate} 00:00:00+00:00`;
     dates.push(fmtDate);
@@ -58,7 +58,7 @@ function formatChartData(plots) {
     });
   });
   let sortedData = Object.values(dateToData);
-  sortedData = sortedData.sort((a, b) => new Date(a.date) - new Date(b.date));
+  sortedData = sortedData.sort((a, b) => moment(a.date) - moment(b.date));
   return {
     data: sortedData,
     ticks: getDates(sortedData[0].date, sortedData[sortedData.length - 1].date, 7),

--- a/src/Covid19Dashboard/PlotChart/index.jsx
+++ b/src/Covid19Dashboard/PlotChart/index.jsx
@@ -6,12 +6,13 @@ import {
 
 import { numberWithCommas } from '../dataUtils.js';
 import './PlotChart.less';
+import moment from "moment";
 
 
 class CustomizedAxisTick extends React.Component {
   render() {
     const { x, y, payload } = this.props; // eslint-disable-line react/prop-types
-    const val = payload.value; // eslint-disable-line react/prop-types
+    const val = payload.value.replace(/-/g, '/'); // eslint-disable-line react/prop-types
     const formattedDate = `${new Date(val).getUTCMonth() + 1}/${new Date(val).getUTCDate()}`;
     return (
       <g transform={`translate(${x},${y})`}>
@@ -23,8 +24,8 @@ class CustomizedAxisTick extends React.Component {
 
 function getDates(startDate, endDate, days) {
   const dates = [];
-  let currentDate = new Date(startDate);
-  const endingDate = new Date(endDate);
+  let currentDate = new Date((startDate).replace(/-/g, '/'));
+  const endingDate = new Date((endDate).replace(/-/g, '/'));
   const addDaysToDate = (date) => {
     const newDate = new Date(date.valueOf());
     newDate.setDate(newDate.getUTCDate() + days);
@@ -101,11 +102,11 @@ class PlotChart extends PureComponent { // eslint-disable-line react/no-multi-co
 
   renderTooltip = (props) => {
     const monthNames = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
-    const date = new Date(props.label);
+    const date = moment(props.label);
     const nColumns = Math.ceil(props.payload.length / 5); // up to 5 items per column
     return (
       <div className='plot-chart__tooltip'>
-        <p>{monthNames[date.getUTCMonth()]} {date.getUTCDate()}, {date.getUTCFullYear()}</p>
+        <p>{monthNames[date.month()]} {date.date()}, {date.year()}</p>
         <div style={{ columnCount: nColumns }}>
           {
             props.payload.map((data, i) => (

--- a/src/Covid19Dashboard/PlotChart/index.jsx
+++ b/src/Covid19Dashboard/PlotChart/index.jsx
@@ -6,13 +6,12 @@ import {
 
 import { numberWithCommas } from '../dataUtils.js';
 import './PlotChart.less';
-import moment from "moment";
 
 
 class CustomizedAxisTick extends React.Component {
   render() {
     const { x, y, payload } = this.props; // eslint-disable-line react/prop-types
-    const val = payload.value.replace(/-/g, '/'); // eslint-disable-line react/prop-types
+    const val = payload.value; // eslint-disable-line react/prop-types
     const formattedDate = `${new Date(val).getUTCMonth() + 1}/${new Date(val).getUTCDate()}`;
     return (
       <g transform={`translate(${x},${y})`}>
@@ -24,8 +23,8 @@ class CustomizedAxisTick extends React.Component {
 
 function getDates(startDate, endDate, days) {
   const dates = [];
-  let currentDate = new Date(startDate).replace(/-/g, '/');
-  const endingDate = new Date(endDate).replace(/-/g, '/');
+  let currentDate = new Date(startDate);
+  const endingDate = new Date(endDate);
   const addDaysToDate = (date) => {
     const newDate = new Date(date.valueOf());
     newDate.setDate(newDate.getUTCDate() + days);
@@ -102,11 +101,11 @@ class PlotChart extends PureComponent { // eslint-disable-line react/no-multi-co
 
   renderTooltip = (props) => {
     const monthNames = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
-    const date = moment(props.label);
+    const date = new Date(props.label);
     const nColumns = Math.ceil(props.payload.length / 5); // up to 5 items per column
     return (
       <div className='plot-chart__tooltip'>
-        <p>{monthNames[date.month()]} {date.date()}, {date.year()}</p>
+        <p>{monthNames[date.getUTCMonth()]} {date.getUTCDate()}, {date.getUTCFullYear()}</p>
         <div style={{ columnCount: nColumns }}>
           {
             props.payload.map((data, i) => (

--- a/src/Covid19Dashboard/PlotChart/index.jsx
+++ b/src/Covid19Dashboard/PlotChart/index.jsx
@@ -1,3 +1,4 @@
+import moment from 'moment';
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import {
@@ -6,8 +7,6 @@ import {
 
 import { numberWithCommas } from '../dataUtils.js';
 import './PlotChart.less';
-import moment from "moment";
-
 
 class CustomizedAxisTick extends React.Component {
   render() {
@@ -24,8 +23,8 @@ class CustomizedAxisTick extends React.Component {
 
 function getDates(startDate, endDate, days) {
   const dates = [];
-  let currentDate = new Date((startDate).replace(/-/g, '/'));
-  const endingDate = new Date((endDate).replace(/-/g, '/'));
+  let currentDate = new Date(startDate).replace(/-/g, '/');
+  const endingDate = new Date(endDate).replace(/-/g, '/');
   const addDaysToDate = (date) => {
     const newDate = new Date(date.valueOf());
     newDate.setDate(newDate.getUTCDate() + days);


### PR DESCRIPTION
Handles fixing the Safari charts

use of Moment Library 
- the source data for `props.label` in tooltip was in format yyyy-mm-dd. But Safari's date class didn't support but chrome's date class had support for that format. Safari displayed the date as ("NaN", "NaN") which was used as the label on the tooltip
- Moment is a date parsing library for JS and it supports both Safari and Chrome browser. It allows us to use any date format which is needed