### PR TITLE
COV-402 fix: list in table

### DIFF
--- a/src/GuppyDataExplorer/ExplorerTable/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerTable/index.jsx
@@ -79,8 +79,13 @@ class ExplorerTable extends React.Component {
       accessor: d => d[fieldStringsArray[0]],
       Cell: (row) => {
         let valueStr = '';
+        // not a nested field name
         if (fieldStringsArray.length === 1) {
-          valueStr = row.value;
+          if (_.isArray(row.value)) {
+            valueStr = row.value.join(', ');
+          } else {
+            valueStr = row.value;
+          }
         } else {
           const nestedChildFieldName = fieldStringsArray.slice(1, fieldStringsArray.length).join('.');
           // some logic to handle depends on wether the child field in raw data is an array or not


### PR DESCRIPTION
![Screen Shot 2020-07-29 at 4 35 31 PM](https://user-images.githubusercontent.com/2475897/88856270-ce637180-d1b9-11ea-9510-ec9849f8e404.png)

Fulfills https://occ-data.atlassian.net/browse/COV-402

### Improvements
- Values in a list is displayed properly by concatenating with `,` in explorer table

