### PR TITLE
Fix/charts safari

### DIFF
--- a/src/Covid19Dashboard/PlotChart/index.jsx
+++ b/src/Covid19Dashboard/PlotChart/index.jsx
@@ -56,13 +56,8 @@ function getDates(startDate, endDate, days) {
     newDate.add(days, 'days');
     return newDate;
   };
-  while (moment(currentDate).isSameOrBefore(endingDate)) {
-    const year = currentDate.year();
-    const month = `${currentDate.month() + 1}`.padStart(2, 0);
-    const day = `${currentDate.date()}`.padStart(2, 0);
-    const stringDate = [year, month, day].join('-');
-    const fmtDate = `${stringDate} 00:00:00+00:00`;
-    dates.push(fmtDate);
+  while (currentDate.isSameOrBefore(endingDate)) {
+    dates.push(currentDate.utc().format('YYYY-MM-DD HH:mm:ssZ'));
     currentDate = addDaysToDate(currentDate);
   }
   return dates;

--- a/src/Covid19Dashboard/PlotChart/index.jsx
+++ b/src/Covid19Dashboard/PlotChart/index.jsx
@@ -1,3 +1,4 @@
+import moment from 'moment';
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import {
@@ -17,7 +18,7 @@ class PlotChartAxisTick extends React.Component {
 
     let formattedValue = payload.value;
     if (type === 'date') {
-      formattedValue = `${new Date(formattedValue).getUTCMonth() + 1}/${new Date(formattedValue).getUTCDate()}`;
+      formattedValue = `${moment(formattedValue).month() + 1}/${moment(formattedValue).date()}`;
     } else if (type === 'number') {
       formattedValue = numberWithCommas(formattedValue);
     }
@@ -48,17 +49,17 @@ class PlotChartAxisTick extends React.Component {
 
 function getDates(startDate, endDate, days) {
   const dates = [];
-  let currentDate = new Date(startDate);
-  const endingDate = new Date(endDate);
+  let currentDate = moment(startDate);
+  const endingDate = moment(endDate);
   const addDaysToDate = (date) => {
-    const newDate = new Date(date.valueOf());
-    newDate.setDate(newDate.getUTCDate() + days);
+    const newDate = moment(date);
+    newDate.add(days, 'days');
     return newDate;
   };
-  while (currentDate <= endingDate) {
-    const year = currentDate.getUTCFullYear();
-    const month = `${currentDate.getUTCMonth() + 1}`.padStart(2, 0);
-    const day = `${currentDate.getUTCDate()}`.padStart(2, 0);
+  while (moment(currentDate).isSameOrBefore(endingDate)) {
+    const year = currentDate.year();
+    const month = `${currentDate.month() + 1}`.padStart(2, 0);
+    const day = `${currentDate.date()}`.padStart(2, 0);
     const stringDate = [year, month, day].join('-');
     const fmtDate = `${stringDate} 00:00:00+00:00`;
     dates.push(fmtDate);
@@ -83,7 +84,7 @@ function formatChartDataFromProps(plots) {
     });
   });
   let sortedData = Object.values(dateToData);
-  sortedData = sortedData.sort((a, b) => new Date(a.date) - new Date(b.date));
+  sortedData = sortedData.sort((a, b) => moment(a.date) - moment(b.date));
   return {
     data: sortedData,
     ticks: getDates(sortedData[0].date, sortedData[sortedData.length - 1].date, 7),
@@ -263,11 +264,11 @@ class PlotChart extends PureComponent { // eslint-disable-line react/no-multi-co
 
   renderTooltip = (props) => {
     const monthNames = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
-    const date = new Date(props.label);
+    const date = moment(props.label);
     const nColumns = Math.ceil(props.payload.length / 5); // up to 5 items per column
     return (
       <div className='plot-chart__tooltip'>
-        <p>{monthNames[date.getUTCMonth()]} {date.getUTCDate()}, {date.getUTCFullYear()}</p>
+        <p>{monthNames[date.month()]} {date.date()}, {date.year()}</p>
         <div style={{ columnCount: nColumns }}>
           {
             props.payload.map((data, i) => (

--- a/src/Covid19Dashboard/PlotChart/index.jsx
+++ b/src/Covid19Dashboard/PlotChart/index.jsx
@@ -6,13 +6,12 @@ import {
 
 import { numberWithCommas } from '../dataUtils.js';
 import './PlotChart.less';
-import moment from "moment";
 
 
 class CustomizedAxisTick extends React.Component {
   render() {
     const { x, y, payload } = this.props; // eslint-disable-line react/prop-types
-    const val = payload.value.replace(/-/g, '/'); // eslint-disable-line react/prop-types
+    const val = payload.value; // eslint-disable-line react/prop-types
     const formattedDate = `${new Date(val).getUTCMonth() + 1}/${new Date(val).getUTCDate()}`;
     return (
       <g transform={`translate(${x},${y})`}>
@@ -24,8 +23,8 @@ class CustomizedAxisTick extends React.Component {
 
 function getDates(startDate, endDate, days) {
   const dates = [];
-  let currentDate = new Date(startDate).replace(/-/g, '/');
-  const endingDate = new Date(endDate).replace(/-/g, '/');
+  let currentDate = new Date(startDate);
+  const endingDate = new Date(endDate);
   const addDaysToDate = (date) => {
     const newDate = new Date(date.valueOf());
     newDate.setDate(newDate.getUTCDate() + days);
@@ -102,11 +101,11 @@ class PlotChart extends PureComponent { // eslint-disable-line react/no-multi-co
 
   renderTooltip = (props) => {
     const monthNames = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
-    const date = moment(props.label);
+    const date = new Date(props.label);
     const nColumns = Math.ceil(props.payload.length / 5); // up to 5 items per column
     return (
       <div className='plot-chart__tooltip'>
-        <p>{monthNames[date.month()]} {date.date()}, {date.year()}</p>
+        <p>{monthNames[date.getUTCMonth()]} {date.getUTCDate()}, {date.getUTCFullYear()}</p>
         <div style={{ columnCount: nColumns }}>
           {
             props.payload.map((data, i) => (


### PR DESCRIPTION
Handles fixing the Safari charts

use of Moment Library

the source data for props.label in tooltip was in format yyyy-mm-dd. But Safari's date class didn't support but chrome's date class had support for that format. Safari displayed the date as ("NaN", "NaN") which was used as the label on the tooltip
Moment is a date parsing library for JS and it supports both Safari and Chrome browser. It allows us to use any date format which is needed