### PR TITLE
Feat/covid bundle

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -68,9 +68,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "10.17.29",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.29.tgz",
-          "integrity": "sha512-zLo9rjUeQ5+QVhOufDwrb3XKyso31fJBJnk9wUUQIBDExF/O4LryvpOfozfUaxgqifTnlt7FyqsAPXUq5yFZSA=="
+          "version": "10.17.35",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.35.tgz",
+          "integrity": "sha512-gXx7jAWpMddu0f7a+L+txMplp3FnHl53OhQIF9puXKq3hDGY/GjH+MF04oWnV/adPSCrbtHumDCFwzq2VhltWA=="
         }
       }
     },
@@ -164,9 +164,9 @@
       },
       "dependencies": {
         "node-fetch": {
-          "version": "2.6.0",
-          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
-          "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA=="
+          "version": "2.6.1",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+          "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
         }
       }
     },
@@ -204,12 +204,12 @@
       }
     },
     "@babel/core": {
-      "version": "7.11.5",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.11.5.tgz",
-      "integrity": "sha512-fsEANVOcZHzrsV6dMVWqpSeXClq3lNbYrfFGme6DE25FQWe7pyeYpXyx9guqUnpy466JLzZ8z4uwSr2iv60V5Q==",
+      "version": "7.11.6",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.11.6.tgz",
+      "integrity": "sha512-Wpcv03AGnmkgm6uS6k8iwhIwTrcP0m17TL1n1sy7qD0qelDu4XNeW0dN0mHfa+Gei211yDaLoEe/VlbXQzM4Bg==",
       "requires": {
         "@babel/code-frame": "^7.10.4",
-        "@babel/generator": "^7.11.5",
+        "@babel/generator": "^7.11.6",
         "@babel/helper-module-transforms": "^7.11.0",
         "@babel/helpers": "^7.10.4",
         "@babel/parser": "^7.11.5",
@@ -223,7 +223,7 @@
         "lodash": "^4.17.19",
         "resolve": "^1.3.2",
         "semver": "^5.4.1",
-        "source-map": "^0.6.1"
+        "source-map": "^0.5.0"
       },
       "dependencies": {
         "@babel/types": {
@@ -248,22 +248,17 @@
           "version": "2.1.2",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-        },
-        "source-map": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
         }
       }
     },
     "@babel/generator": {
-      "version": "7.11.5",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.11.5.tgz",
-      "integrity": "sha512-9UqHWJ4IwRTy4l0o8gq2ef8ws8UPzvtMkVKjTLAiRmza9p9V6Z+OfuNd9fB1j5Q67F+dVJtPC2sZXI8NM9br4g==",
+      "version": "7.11.6",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.11.6.tgz",
+      "integrity": "sha512-DWtQ1PV3r+cLbySoHrwn9RWEgKMBLLma4OBQloPRyDYvc5msJM9kvTLo1YnlJd1P/ZuKbdli3ijr5q3FvAF3uA==",
       "requires": {
         "@babel/types": "^7.11.5",
         "jsesc": "^2.5.1",
-        "source-map": "^0.6.1"
+        "source-map": "^0.5.0"
       },
       "dependencies": {
         "@babel/types": {
@@ -275,11 +270,6 @@
             "lodash": "^4.17.19",
             "to-fast-properties": "^2.0.0"
           }
-        },
-        "source-map": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
         }
       }
     },
@@ -2037,9 +2027,9 @@
           "integrity": "sha512-Wz3c3XQ5xroCxd1G8b7yL0Ehkf0TC9oYC6buPFkNnU9EnaPlifeAFCyCh+iewXTyFRcg0a6j3J7FmJsIhlhBdw=="
         },
         "node-fetch": {
-          "version": "2.6.0",
-          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
-          "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA=="
+          "version": "2.6.1",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+          "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
         }
       }
     },
@@ -2223,9 +2213,9 @@
           }
         },
         "stylelint": {
-          "version": "13.7.0",
-          "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-13.7.0.tgz",
-          "integrity": "sha512-1wStd4zVetnlHO98VjcHQbjSDmvcA39smkZQMct2cf+hom40H0xlQNdzzbswoG/jGBh61/Ue9m7Lu99PY51O6A==",
+          "version": "13.7.1",
+          "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-13.7.1.tgz",
+          "integrity": "sha512-qzqazcyRxrSRdmFuO0/SZOJ+LyCxYy0pwcvaOBBnl8/2VfHSMrtNIE+AnyJoyq6uKb+mt+hlgmVrvVi6G6XHfQ==",
           "requires": {
             "@stylelint/postcss-css-in-js": "^0.37.2",
             "@stylelint/postcss-markdown": "^0.36.1",
@@ -3069,114 +3059,36 @@
       }
     },
     "@mdx-js/mdx": {
-      "version": "1.6.16",
-      "resolved": "https://registry.npmjs.org/@mdx-js/mdx/-/mdx-1.6.16.tgz",
-      "integrity": "sha512-jnYyJ0aCafCIehn3GjYcibIapaLBgs3YkoenNQBPcPFyyuUty7B3B07OE+pMllhJ6YkWeP/R5Ax19x0nqTzgJw==",
+      "version": "1.6.18",
+      "resolved": "https://registry.npmjs.org/@mdx-js/mdx/-/mdx-1.6.18.tgz",
+      "integrity": "sha512-RXtdFBP3cnf/RILx/ipp5TsSY1k75bYYmjorv7jTaPcHPQwhQdI6K4TrVUed/GL4f8zX5TN2QwO5g+3E/8RsXA==",
       "dev": true,
       "requires": {
-        "@babel/core": "7.10.5",
+        "@babel/core": "7.11.6",
         "@babel/plugin-syntax-jsx": "7.10.4",
         "@babel/plugin-syntax-object-rest-spread": "7.8.3",
-        "@mdx-js/util": "1.6.16",
-        "babel-plugin-apply-mdx-type-prop": "1.6.16",
-        "babel-plugin-extract-import-names": "1.6.16",
+        "@mdx-js/util": "1.6.18",
+        "babel-plugin-apply-mdx-type-prop": "1.6.18",
+        "babel-plugin-extract-import-names": "1.6.18",
         "camelcase-css": "2.0.1",
         "detab": "2.0.3",
-        "hast-util-raw": "6.0.0",
+        "hast-util-raw": "6.0.1",
         "lodash.uniq": "4.5.0",
-        "mdast-util-to-hast": "9.1.0",
-        "remark-footnotes": "1.0.0",
-        "remark-mdx": "1.6.16",
+        "mdast-util-to-hast": "9.1.1",
+        "remark-footnotes": "2.0.0",
+        "remark-mdx": "1.6.18",
         "remark-parse": "8.0.3",
         "remark-squeeze-paragraphs": "4.0.0",
         "style-to-object": "0.3.0",
-        "unified": "9.1.0",
+        "unified": "9.2.0",
         "unist-builder": "2.0.3",
         "unist-util-visit": "2.0.3"
-      },
-      "dependencies": {
-        "@babel/core": {
-          "version": "7.10.5",
-          "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.10.5.tgz",
-          "integrity": "sha512-O34LQooYVDXPl7QWCdW9p4NR+QlzOr7xShPPJz8GsuCU3/8ua/wqTr7gmnxXv+WBESiGU/G5s16i6tUvHkNb+w==",
-          "dev": true,
-          "requires": {
-            "@babel/code-frame": "^7.10.4",
-            "@babel/generator": "^7.10.5",
-            "@babel/helper-module-transforms": "^7.10.5",
-            "@babel/helpers": "^7.10.4",
-            "@babel/parser": "^7.10.5",
-            "@babel/template": "^7.10.4",
-            "@babel/traverse": "^7.10.5",
-            "@babel/types": "^7.10.5",
-            "convert-source-map": "^1.7.0",
-            "debug": "^4.1.0",
-            "gensync": "^1.0.0-beta.1",
-            "json5": "^2.1.2",
-            "lodash": "^4.17.19",
-            "resolve": "^1.3.2",
-            "semver": "^5.4.1",
-            "source-map": "^0.5.0"
-          }
-        },
-        "@babel/types": {
-          "version": "7.11.5",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.11.5.tgz",
-          "integrity": "sha512-bvM7Qz6eKnJVFIn+1LPtjlBFPVN5jNDc1XmN15vWe7Q3DPBufWWsLiIvUu7xW87uTG6QoggpIDnUgLQvPheU+Q==",
-          "dev": true,
-          "requires": {
-            "@babel/helper-validator-identifier": "^7.10.4",
-            "lodash": "^4.17.19",
-            "to-fast-properties": "^2.0.0"
-          }
-        },
-        "debug": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-          "dev": true,
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "is-buffer": {
-          "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.4.tgz",
-          "integrity": "sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A==",
-          "dev": true
-        },
-        "is-plain-obj": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
-          "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
-          "dev": true
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-          "dev": true
-        },
-        "unified": {
-          "version": "9.1.0",
-          "resolved": "https://registry.npmjs.org/unified/-/unified-9.1.0.tgz",
-          "integrity": "sha512-VXOv7Ic6twsKGJDeZQ2wwPqXs2hM0KNu5Hkg9WgAZbSD1pxhZ7p8swqg583nw1Je2fhwHy6U8aEjiI79x1gvag==",
-          "dev": true,
-          "requires": {
-            "bail": "^1.0.0",
-            "extend": "^3.0.0",
-            "is-buffer": "^2.0.0",
-            "is-plain-obj": "^2.0.0",
-            "trough": "^1.0.0",
-            "vfile": "^4.0.0"
-          }
-        }
       }
     },
     "@mdx-js/util": {
-      "version": "1.6.16",
-      "resolved": "https://registry.npmjs.org/@mdx-js/util/-/util-1.6.16.tgz",
-      "integrity": "sha512-SFtLGIGZummuyMDPRL5KdmpgI8U19Ble28UjEWihPjGxF1Lgj8aDjLWY8KiaUy9eqb9CKiVCqEIrK9jbnANfkw==",
+      "version": "1.6.18",
+      "resolved": "https://registry.npmjs.org/@mdx-js/util/-/util-1.6.18.tgz",
+      "integrity": "sha512-axMe+NoLF55OlXPbhRn4GNCHcL1f5W3V3c0dWzg05S9JXm3Ecpxzxaht3g3vTP0dcqBL/yh/xCvzK0ZpO54Eug==",
       "dev": true
     },
     "@mrmlnc/readdir-enhanced": {
@@ -4062,9 +3974,9 @@
           "integrity": "sha512-RZKhC3EmpBchfTGBVb8fb+RL2cWyw/32lshnsETttkBAyAUXSGHxbEJWWRXc751DrIxG1q04b8QwMbAwkRPpUA=="
         },
         "node-fetch": {
-          "version": "2.6.0",
-          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
-          "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA=="
+          "version": "2.6.1",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+          "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
         },
         "schema-utils": {
           "version": "2.7.1",
@@ -4669,9 +4581,9 @@
       }
     },
     "@types/babel__traverse": {
-      "version": "7.0.13",
-      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.0.13.tgz",
-      "integrity": "sha512-i+zS7t6/s9cdQvbqKDARrcbrPvtJGlbYsMkazo03nTAK3RX9FNrLllXys22uiTGJapPOTZTQ35nHh4ISph4SLQ==",
+      "version": "7.0.14",
+      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.0.14.tgz",
+      "integrity": "sha512-8w9szzKs14ZtBVuP6Wn7nMLRJ0D6dfB0VEBEyRgxrZ/Ln49aNMykrghM2FaNn4FJRzNppCSa0Rv9pBRM5Xc3wg==",
       "dev": true,
       "requires": {
         "@babel/types": "^7.3.0"
@@ -4776,14 +4688,21 @@
       }
     },
     "@types/graphql-upload": {
-      "version": "8.0.3",
-      "resolved": "https://registry.npmjs.org/@types/graphql-upload/-/graphql-upload-8.0.3.tgz",
-      "integrity": "sha512-hmLg9pCU/GmxBscg8GCr1vmSoEmbItNNxdD5YH2TJkXm//8atjwuprB+xJBK714JG1dkxbbhp5RHX+Pz1KsCMA==",
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/@types/graphql-upload/-/graphql-upload-8.0.4.tgz",
+      "integrity": "sha512-0TRyJD2o8vbkmJF8InppFcPVcXKk+Rvlg/xvpHBIndSJYpmDWfmtx/ZAtl4f3jR2vfarpTqYgj8MZuJssSoU7Q==",
       "requires": {
         "@types/express": "*",
         "@types/fs-capacitor": "*",
         "@types/koa": "*",
-        "graphql": "^14.5.3"
+        "graphql": "^15.3.0"
+      },
+      "dependencies": {
+        "graphql": {
+          "version": "15.3.0",
+          "resolved": "https://registry.npmjs.org/graphql/-/graphql-15.3.0.tgz",
+          "integrity": "sha512-GTCJtzJmkFLWRfFJuoo9RWWa/FfamUHgiFosxi/X1Ani4AVWbeyBenZTNX6dM+7WSbbFfTo/25eh0LLkwHMw2w=="
+        }
       }
     },
     "@types/hast": {
@@ -4796,9 +4715,9 @@
       }
     },
     "@types/history": {
-      "version": "4.7.7",
-      "resolved": "https://registry.npmjs.org/@types/history/-/history-4.7.7.tgz",
-      "integrity": "sha512-2xtoL22/3Mv6a70i4+4RB7VgbDDORoWwjcqeNysojZA0R7NK17RbY5Gof/2QiFfJgX+KkWghbwJ+d/2SB8Ndzg=="
+      "version": "4.7.8",
+      "resolved": "https://registry.npmjs.org/@types/history/-/history-4.7.8.tgz",
+      "integrity": "sha512-S78QIYirQcUoo6UJZx9CSP0O2ix9IaeAXwQi26Rhr/+mg7qqPy8TzaxHSUut7eGjL8WmLccT7/MXf304WjqHcA=="
     },
     "@types/html-minifier-terser": {
       "version": "5.1.0",
@@ -4915,9 +4834,9 @@
       "integrity": "sha1-aaI6OtKcrwCX8G7aWbNh7i8GOfY="
     },
     "@types/node": {
-      "version": "14.6.3",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.6.3.tgz",
-      "integrity": "sha512-pC/hkcREG6YfDfui1FBmj8e20jFU5Exjw4NYDm8kEdrW+mOh0T1Zve8DWKnS7ZIZvgncrctcNCXF4Q2I+loyww=="
+      "version": "14.11.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.11.1.tgz",
+      "integrity": "sha512-oTQgnd0hblfLsJ6BvJzzSL+Inogp3lq9fGgqRkMB/ziKMgEUaFl801OncOzUmalfzt14N0oPHMK47ipl+wbTIw=="
     },
     "@types/node-fetch": {
       "version": "2.5.7",
@@ -4960,9 +4879,9 @@
       "integrity": "sha512-1HcDas8SEj4z1Wc696tH56G8OlRaH/sqZOynNNB+HF0WOeXPaxTtbYzJY2oEfiUxjSKjhCKr+MvR7dCHcEelug=="
     },
     "@types/qs": {
-      "version": "6.9.4",
-      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.4.tgz",
-      "integrity": "sha512-+wYo+L6ZF6BMoEjtf8zB2esQsqdV6WsjRK/GP9WOgLPrq87PbNWgIxS76dS5uvl/QXtHGakZmwTznIfcPXcKlQ=="
+      "version": "6.9.5",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.5.tgz",
+      "integrity": "sha512-/JHkVHtx/REVG0VVToGRGH2+23hsYLHdyG+GrvoUGlGAd0ErauXDyvHtRI/7H7mzLm+tBCKA7pfcpkQ1lf58iQ=="
     },
     "@types/range-parser": {
       "version": "1.2.3",
@@ -5077,9 +4996,9 @@
       }
     },
     "@types/webpack": {
-      "version": "4.41.21",
-      "resolved": "https://registry.npmjs.org/@types/webpack/-/webpack-4.41.21.tgz",
-      "integrity": "sha512-2j9WVnNrr/8PLAB5csW44xzQSJwS26aOnICsP3pSGCEdsu6KYtfQ6QJsVUKHWRnm1bL7HziJsfh5fHqth87yKA==",
+      "version": "4.41.22",
+      "resolved": "https://registry.npmjs.org/@types/webpack/-/webpack-4.41.22.tgz",
+      "integrity": "sha512-JQDJK6pj8OMV9gWOnN1dcLCyU9Hzs6lux0wBO4lr1+gyEhIBR9U3FMrz12t2GPkg110XAxEAw2WHF6g7nZIbRQ==",
       "requires": {
         "@types/anymatch": "*",
         "@types/node": "*",
@@ -5097,9 +5016,9 @@
       }
     },
     "@types/webpack-env": {
-      "version": "1.15.2",
-      "resolved": "https://registry.npmjs.org/@types/webpack-env/-/webpack-env-1.15.2.tgz",
-      "integrity": "sha512-67ZgZpAlhIICIdfQrB5fnDvaKFcDxpKibxznfYRVAT4mQE41Dido/3Ty+E3xGBmTogc5+0Qb8tWhna+5B8z1iQ=="
+      "version": "1.15.3",
+      "resolved": "https://registry.npmjs.org/@types/webpack-env/-/webpack-env-1.15.3.tgz",
+      "integrity": "sha512-5oiXqR7kwDGZ6+gmzIO2lTC+QsriNuQXZDWNYRV3l2XRN/zmPgnC21DLSx2D05zvD8vnXW6qUg7JnXZ4I6qLVQ=="
     },
     "@types/webpack-sources": {
       "version": "1.4.2",
@@ -5332,9 +5251,9 @@
       "integrity": "sha512-RYTOHHdWipFUliRFMCS4X2Yn2X8M87V/OpSqWzKKOGhzqyUxzyVmhHDH9sAvG+ZuQf/TAOFsLCpMw09I1ufUnA=="
     },
     "abab": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.4.tgz",
-      "integrity": "sha512-Eu9ELJWCz/c1e9gTiCY+FceWxcqzjYEbqMgtndnuSqZSUCOL73TWNK2mHfIj4Cw2E/ongOp+JISVNCmovt2KYQ==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.5.tgz",
+      "integrity": "sha512-9IK9EadsbHo6jLWIpxpR6pL0sazTXV6+SQv25ZB+F7Bj9mJNaOc4nCRabwd5M/JwmUa8idz6Eci6eKfJryPs6Q==",
       "dev": true
     },
     "abbrev": {
@@ -5475,9 +5394,9 @@
       }
     },
     "ajv": {
-      "version": "6.12.4",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.4.tgz",
-      "integrity": "sha512-eienB2c9qVQs2KWexhkrdMLVDoIQCz5KSeLxwg9Lzk4DOfBtIK9PQwwufcsn1jjGuf9WZmqPMbGxOzfcuphJCQ==",
+      "version": "6.12.5",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.5.tgz",
+      "integrity": "sha512-lRF8RORchjpKG50/WFf8xmg7sgCLFiYNNnqdKflk63whMQcWR5ngGjiSXkL9bjxy6B2npOK2HSMN49jEBMSkag==",
       "requires": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -5583,15 +5502,15 @@
       }
     },
     "antd": {
-      "version": "4.6.2",
-      "resolved": "https://registry.npmjs.org/antd/-/antd-4.6.2.tgz",
-      "integrity": "sha512-6hmSRiSV3Lzz/1fKGOLHld7gf0d+MW7fg7MNGCAAceGmxtG1WEaaOtV8dZeL2WXq0SGH4wY4GytN6chRrtatfw==",
+      "version": "4.6.4",
+      "resolved": "https://registry.npmjs.org/antd/-/antd-4.6.4.tgz",
+      "integrity": "sha512-fzrxyXc93fq+h0A0Rduw+7we1qyZEIgwIefXJmZg7ft81M/nQcdJ1l37sbaJWcg120f+kjeuWIbrmCVUqTpgXw==",
       "requires": {
         "@ant-design/colors": "^4.0.5",
         "@ant-design/css-animation": "^1.7.2",
         "@ant-design/icons": "^4.2.1",
         "@ant-design/react-slick": "~0.27.0",
-        "@babel/runtime": "^7.10.4",
+        "@babel/runtime": "^7.11.2",
         "array-tree-filter": "^2.1.0",
         "classnames": "^2.2.6",
         "copy-to-clipboard": "^3.2.0",
@@ -5603,33 +5522,33 @@
         "rc-cascader": "~1.3.0",
         "rc-checkbox": "~2.3.0",
         "rc-collapse": "~2.0.0",
-        "rc-dialog": "~8.1.0",
+        "rc-dialog": "~8.2.1",
         "rc-drawer": "~4.1.0",
         "rc-dropdown": "~3.1.2",
         "rc-field-form": "~1.10.0",
-        "rc-image": "~3.0.2",
+        "rc-image": "~3.0.6",
         "rc-input-number": "~6.0.0",
         "rc-mentions": "~1.4.0",
-        "rc-menu": "~8.5.2",
-        "rc-motion": "^1.0.0",
+        "rc-menu": "~8.6.1",
+        "rc-motion": "^2.0.0",
         "rc-notification": "~4.4.0",
         "rc-pagination": "~3.0.3",
         "rc-picker": "~2.0.6",
-        "rc-progress": "~3.0.0",
+        "rc-progress": "~3.1.0",
         "rc-rate": "~2.8.2",
         "rc-resize-observer": "^0.2.3",
-        "rc-select": "~11.1.0",
+        "rc-select": "~11.2.0",
         "rc-slider": "~9.3.0",
         "rc-steps": "~4.1.0",
         "rc-switch": "~3.2.0",
         "rc-table": "~7.9.2",
         "rc-tabs": "~11.6.0",
         "rc-textarea": "~0.3.0",
-        "rc-tooltip": "~4.2.0",
+        "rc-tooltip": "~5.0.0",
         "rc-tree": "~3.9.0",
         "rc-tree-select": "~4.1.1",
-        "rc-trigger": "~4.4.0",
-        "rc-upload": "~3.2.1",
+        "rc-trigger": "~5.0.3",
+        "rc-upload": "~3.3.1",
         "rc-util": "^5.1.0",
         "scroll-into-view-if-needed": "^2.2.25",
         "warning": "^4.0.3"
@@ -5644,9 +5563,9 @@
           }
         },
         "rc-align": {
-          "version": "4.0.3",
-          "resolved": "https://registry.npmjs.org/rc-align/-/rc-align-4.0.3.tgz",
-          "integrity": "sha512-TpI0t1tvAo/wYdoZbZlkCK+MkQBqNuPyRZesfsji4tMlqoqQ0q0MhnC9JD5KGPitMvmSB+KWgFpaN2uTz4hw6Q==",
+          "version": "4.0.4",
+          "resolved": "https://registry.npmjs.org/rc-align/-/rc-align-4.0.4.tgz",
+          "integrity": "sha512-lXEFdJ8D6k8BFjcliaMCGojmrfVnfu4t5nUpo6OpE3tQc4WgwTEm9ENB/yvkFWPXsRZFVTwMn8KHKzsjoKb3Rw==",
           "requires": {
             "@babel/runtime": "^7.10.1",
             "classnames": "2.x",
@@ -5676,27 +5595,62 @@
             "rc-tooltip": "^4.0.0",
             "rc-util": "^5.0.0",
             "shallowequal": "^1.1.0"
+          },
+          "dependencies": {
+            "rc-motion": {
+              "version": "1.1.2",
+              "resolved": "https://registry.npmjs.org/rc-motion/-/rc-motion-1.1.2.tgz",
+              "integrity": "sha512-YC/E7SSWKBFakYg4PENhSRWD4ZLDqkI7FKmutJcrMewZ91/ZIWfoZSDvPaBdKO0hsFrrzWepFhXQIq0FNnCMWA==",
+              "requires": {
+                "@babel/runtime": "^7.11.1",
+                "classnames": "^2.2.1",
+                "raf": "^3.4.1",
+                "rc-util": "^5.0.6"
+              }
+            },
+            "rc-tooltip": {
+              "version": "4.2.3",
+              "resolved": "https://registry.npmjs.org/rc-tooltip/-/rc-tooltip-4.2.3.tgz",
+              "integrity": "sha512-7ySkaPGeqLLM4a/QYrKQ280aDthPxyvjJqQMstWX/AWX7/b1p23HIdHXdjBkziuvcnvXkW4lgZdFTVsylDiX1w==",
+              "requires": {
+                "@babel/runtime": "^7.11.2",
+                "rc-trigger": "^4.2.1"
+              }
+            },
+            "rc-trigger": {
+              "version": "4.4.3",
+              "resolved": "https://registry.npmjs.org/rc-trigger/-/rc-trigger-4.4.3.tgz",
+              "integrity": "sha512-yq/WyuiPwxd2q6jy+VPyy0GUCRFJ2eFqAaCwPE27AOftXeIupOcJ/2t1wakSq63cfk7qtzev5DKHUAjb8LOJCw==",
+              "requires": {
+                "@babel/runtime": "^7.11.2",
+                "classnames": "^2.2.6",
+                "raf": "^3.4.1",
+                "rc-align": "^4.0.0",
+                "rc-motion": "^1.0.0",
+                "rc-util": "^5.0.1"
+              }
+            }
           }
         },
         "rc-tooltip": {
-          "version": "4.2.2",
-          "resolved": "https://registry.npmjs.org/rc-tooltip/-/rc-tooltip-4.2.2.tgz",
-          "integrity": "sha512-mAs+gAngUyHVA6HdFXsELoJOHgfjAACLLc8SGtnVhovJdyqs5ZGSL9p5i+ApNaVpwjswqShw7L4DRtMl7cXCQg==",
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/rc-tooltip/-/rc-tooltip-5.0.1.tgz",
+          "integrity": "sha512-3AnxhUS0j74xAV3khrKw8o6rg+Ima3nw09DJBezMPnX3ImQUAnayWsPSlN1mEnihjA43rcFkGM1emiKE+CXyMQ==",
           "requires": {
-            "rc-trigger": "^4.2.1"
+            "@babel/runtime": "^7.11.2",
+            "rc-trigger": "^5.0.0"
           }
         },
         "rc-trigger": {
-          "version": "4.4.2",
-          "resolved": "https://registry.npmjs.org/rc-trigger/-/rc-trigger-4.4.2.tgz",
-          "integrity": "sha512-uw2/s7j1b/RXyixa4omPuxZWv/3ln+H+p0v3trIUBxseolbdj8TTFpXYjXMZdGtMpAEAIbN1yo/K+r7wRB+xtQ==",
+          "version": "5.0.4",
+          "resolved": "https://registry.npmjs.org/rc-trigger/-/rc-trigger-5.0.4.tgz",
+          "integrity": "sha512-cFTuV73YpfC8ujknycSjEvIDX7VtspEgFhibk/evf415Q0roHazs9dEbajKRgionpC/88OKLRR6G81eA4BvLTQ==",
           "requires": {
-            "@babel/runtime": "^7.10.1",
+            "@babel/runtime": "^7.11.2",
             "classnames": "^2.2.6",
-            "raf": "^3.4.1",
             "rc-align": "^4.0.0",
-            "rc-motion": "^1.0.0",
-            "rc-util": "^5.0.1"
+            "rc-motion": "^2.0.0",
+            "rc-util": "^5.2.1"
           }
         },
         "warning": {
@@ -5785,9 +5739,9 @@
           "integrity": "sha512-vZVEEwZoIsI+vPEuoF9Iqf5H7/M3eeQqWlQnYa8FSKKePuYTf5MWnxb5SDAzCa60b3JBRS5g9b+Dq7b1y/RCrA=="
         },
         "node-fetch": {
-          "version": "2.6.0",
-          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
-          "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA=="
+          "version": "2.6.1",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+          "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
         }
       }
     },
@@ -5870,9 +5824,9 @@
       },
       "dependencies": {
         "node-fetch": {
-          "version": "2.6.0",
-          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
-          "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA=="
+          "version": "2.6.1",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+          "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw=="
         }
       }
     },
@@ -6554,13 +6508,13 @@
       "integrity": "sha1-M51M3be2X9YtHfnbn+BN4TQSK9U="
     },
     "babel-plugin-apply-mdx-type-prop": {
-      "version": "1.6.16",
-      "resolved": "https://registry.npmjs.org/babel-plugin-apply-mdx-type-prop/-/babel-plugin-apply-mdx-type-prop-1.6.16.tgz",
-      "integrity": "sha512-hjUd24Yhnr5NKtHpC2mcRBGjC6RUKGzSzjN9g5SdjT4WpL/JDlpmjyBf7vWsJJSXFvMIbzRyxF4lT9ukwOnj/w==",
+      "version": "1.6.18",
+      "resolved": "https://registry.npmjs.org/babel-plugin-apply-mdx-type-prop/-/babel-plugin-apply-mdx-type-prop-1.6.18.tgz",
+      "integrity": "sha512-lcpbj/GatKQp48jsJ8Os/ZXv381ZYFNKA27EPllcpFMpqiS696XkoK+xie/2GjzQSe5IIbo3srsXpd6/ik8PsQ==",
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "7.10.4",
-        "@mdx-js/util": "1.6.16"
+        "@mdx-js/util": "1.6.18"
       }
     },
     "babel-plugin-check-es2015-constants": {
@@ -6601,9 +6555,9 @@
       }
     },
     "babel-plugin-extract-import-names": {
-      "version": "1.6.16",
-      "resolved": "https://registry.npmjs.org/babel-plugin-extract-import-names/-/babel-plugin-extract-import-names-1.6.16.tgz",
-      "integrity": "sha512-Da6Ra0sbA/1Iavli8LdMbTjyrsOPaxMm4lrKl8VJN4sJI5F64qy2EpLj3+5INLvNPfW4ddwpStbfP3Rf3jIgcw==",
+      "version": "1.6.18",
+      "resolved": "https://registry.npmjs.org/babel-plugin-extract-import-names/-/babel-plugin-extract-import-names-1.6.18.tgz",
+      "integrity": "sha512-2EyZia3Ezl3UdhBcgDl6KZTNkYa2VhmAHHbJdhCroa1pZD/E56BulVsSKIhm/kza9agnabDR2VEHO+ZnqpfxbQ==",
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "7.10.4"
@@ -7744,14 +7698,14 @@
       }
     },
     "browserslist": {
-      "version": "4.14.0",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.14.0.tgz",
-      "integrity": "sha512-pUsXKAF2lVwhmtpeA3LJrZ76jXuusrNyhduuQs7CDFf9foT4Y38aQOserd2lMe5DSSrjf3fx34oHwryuvxAUgQ==",
+      "version": "4.14.3",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.14.3.tgz",
+      "integrity": "sha512-GcZPC5+YqyPO4SFnz48/B0YaCwS47Q9iPChRGi6t7HhflKBcINzFrJvRfC+jp30sRMKxF+d4EHGs27Z0XP1NaQ==",
       "requires": {
-        "caniuse-lite": "^1.0.30001111",
-        "electron-to-chromium": "^1.3.523",
-        "escalade": "^3.0.2",
-        "node-releases": "^1.1.60"
+        "caniuse-lite": "^1.0.30001131",
+        "electron-to-chromium": "^1.3.570",
+        "escalade": "^3.1.0",
+        "node-releases": "^1.1.61"
       }
     },
     "bser": {
@@ -7986,9 +7940,9 @@
       "integrity": "sha1-IsxKNKCrxDlQ9CxkEQJKP2NmtFo="
     },
     "caniuse-lite": {
-      "version": "1.0.30001122",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001122.tgz",
-      "integrity": "sha512-pxjw28CThdrqfz06nJkpAc5SXM404TXB/h5f4UJX+rrXJKE/1bu/KAILc2AY+O6cQIFtRjV9qOR2vaEp9LDGUA=="
+      "version": "1.0.30001131",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001131.tgz",
+      "integrity": "sha512-4QYi6Mal4MMfQMSqGIRPGbKIbZygeN83QsWq1ixpUwvtfgAZot5BrCKzGygvZaV+CnELdTwD0S4cqUNozq7/Cw=="
     },
     "capture-exit": {
       "version": "2.0.0",
@@ -9326,9 +9280,9 @@
       "integrity": "sha512-hBSVCvSmWC+QypYObzwGOd9wqdDpOt+0wl0KbU+R+uuZBS1jN8VsD1ss3irQDknRj5NvxiTF6oj/nDRnN/UQNw=="
     },
     "dayjs": {
-      "version": "1.8.35",
-      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.8.35.tgz",
-      "integrity": "sha512-isAbIEenO4ilm6f8cpqvgjZCsuerDAz2Kb7ri201AiNn58aqXuaLJEnCtfIMdCvERZHNGRY5lDMTr/jdAnKSWQ=="
+      "version": "1.8.36",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.8.36.tgz",
+      "integrity": "sha512-3VmRXEtw7RZKAf+4Tv1Ym9AGeo8r8+CjDi26x+7SYQil1UqtqdaokhzoEJohqlzt0m5kacJSDhJQkG/LWhpRBw=="
     },
     "debug": {
       "version": "2.6.9",
@@ -9754,9 +9708,9 @@
       },
       "dependencies": {
         "domelementtype": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.0.1.tgz",
-          "integrity": "sha512-5HOHUDsYZWV8FGWN0Njbr/Rn7f/eWSQi1v7+HsUVwXgn8nWWlL64zKDkS0n8ZmQ3mlWOMuXOnR+7Nx/5tMO5AQ=="
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.0.2.tgz",
+          "integrity": "sha512-wFwTwCVebUrMgGeAwRL/NhZtHAUyT9n9yg4IMDwf10+6iCMxSkVq9MGCVEH+QZWo1nNidy8kNvwmv4zWHDTqvA=="
         },
         "entities": {
           "version": "2.0.3",
@@ -9947,9 +9901,9 @@
       }
     },
     "electron-to-chromium": {
-      "version": "1.3.558",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.558.tgz",
-      "integrity": "sha512-r6th6b/TU2udqVoUDGWHF/z2ACJVnEei0wvWZf/nt+Qql1Vxh60ZYPhQP46j4D73T/Jou7hl4TqQfxben+qJTg=="
+      "version": "1.3.570",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.570.tgz",
+      "integrity": "sha512-Y6OCoVQgFQBP5py6A/06+yWxUZHDlNr/gNDGatjH8AZqXl8X0tE4LfjLJsXGz/JmWJz8a6K7bR1k+QzZ+k//fg=="
     },
     "element-resize-detector": {
       "version": "1.2.1",
@@ -10322,9 +10276,9 @@
       "integrity": "sha512-E9kK/bjtCQRpN1K28Xh4BlmP8egvZBGJJ+9GtnzOwt7mdqtrjHFuVGr7QJfdjBIKqrlU5duPf3pCBoDrkjVYFg=="
     },
     "escalade": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.0.2.tgz",
-      "integrity": "sha512-gPYAU37hYCUhW5euPeR+Y74F7BL+IBsV93j5cvGriSaD1aG6MGsqsV1yamRdrWrb2j3aiZvb0X+UBOWpx3JWtQ=="
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.0.tgz",
+      "integrity": "sha512-mAk+hPSO8fLDkhV7V0dXazH5pDc6MrjBTPyD3VeKzxnVFjH1MIxbCdqGZB9O8+EwWakZs3ZCbDS4IpRt79V1ig=="
     },
     "escape-html": {
       "version": "1.0.3",
@@ -11814,9 +11768,9 @@
       "integrity": "sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA=="
     },
     "flow-parser": {
-      "version": "0.132.0",
-      "resolved": "https://registry.npmjs.org/flow-parser/-/flow-parser-0.132.0.tgz",
-      "integrity": "sha512-y1P37zDCPSdphlk+w+roCqcOar6iQdNaAJldJ6xx5/2r4ZRv4KHO+qL+AXwPWp+34eN+oPxPjWnU7GybJnyISQ==",
+      "version": "0.134.0",
+      "resolved": "https://registry.npmjs.org/flow-parser/-/flow-parser-0.134.0.tgz",
+      "integrity": "sha512-VmRba5YXKmVqIH3xNzUJ4pNobxXEOl6h36m+0f5dZ6/av9YlRpls/yBnPESQ4qBUbyyp7iqoc1Feo1lFw3u1YQ==",
       "dev": true
     },
     "flush-write-stream": {
@@ -12453,9 +12407,13 @@
           }
         },
         "graphql-language-service-parser": {
-          "version": "1.6.2",
-          "resolved": "https://registry.npmjs.org/graphql-language-service-parser/-/graphql-language-service-parser-1.6.2.tgz",
-          "integrity": "sha512-7CwFkvuOjyrzwk+Ox4hPH839NOGnFHbzlWD08nsRxRTqth71LkHWS1ADVFxvBv49C1kXFmLSsCMhi4PH1meozQ=="
+          "version": "1.6.3",
+          "resolved": "https://registry.npmjs.org/graphql-language-service-parser/-/graphql-language-service-parser-1.6.3.tgz",
+          "integrity": "sha512-UjmVXcSN59pCkFDBIZav0rTdz7ISeYAgGshA/0OpFlrJ6ZkS3hlOBbu/QvLyjRvTcjKpx95qT299auL39kE+/g==",
+          "requires": {
+            "graphql-language-service-types": "^1.6.2",
+            "typescript": "^3.9.5"
+          }
         }
       }
     },
@@ -12524,9 +12482,13 @@
       },
       "dependencies": {
         "graphql-language-service-parser": {
-          "version": "1.6.2",
-          "resolved": "https://registry.npmjs.org/graphql-language-service-parser/-/graphql-language-service-parser-1.6.2.tgz",
-          "integrity": "sha512-7CwFkvuOjyrzwk+Ox4hPH839NOGnFHbzlWD08nsRxRTqth71LkHWS1ADVFxvBv49C1kXFmLSsCMhi4PH1meozQ=="
+          "version": "1.6.3",
+          "resolved": "https://registry.npmjs.org/graphql-language-service-parser/-/graphql-language-service-parser-1.6.3.tgz",
+          "integrity": "sha512-UjmVXcSN59pCkFDBIZav0rTdz7ISeYAgGshA/0OpFlrJ6ZkS3hlOBbu/QvLyjRvTcjKpx95qT299auL39kE+/g==",
+          "requires": {
+            "graphql-language-service-types": "^1.6.2",
+            "typescript": "^3.9.5"
+          }
         }
       }
     },
@@ -12546,9 +12508,9 @@
       }
     },
     "graphql-language-service-types": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/graphql-language-service-types/-/graphql-language-service-types-1.6.1.tgz",
-      "integrity": "sha512-ag3m5b7aje7ZBSuLVQE/gt2iDL9WEfzotZfLyskUDOonhHKniQ8BfmSQ/pF9F6zrdVjtZ8VRr5nes1sEYvvwKQ=="
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/graphql-language-service-types/-/graphql-language-service-types-1.6.2.tgz",
+      "integrity": "sha512-5cslPoUd8P7/EjJ5L3/zs0NBeDhvQHhjUMbjKQakwqu4tZXplriZ9KvvA+Q/n4w/Rn79+3cbr7maNtsTk6/TmQ=="
     },
     "graphql-language-service-utils": {
       "version": "1.2.2",
@@ -12568,11 +12530,12 @@
       }
     },
     "graphql-parse-resolve-info": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/graphql-parse-resolve-info/-/graphql-parse-resolve-info-4.7.0.tgz",
-      "integrity": "sha512-vrfvITs1vQCmzasAnfpzjTnImfo1gSwBijJEo6PF+0ZP3cLgJsmsNBvc9VJaiXxdjShS6sWI4V7HTrlz+UjGGw==",
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/graphql-parse-resolve-info/-/graphql-parse-resolve-info-4.9.0.tgz",
+      "integrity": "sha512-tJqpmG+t5e68ZUjlbNzZ6O6kjzULeVBa+2KOC0IwwxaajtnKpp1bzaZxteOvWATdPwuASfOFJA1epYiva6/ztQ==",
       "requires": {
-        "debug": "^4.1.1"
+        "debug": "^4.1.1",
+        "tslib": "^2.0.1"
       },
       "dependencies": {
         "debug": {
@@ -12587,6 +12550,11 @@
           "version": "2.1.2",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        },
+        "tslib": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.1.tgz",
+          "integrity": "sha512-SgIkNheinmEBgx1IUNirK0TUD4X9yjjBRTqqjggWCU3pUEqIk3/Uwl3yRixYKT6WjQuGiwDv4NomL3wqRCj+CQ=="
         }
       }
     },
@@ -12882,9 +12850,9 @@
       "integrity": "sha512-gW3sxfynIvZApL4L07wryYF4+C9VvH3AUi7LAnVXV4MneGEgwOByXvFo18BgmTWnm7oHAe874jKbIB1YhHSIzA=="
     },
     "hast-util-raw": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/hast-util-raw/-/hast-util-raw-6.0.0.tgz",
-      "integrity": "sha512-IQo6tv3bMMKxk53DljswliucCJOQxaZFCuKEJ7X80249dmJ1nA9LtOnnylsLlqTG98NjQ+iGcoLAYo9q5FRhRg==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/hast-util-raw/-/hast-util-raw-6.0.1.tgz",
+      "integrity": "sha512-ZMuiYA+UF7BXBtsTBNcLBF5HzXzkyE6MLzJnL605LKE8GJylNjGc4jjxazAHUtcwT5/CEt6afRKViYB4X66dig==",
       "dev": true,
       "requires": {
         "@types/hast": "^2.0.0",
@@ -13578,9 +13546,9 @@
           "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
         },
         "rxjs": {
-          "version": "6.6.2",
-          "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.2.tgz",
-          "integrity": "sha512-BHdBMVoWC2sL26w//BCu3YzKT4s2jip/WhwsGEDmeKYBhKDZeYezVUnHatYB7L85v5xs0BAQmg6BEYJEKxBabg==",
+          "version": "6.6.3",
+          "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.3.tgz",
+          "integrity": "sha512-trsQc+xYYXZ3urjOiJOuCOa5N3jAZ3eiSpQB5hIT8zGlL2QfnHLJ2r7GMkBGuIausdJN1OneaI6gQlsqNHHmZQ==",
           "requires": {
             "tslib": "^1.9.0"
           }
@@ -13746,9 +13714,9 @@
       "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
     },
     "is-callable": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.0.tgz",
-      "integrity": "sha512-pyVD9AaGLxtg6srb2Ng6ynWJqkHU9bEM087AKck0w8QwDarTfNcpIYoU8x8Hv2Icm8u6kFJM18Dag8lyqGkviw=="
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.1.tgz",
+      "integrity": "sha512-wliAfSzx6V+6WfMOmus1xy0XvSgf/dlStkvTfq7F0g4bOIW0PSUbnyse3NhDwdyYS1ozfUtAAySqTws3z9Eqgg=="
     },
     "is-ci": {
       "version": "1.2.1",
@@ -17011,18 +16979,15 @@
       }
     },
     "mdast-util-to-hast": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-9.1.0.tgz",
-      "integrity": "sha512-Akl2Vi9y9cSdr19/Dfu58PVwifPXuFt1IrHe7l+Crme1KvgUT+5z+cHLVcQVGCiNTZZcdqjnuv9vPkGsqWytWA==",
+      "version": "9.1.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-9.1.1.tgz",
+      "integrity": "sha512-vpMWKFKM2mnle+YbNgDXxx95vv0CoLU0v/l3F5oFAG5DV7qwkZVWA206LsAdOnEVyf5vQcLnb3cWJywu7mUxsQ==",
       "dev": true,
       "requires": {
         "@types/mdast": "^3.0.0",
         "@types/unist": "^2.0.3",
-        "collapse-white-space": "^1.0.0",
-        "detab": "^2.0.0",
         "mdast-util-definitions": "^3.0.0",
         "mdurl": "^1.0.0",
-        "trim-lines": "^1.0.0",
         "unist-builder": "^2.0.0",
         "unist-util-generated": "^1.0.0",
         "unist-util-position": "^3.0.0",
@@ -17462,9 +17427,9 @@
       }
     },
     "moment": {
-      "version": "2.27.0",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.27.0.tgz",
-      "integrity": "sha512-al0MUK7cpIcglMv3YF13qSgdAIqxHTO7brRtaz3DlSULbqfazqkc5kEjNrLDOM7fsjshoFIihnU8snrP7zUvhQ=="
+      "version": "2.28.0",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.28.0.tgz",
+      "integrity": "sha512-Z5KOjYmnHyd/ukynmFd/WwyXHd7L4J9vTI/nn5Ap9AVUgaAE15VvQ9MOGmJJygEUklupqIrFnor/tjTwRU+tQw=="
     },
     "moo": {
       "version": "0.5.1",
@@ -17645,9 +17610,9 @@
       }
     },
     "node-forge": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.9.0.tgz",
-      "integrity": "sha512-7ASaDa3pD+lJ3WvXFsxekJQelBKRpne+GOVbLbtHYdd7pFspyeuJHnWfLplGf3SwKGbfs/aYl5V/JCIaHVUKKQ==",
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.10.0.tgz",
+      "integrity": "sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA==",
       "dev": true
     },
     "node-gyp": {
@@ -17748,9 +17713,9 @@
       }
     },
     "node-releases": {
-      "version": "1.1.60",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.60.tgz",
-      "integrity": "sha512-gsO4vjEdQaTusZAEebUWp2a5d7dF5DYoIpDG7WySnk7BuZDW+GPpHXoXXuYawRBr/9t5q54tirPz79kFIWg4dA=="
+      "version": "1.1.61",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.61.tgz",
+      "integrity": "sha512-DD5vebQLg8jLCOzwupn954fbIiZht05DAZs0k2u8NStSe6h9XdsuIQL8hSRKYiU8WUQRznmSDrKGbv3ObOmC7g=="
     },
     "nopt": {
       "version": "1.0.10",
@@ -21199,14 +21164,35 @@
       }
     },
     "object.assign": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.0.tgz",
-      "integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.1.tgz",
+      "integrity": "sha512-VT/cxmx5yaoHSOTSyrCygIDFco+RsibY2NM0a4RdEeY/4KgqezwFtK1yr3U67xYhqJSlASm2pKhLVzPj2lr4bA==",
       "requires": {
-        "define-properties": "^1.1.2",
-        "function-bind": "^1.1.1",
-        "has-symbols": "^1.0.0",
-        "object-keys": "^1.0.11"
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.18.0-next.0",
+        "has-symbols": "^1.0.1",
+        "object-keys": "^1.1.1"
+      },
+      "dependencies": {
+        "es-abstract": {
+          "version": "1.18.0-next.0",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0-next.0.tgz",
+          "integrity": "sha512-elZXTZXKn51hUBdJjSZGYRujuzilgXo8vSPQzjGYXLvSlGiCo8VO8ZGV3kjo9a0WNJJ57hENagwbtlRuHuzkcQ==",
+          "requires": {
+            "es-to-primitive": "^1.2.1",
+            "function-bind": "^1.1.1",
+            "has": "^1.0.3",
+            "has-symbols": "^1.0.1",
+            "is-callable": "^1.2.0",
+            "is-negative-zero": "^2.0.0",
+            "is-regex": "^1.1.1",
+            "object-inspect": "^1.8.0",
+            "object-keys": "^1.1.1",
+            "object.assign": "^4.1.0",
+            "string.prototype.trimend": "^1.0.1",
+            "string.prototype.trimstart": "^1.0.1"
+          }
+        }
       }
     },
     "object.entries": {
@@ -22037,9 +22023,9 @@
       "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs="
     },
     "postcss": {
-      "version": "7.0.32",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.32.tgz",
-      "integrity": "sha512-03eXong5NLnNCD05xscnGKGDZ98CyzoqPSMjOe6SuoQY7Z2hIj0Ld1g/O/UQRuOle2aRtiIRDg9tDcTGAkLfKw==",
+      "version": "7.0.34",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.34.tgz",
+      "integrity": "sha512-H/7V2VeNScX9KE83GDrDZNiGT1m2H+UTnlinIzhjlLX9hfMUn1mHNnGeX81a1c8JSBdBvqk7c2ZOG6ZPn5itGw==",
       "requires": {
         "chalk": "^2.4.2",
         "source-map": "^0.6.1",
@@ -22123,9 +22109,9 @@
       }
     },
     "postcss-load-config": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-2.1.0.tgz",
-      "integrity": "sha512-4pV3JJVPLd5+RueiVVB+gFOAa7GWc25XQcMp86Zexzke69mKf6Nx9LRcQywdz7yZI9n1udOxmLuAwTBypypF8Q==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-2.1.1.tgz",
+      "integrity": "sha512-D2ENobdoZsW0+BHy4x1CAkXtbXtYWYRIxL/JbtRBqrRGOPtJ2zoga/bEZWhV/ShWB5saVxJMzbMdSyA/vv4tXw==",
       "requires": {
         "cosmiconfig": "^5.0.0",
         "import-cwd": "^2.0.0"
@@ -22828,9 +22814,9 @@
       "integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ=="
     },
     "query-string": {
-      "version": "6.13.1",
-      "resolved": "https://registry.npmjs.org/query-string/-/query-string-6.13.1.tgz",
-      "integrity": "sha512-RfoButmcK+yCta1+FuU8REvisx1oEzhMKwhLUNcepQTPGcNMp1sIqjnfCtfnvGSQZQEhaBHvccujtWoUV3TTbA==",
+      "version": "6.13.2",
+      "resolved": "https://registry.npmjs.org/query-string/-/query-string-6.13.2.tgz",
+      "integrity": "sha512-BMmDaUiLDFU1hlM38jTFcRt7HYiGP/zt1sRzrIWm5zpeEuO1rkbPS0ELI3uehoLuuhHDCS8u8lhFN3fEN4JzPQ==",
       "requires": {
         "decode-uri-component": "^0.2.0",
         "split-on-first": "^1.0.0",
@@ -23037,9 +23023,9 @@
       },
       "dependencies": {
         "rc-align": {
-          "version": "4.0.3",
-          "resolved": "https://registry.npmjs.org/rc-align/-/rc-align-4.0.3.tgz",
-          "integrity": "sha512-TpI0t1tvAo/wYdoZbZlkCK+MkQBqNuPyRZesfsji4tMlqoqQ0q0MhnC9JD5KGPitMvmSB+KWgFpaN2uTz4hw6Q==",
+          "version": "4.0.4",
+          "resolved": "https://registry.npmjs.org/rc-align/-/rc-align-4.0.4.tgz",
+          "integrity": "sha512-lXEFdJ8D6k8BFjcliaMCGojmrfVnfu4t5nUpo6OpE3tQc4WgwTEm9ENB/yvkFWPXsRZFVTwMn8KHKzsjoKb3Rw==",
           "requires": {
             "@babel/runtime": "^7.10.1",
             "classnames": "2.x",
@@ -23048,12 +23034,23 @@
             "resize-observer-polyfill": "^1.5.1"
           }
         },
-        "rc-trigger": {
-          "version": "4.4.2",
-          "resolved": "https://registry.npmjs.org/rc-trigger/-/rc-trigger-4.4.2.tgz",
-          "integrity": "sha512-uw2/s7j1b/RXyixa4omPuxZWv/3ln+H+p0v3trIUBxseolbdj8TTFpXYjXMZdGtMpAEAIbN1yo/K+r7wRB+xtQ==",
+        "rc-motion": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/rc-motion/-/rc-motion-1.1.2.tgz",
+          "integrity": "sha512-YC/E7SSWKBFakYg4PENhSRWD4ZLDqkI7FKmutJcrMewZ91/ZIWfoZSDvPaBdKO0hsFrrzWepFhXQIq0FNnCMWA==",
           "requires": {
-            "@babel/runtime": "^7.10.1",
+            "@babel/runtime": "^7.11.1",
+            "classnames": "^2.2.1",
+            "raf": "^3.4.1",
+            "rc-util": "^5.0.6"
+          }
+        },
+        "rc-trigger": {
+          "version": "4.4.3",
+          "resolved": "https://registry.npmjs.org/rc-trigger/-/rc-trigger-4.4.3.tgz",
+          "integrity": "sha512-yq/WyuiPwxd2q6jy+VPyy0GUCRFJ2eFqAaCwPE27AOftXeIupOcJ/2t1wakSq63cfk7qtzev5DKHUAjb8LOJCw==",
+          "requires": {
+            "@babel/runtime": "^7.11.2",
             "classnames": "^2.2.6",
             "raf": "^3.4.1",
             "rc-align": "^4.0.0",
@@ -23106,10 +23103,11 @@
       }
     },
     "rc-dialog": {
-      "version": "8.1.1",
-      "resolved": "https://registry.npmjs.org/rc-dialog/-/rc-dialog-8.1.1.tgz",
-      "integrity": "sha512-ToyHiMlV94z8LfnmeKoVvu04Pd9+HdwwSHhY2a8IWeYGA5Cjk1WyIZvS+njCsm8rSMM4NqPqFkMZA0N/Iw0NrQ==",
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/rc-dialog/-/rc-dialog-8.2.2.tgz",
+      "integrity": "sha512-U4jR5bE7XpIbMC20JAIv91254b+vQ8LODd8Kxco0XvkL+eJ1aCYkOfRqevJ1ipOIzF3s6F08jSH8YvJqxvpAvA==",
       "requires": {
+        "@babel/runtime": "^7.10.1",
         "rc-animate": "3.x",
         "rc-util": "^5.0.1"
       },
@@ -23138,9 +23136,9 @@
       }
     },
     "rc-dropdown": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/rc-dropdown/-/rc-dropdown-3.1.2.tgz",
-      "integrity": "sha512-s2W5jqvjTid5DxotGO5FlTBaQWeB+Bu7McQgjB8Ot3Wbl72AIKwLf11+lgbV4mA2vWC1H8DKyn6SW9TKLTi0xg==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/rc-dropdown/-/rc-dropdown-3.1.3.tgz",
+      "integrity": "sha512-sqVMDZcyV32y2YIEUBfxzgRzOLXqi/v5JB1GPe0CMyGMadPvbi+YIRF8toKdQf26tcHZobZUOyFk8OOV2BRusw==",
       "requires": {
         "@babel/runtime": "^7.10.1",
         "classnames": "^2.2.6",
@@ -23148,9 +23146,9 @@
       },
       "dependencies": {
         "rc-align": {
-          "version": "4.0.3",
-          "resolved": "https://registry.npmjs.org/rc-align/-/rc-align-4.0.3.tgz",
-          "integrity": "sha512-TpI0t1tvAo/wYdoZbZlkCK+MkQBqNuPyRZesfsji4tMlqoqQ0q0MhnC9JD5KGPitMvmSB+KWgFpaN2uTz4hw6Q==",
+          "version": "4.0.4",
+          "resolved": "https://registry.npmjs.org/rc-align/-/rc-align-4.0.4.tgz",
+          "integrity": "sha512-lXEFdJ8D6k8BFjcliaMCGojmrfVnfu4t5nUpo6OpE3tQc4WgwTEm9ENB/yvkFWPXsRZFVTwMn8KHKzsjoKb3Rw==",
           "requires": {
             "@babel/runtime": "^7.10.1",
             "classnames": "2.x",
@@ -23159,12 +23157,23 @@
             "resize-observer-polyfill": "^1.5.1"
           }
         },
-        "rc-trigger": {
-          "version": "4.4.2",
-          "resolved": "https://registry.npmjs.org/rc-trigger/-/rc-trigger-4.4.2.tgz",
-          "integrity": "sha512-uw2/s7j1b/RXyixa4omPuxZWv/3ln+H+p0v3trIUBxseolbdj8TTFpXYjXMZdGtMpAEAIbN1yo/K+r7wRB+xtQ==",
+        "rc-motion": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/rc-motion/-/rc-motion-1.1.2.tgz",
+          "integrity": "sha512-YC/E7SSWKBFakYg4PENhSRWD4ZLDqkI7FKmutJcrMewZ91/ZIWfoZSDvPaBdKO0hsFrrzWepFhXQIq0FNnCMWA==",
           "requires": {
-            "@babel/runtime": "^7.10.1",
+            "@babel/runtime": "^7.11.1",
+            "classnames": "^2.2.1",
+            "raf": "^3.4.1",
+            "rc-util": "^5.0.6"
+          }
+        },
+        "rc-trigger": {
+          "version": "4.4.3",
+          "resolved": "https://registry.npmjs.org/rc-trigger/-/rc-trigger-4.4.3.tgz",
+          "integrity": "sha512-yq/WyuiPwxd2q6jy+VPyy0GUCRFJ2eFqAaCwPE27AOftXeIupOcJ/2t1wakSq63cfk7qtzev5DKHUAjb8LOJCw==",
+          "requires": {
+            "@babel/runtime": "^7.11.2",
             "classnames": "^2.2.6",
             "raf": "^3.4.1",
             "rc-align": "^4.0.0",
@@ -23185,44 +23194,21 @@
       }
     },
     "rc-image": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/rc-image/-/rc-image-3.0.4.tgz",
-      "integrity": "sha512-XPcggtKffW4k2ktOxzcu4N4RXnQwN7yrdiS0rRXK4r55SHb8BG7qQUmA0VnvKF7o+bPXUP18A3y+OI35hr8CLQ==",
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/rc-image/-/rc-image-3.0.6.tgz",
+      "integrity": "sha512-Dn8mTSlcgKJko417OX8+6yyNIL9+DEa81aexBfT78qWlEpcxtR4GgdsU0+zJLNqa2rnGZyjaBLFtaPw9tUuxYA==",
       "requires": {
         "@ant-design/icons": "^4.2.2",
         "@babel/runtime": "^7.11.2",
         "classnames": "^2.2.6",
-        "rc-dialog": "^8.3.2",
+        "rc-dialog": "~8.2.2",
         "rc-util": "^5.0.6"
-      },
-      "dependencies": {
-        "rc-animate": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/rc-animate/-/rc-animate-3.1.0.tgz",
-          "integrity": "sha512-8FsM+3B1H+0AyTyGggY6JyVldHTs1CyYT8CfTmG/nGHHXlecvSLeICJhcKgRLjUiQlctNnRtB1rwz79cvBVmrw==",
-          "requires": {
-            "@ant-design/css-animation": "^1.7.2",
-            "classnames": "^2.2.6",
-            "raf": "^3.4.0",
-            "rc-util": "^5.0.1"
-          }
-        },
-        "rc-dialog": {
-          "version": "8.3.3",
-          "resolved": "https://registry.npmjs.org/rc-dialog/-/rc-dialog-8.3.3.tgz",
-          "integrity": "sha512-EEc9PoyZ+5lLdoT+b8p39628qQngULF/+Id1Sw/LNE26+P/fjEdbTisAanCZyrguhjPI5ougAkEr3drlQAW/ZA==",
-          "requires": {
-            "@babel/runtime": "^7.10.1",
-            "rc-animate": "3.x",
-            "rc-util": "^5.0.1"
-          }
-        }
       }
     },
     "rc-input-number": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/rc-input-number/-/rc-input-number-6.0.0.tgz",
-      "integrity": "sha512-vbe+g7HvR/joknSnvLkBTi9N9I+LsV4kljfuog8WNiS7OAF3aEN0QcHSOQ4+xk6+Hx9P1tU63z2+TyEx8W/j2Q==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/rc-input-number/-/rc-input-number-6.0.1.tgz",
+      "integrity": "sha512-cS1k6IB/V84VUQd5qWzGFrLHvZjWGHGmYbrvR0QP/C1Ju1SlBqlhqhOBTc6w+dpPs84PCH5caZtNzsHeWZ1zYA==",
       "requires": {
         "@babel/runtime": "^7.10.1",
         "classnames": "^2.2.5",
@@ -23243,9 +23229,9 @@
       },
       "dependencies": {
         "rc-align": {
-          "version": "4.0.3",
-          "resolved": "https://registry.npmjs.org/rc-align/-/rc-align-4.0.3.tgz",
-          "integrity": "sha512-TpI0t1tvAo/wYdoZbZlkCK+MkQBqNuPyRZesfsji4tMlqoqQ0q0MhnC9JD5KGPitMvmSB+KWgFpaN2uTz4hw6Q==",
+          "version": "4.0.4",
+          "resolved": "https://registry.npmjs.org/rc-align/-/rc-align-4.0.4.tgz",
+          "integrity": "sha512-lXEFdJ8D6k8BFjcliaMCGojmrfVnfu4t5nUpo6OpE3tQc4WgwTEm9ENB/yvkFWPXsRZFVTwMn8KHKzsjoKb3Rw==",
           "requires": {
             "@babel/runtime": "^7.10.1",
             "classnames": "2.x",
@@ -23254,12 +23240,23 @@
             "resize-observer-polyfill": "^1.5.1"
           }
         },
-        "rc-trigger": {
-          "version": "4.4.2",
-          "resolved": "https://registry.npmjs.org/rc-trigger/-/rc-trigger-4.4.2.tgz",
-          "integrity": "sha512-uw2/s7j1b/RXyixa4omPuxZWv/3ln+H+p0v3trIUBxseolbdj8TTFpXYjXMZdGtMpAEAIbN1yo/K+r7wRB+xtQ==",
+        "rc-motion": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/rc-motion/-/rc-motion-1.1.2.tgz",
+          "integrity": "sha512-YC/E7SSWKBFakYg4PENhSRWD4ZLDqkI7FKmutJcrMewZ91/ZIWfoZSDvPaBdKO0hsFrrzWepFhXQIq0FNnCMWA==",
           "requires": {
-            "@babel/runtime": "^7.10.1",
+            "@babel/runtime": "^7.11.1",
+            "classnames": "^2.2.1",
+            "raf": "^3.4.1",
+            "rc-util": "^5.0.6"
+          }
+        },
+        "rc-trigger": {
+          "version": "4.4.3",
+          "resolved": "https://registry.npmjs.org/rc-trigger/-/rc-trigger-4.4.3.tgz",
+          "integrity": "sha512-yq/WyuiPwxd2q6jy+VPyy0GUCRFJ2eFqAaCwPE27AOftXeIupOcJ/2t1wakSq63cfk7qtzev5DKHUAjb8LOJCw==",
+          "requires": {
+            "@babel/runtime": "^7.11.2",
             "classnames": "^2.2.6",
             "raf": "^3.4.1",
             "rc-align": "^4.0.0",
@@ -23270,9 +23267,9 @@
       }
     },
     "rc-menu": {
-      "version": "8.5.3",
-      "resolved": "https://registry.npmjs.org/rc-menu/-/rc-menu-8.5.3.tgz",
-      "integrity": "sha512-OLdN+jwhabgyRZDvWYjYpO7RP7wLybhNuAulgGqx1oUPBJrtgVlG/X4HtPb7nypRx/n+eicj6H8CtbCs0L4m/Q==",
+      "version": "8.6.1",
+      "resolved": "https://registry.npmjs.org/rc-menu/-/rc-menu-8.6.1.tgz",
+      "integrity": "sha512-/PzdoOLmhjOi5RqXKrmUGbhKFzM22eZgL3HyYpa2fym1wUfEFXqp8U8b69mbGmY16+YzU7f15nYTxJkbTdgdTA==",
       "requires": {
         "@babel/runtime": "^7.10.1",
         "classnames": "2.x",
@@ -23286,9 +23283,9 @@
       },
       "dependencies": {
         "rc-align": {
-          "version": "4.0.3",
-          "resolved": "https://registry.npmjs.org/rc-align/-/rc-align-4.0.3.tgz",
-          "integrity": "sha512-TpI0t1tvAo/wYdoZbZlkCK+MkQBqNuPyRZesfsji4tMlqoqQ0q0MhnC9JD5KGPitMvmSB+KWgFpaN2uTz4hw6Q==",
+          "version": "4.0.4",
+          "resolved": "https://registry.npmjs.org/rc-align/-/rc-align-4.0.4.tgz",
+          "integrity": "sha512-lXEFdJ8D6k8BFjcliaMCGojmrfVnfu4t5nUpo6OpE3tQc4WgwTEm9ENB/yvkFWPXsRZFVTwMn8KHKzsjoKb3Rw==",
           "requires": {
             "@babel/runtime": "^7.10.1",
             "classnames": "2.x",
@@ -23297,12 +23294,23 @@
             "resize-observer-polyfill": "^1.5.1"
           }
         },
-        "rc-trigger": {
-          "version": "4.4.2",
-          "resolved": "https://registry.npmjs.org/rc-trigger/-/rc-trigger-4.4.2.tgz",
-          "integrity": "sha512-uw2/s7j1b/RXyixa4omPuxZWv/3ln+H+p0v3trIUBxseolbdj8TTFpXYjXMZdGtMpAEAIbN1yo/K+r7wRB+xtQ==",
+        "rc-motion": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/rc-motion/-/rc-motion-1.1.2.tgz",
+          "integrity": "sha512-YC/E7SSWKBFakYg4PENhSRWD4ZLDqkI7FKmutJcrMewZ91/ZIWfoZSDvPaBdKO0hsFrrzWepFhXQIq0FNnCMWA==",
           "requires": {
-            "@babel/runtime": "^7.10.1",
+            "@babel/runtime": "^7.11.1",
+            "classnames": "^2.2.1",
+            "raf": "^3.4.1",
+            "rc-util": "^5.0.6"
+          }
+        },
+        "rc-trigger": {
+          "version": "4.4.3",
+          "resolved": "https://registry.npmjs.org/rc-trigger/-/rc-trigger-4.4.3.tgz",
+          "integrity": "sha512-yq/WyuiPwxd2q6jy+VPyy0GUCRFJ2eFqAaCwPE27AOftXeIupOcJ/2t1wakSq63cfk7qtzev5DKHUAjb8LOJCw==",
+          "requires": {
+            "@babel/runtime": "^7.11.2",
             "classnames": "^2.2.6",
             "raf": "^3.4.1",
             "rc-align": "^4.0.0",
@@ -23313,14 +23321,13 @@
       }
     },
     "rc-motion": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/rc-motion/-/rc-motion-1.1.2.tgz",
-      "integrity": "sha512-YC/E7SSWKBFakYg4PENhSRWD4ZLDqkI7FKmutJcrMewZ91/ZIWfoZSDvPaBdKO0hsFrrzWepFhXQIq0FNnCMWA==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/rc-motion/-/rc-motion-2.0.1.tgz",
+      "integrity": "sha512-spiBod/mQhbAt4ynq0P7TYa8OXAgg/nEloU0jrTO2X4wVkVTI8ynadyjgq7Tr55pegTsuCbYlysEsIdsSrcU0g==",
       "requires": {
         "@babel/runtime": "^7.11.1",
         "classnames": "^2.2.1",
-        "raf": "^3.4.1",
-        "rc-util": "^5.0.6"
+        "rc-util": "^5.2.1"
       }
     },
     "rc-notification": {
@@ -23348,18 +23355,18 @@
       }
     },
     "rc-pagination": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/rc-pagination/-/rc-pagination-3.0.3.tgz",
-      "integrity": "sha512-xm6LsiSOAWlxferiL5e0jcun1B9vbvYzcIkqpYZR7YvC5ZrcU9KKihb+DZe3DY+oUc49xhX2qGS4D66ITHqekQ==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/rc-pagination/-/rc-pagination-3.0.4.tgz",
+      "integrity": "sha512-9v9mmB7FTWS4kWRLFfWafm6LtvB+xdNi+pTIwUODSevzImrlrmMOIhDrOB3u2tEXiy8LyqvCnoyPYt5jQBapxA==",
       "requires": {
         "@babel/runtime": "^7.10.1",
         "classnames": "^2.2.1"
       }
     },
     "rc-picker": {
-      "version": "2.0.9",
-      "resolved": "https://registry.npmjs.org/rc-picker/-/rc-picker-2.0.9.tgz",
-      "integrity": "sha512-fLVYQYUv+gV9Nr5TXsf//3if7mKaGT/h3roONNSrw3KN86To/ppbfFgvJfzkfdO7zyfY8TpOVhdgYPATehEolg==",
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/rc-picker/-/rc-picker-2.0.11.tgz",
+      "integrity": "sha512-pUEne2fikHvzqmOjWNLa1P/ss4/1J9lpHrtSU1IrueRiEbUPLIgXmnzoUeVt3syOZGBnWok6nNDu1FvIQfVMCw==",
       "requires": {
         "@babel/runtime": "^7.10.1",
         "classnames": "^2.2.1",
@@ -23377,9 +23384,9 @@
           "integrity": "sha512-sAJVKx/FqrLYHAQeN7VpJrPhagZc9R4ImZIWYRFZaaohR3KzmuK88touwsSwSVT8Qcbd4zoDsnGfX4GFB4imyQ=="
         },
         "rc-align": {
-          "version": "4.0.3",
-          "resolved": "https://registry.npmjs.org/rc-align/-/rc-align-4.0.3.tgz",
-          "integrity": "sha512-TpI0t1tvAo/wYdoZbZlkCK+MkQBqNuPyRZesfsji4tMlqoqQ0q0MhnC9JD5KGPitMvmSB+KWgFpaN2uTz4hw6Q==",
+          "version": "4.0.4",
+          "resolved": "https://registry.npmjs.org/rc-align/-/rc-align-4.0.4.tgz",
+          "integrity": "sha512-lXEFdJ8D6k8BFjcliaMCGojmrfVnfu4t5nUpo6OpE3tQc4WgwTEm9ENB/yvkFWPXsRZFVTwMn8KHKzsjoKb3Rw==",
           "requires": {
             "@babel/runtime": "^7.10.1",
             "classnames": "2.x",
@@ -23388,12 +23395,23 @@
             "resize-observer-polyfill": "^1.5.1"
           }
         },
-        "rc-trigger": {
-          "version": "4.4.2",
-          "resolved": "https://registry.npmjs.org/rc-trigger/-/rc-trigger-4.4.2.tgz",
-          "integrity": "sha512-uw2/s7j1b/RXyixa4omPuxZWv/3ln+H+p0v3trIUBxseolbdj8TTFpXYjXMZdGtMpAEAIbN1yo/K+r7wRB+xtQ==",
+        "rc-motion": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/rc-motion/-/rc-motion-1.1.2.tgz",
+          "integrity": "sha512-YC/E7SSWKBFakYg4PENhSRWD4ZLDqkI7FKmutJcrMewZ91/ZIWfoZSDvPaBdKO0hsFrrzWepFhXQIq0FNnCMWA==",
           "requires": {
-            "@babel/runtime": "^7.10.1",
+            "@babel/runtime": "^7.11.1",
+            "classnames": "^2.2.1",
+            "raf": "^3.4.1",
+            "rc-util": "^5.0.6"
+          }
+        },
+        "rc-trigger": {
+          "version": "4.4.3",
+          "resolved": "https://registry.npmjs.org/rc-trigger/-/rc-trigger-4.4.3.tgz",
+          "integrity": "sha512-yq/WyuiPwxd2q6jy+VPyy0GUCRFJ2eFqAaCwPE27AOftXeIupOcJ/2t1wakSq63cfk7qtzev5DKHUAjb8LOJCw==",
+          "requires": {
+            "@babel/runtime": "^7.11.2",
             "classnames": "^2.2.6",
             "raf": "^3.4.1",
             "rc-align": "^4.0.0",
@@ -23404,10 +23422,11 @@
       }
     },
     "rc-progress": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/rc-progress/-/rc-progress-3.0.0.tgz",
-      "integrity": "sha512-dQv1KU3o6Vay604FMYMF4S0x4GNXAgXf1tbQ1QoxeIeQt4d5fUeB7Ri82YPu+G+aRvH/AtxYAlEcnxyVZ1/4Hw==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/rc-progress/-/rc-progress-3.1.0.tgz",
+      "integrity": "sha512-DIe9CFkGA4R/pLZ/4nPChQFmIeB8/4tVCr2knlSf9he71j8Fky469zZHhtCFyNwvNGjw/GVDeoTn4BqU4S0ylw==",
       "requires": {
+        "@babel/runtime": "^7.10.1",
         "classnames": "^2.2.6"
       }
     },
@@ -23433,9 +23452,9 @@
       }
     },
     "rc-select": {
-      "version": "11.1.7",
-      "resolved": "https://registry.npmjs.org/rc-select/-/rc-select-11.1.7.tgz",
-      "integrity": "sha512-HZozKGhFbLDI995OUKQW2uZ2ZcGyzNhWN6gTQqpW5/Z0rae1zftpgkI1yxZ79LukOc8lO2NKlDDKCGH/SJH2Cg==",
+      "version": "11.2.2",
+      "resolved": "https://registry.npmjs.org/rc-select/-/rc-select-11.2.2.tgz",
+      "integrity": "sha512-pfQu3CoW6cYXi4tsCYnoCVEf/1ze8t1vvK9X8NbBtOxL4l9VIAAGf8oAMvotPKNTHrrAouxbORtL8ZZ3uw5lTA==",
       "requires": {
         "@babel/runtime": "^7.10.1",
         "classnames": "2.x",
@@ -23447,9 +23466,9 @@
       },
       "dependencies": {
         "rc-align": {
-          "version": "4.0.3",
-          "resolved": "https://registry.npmjs.org/rc-align/-/rc-align-4.0.3.tgz",
-          "integrity": "sha512-TpI0t1tvAo/wYdoZbZlkCK+MkQBqNuPyRZesfsji4tMlqoqQ0q0MhnC9JD5KGPitMvmSB+KWgFpaN2uTz4hw6Q==",
+          "version": "4.0.4",
+          "resolved": "https://registry.npmjs.org/rc-align/-/rc-align-4.0.4.tgz",
+          "integrity": "sha512-lXEFdJ8D6k8BFjcliaMCGojmrfVnfu4t5nUpo6OpE3tQc4WgwTEm9ENB/yvkFWPXsRZFVTwMn8KHKzsjoKb3Rw==",
           "requires": {
             "@babel/runtime": "^7.10.1",
             "classnames": "2.x",
@@ -23458,12 +23477,23 @@
             "resize-observer-polyfill": "^1.5.1"
           }
         },
-        "rc-trigger": {
-          "version": "4.4.2",
-          "resolved": "https://registry.npmjs.org/rc-trigger/-/rc-trigger-4.4.2.tgz",
-          "integrity": "sha512-uw2/s7j1b/RXyixa4omPuxZWv/3ln+H+p0v3trIUBxseolbdj8TTFpXYjXMZdGtMpAEAIbN1yo/K+r7wRB+xtQ==",
+        "rc-motion": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/rc-motion/-/rc-motion-1.1.2.tgz",
+          "integrity": "sha512-YC/E7SSWKBFakYg4PENhSRWD4ZLDqkI7FKmutJcrMewZ91/ZIWfoZSDvPaBdKO0hsFrrzWepFhXQIq0FNnCMWA==",
           "requires": {
-            "@babel/runtime": "^7.10.1",
+            "@babel/runtime": "^7.11.1",
+            "classnames": "^2.2.1",
+            "raf": "^3.4.1",
+            "rc-util": "^5.0.6"
+          }
+        },
+        "rc-trigger": {
+          "version": "4.4.3",
+          "resolved": "https://registry.npmjs.org/rc-trigger/-/rc-trigger-4.4.3.tgz",
+          "integrity": "sha512-yq/WyuiPwxd2q6jy+VPyy0GUCRFJ2eFqAaCwPE27AOftXeIupOcJ/2t1wakSq63cfk7qtzev5DKHUAjb8LOJCw==",
+          "requires": {
+            "@babel/runtime": "^7.11.2",
             "classnames": "^2.2.6",
             "raf": "^3.4.1",
             "rc-align": "^4.0.0",
@@ -23539,9 +23569,9 @@
       }
     },
     "rc-table": {
-      "version": "7.9.7",
-      "resolved": "https://registry.npmjs.org/rc-table/-/rc-table-7.9.7.tgz",
-      "integrity": "sha512-S/46pdU7fKBoL7N8JDu+KpkGSB3fJkiGoxvMCLBrR4p7/BJEYr1X4MFKb5BpkE7ZpEK4n44ILiVZZT7I7EiGVA==",
+      "version": "7.9.10",
+      "resolved": "https://registry.npmjs.org/rc-table/-/rc-table-7.9.10.tgz",
+      "integrity": "sha512-WtPBxYsBU/a5MIglilbMlVkiXkPKXpUM/CPCFaqA2veh1b7J40mbTGQmU8VT6S0FClkI5jm0QBtSp6LstPkOMQ==",
       "requires": {
         "@babel/runtime": "^7.10.1",
         "classnames": "^2.2.5",
@@ -23552,45 +23582,17 @@
       }
     },
     "rc-tabs": {
-      "version": "11.6.1",
-      "resolved": "https://registry.npmjs.org/rc-tabs/-/rc-tabs-11.6.1.tgz",
-      "integrity": "sha512-fJZUOmwBo2E4WTbucCSZO/N1ZK+d9K/QchgDeycTIqxl5D/xtX0Dw/vC2DFi140OFjAy2JL7H0EmsSeOFfCgzw==",
+      "version": "11.6.2",
+      "resolved": "https://registry.npmjs.org/rc-tabs/-/rc-tabs-11.6.2.tgz",
+      "integrity": "sha512-7Z5Lg+nP/H4V7dIlewrOC0+aogRVH3ASjTy4VIletYOeStGPWYSfwBnUTBdcCXcUuWuyyKnNkYrUD0yaRqUCIA==",
       "requires": {
-        "@babel/runtime": "^7.10.1",
+        "@babel/runtime": "^7.11.2",
         "classnames": "2.x",
         "raf": "^3.4.1",
-        "rc-dropdown": "^3.1.0",
-        "rc-menu": "^8.2.1",
+        "rc-dropdown": "^3.1.3",
+        "rc-menu": "^8.6.1",
         "rc-resize-observer": "^0.2.1",
-        "rc-trigger": "^4.2.1",
         "rc-util": "^5.0.0"
-      },
-      "dependencies": {
-        "rc-align": {
-          "version": "4.0.3",
-          "resolved": "https://registry.npmjs.org/rc-align/-/rc-align-4.0.3.tgz",
-          "integrity": "sha512-TpI0t1tvAo/wYdoZbZlkCK+MkQBqNuPyRZesfsji4tMlqoqQ0q0MhnC9JD5KGPitMvmSB+KWgFpaN2uTz4hw6Q==",
-          "requires": {
-            "@babel/runtime": "^7.10.1",
-            "classnames": "2.x",
-            "dom-align": "^1.7.0",
-            "rc-util": "^5.0.1",
-            "resize-observer-polyfill": "^1.5.1"
-          }
-        },
-        "rc-trigger": {
-          "version": "4.4.2",
-          "resolved": "https://registry.npmjs.org/rc-trigger/-/rc-trigger-4.4.2.tgz",
-          "integrity": "sha512-uw2/s7j1b/RXyixa4omPuxZWv/3ln+H+p0v3trIUBxseolbdj8TTFpXYjXMZdGtMpAEAIbN1yo/K+r7wRB+xtQ==",
-          "requires": {
-            "@babel/runtime": "^7.10.1",
-            "classnames": "^2.2.6",
-            "raf": "^3.4.1",
-            "rc-align": "^4.0.0",
-            "rc-motion": "^1.0.0",
-            "rc-util": "^5.0.1"
-          }
-        }
       }
     },
     "rc-textarea": {
@@ -23615,15 +23617,28 @@
       }
     },
     "rc-tree": {
-      "version": "3.9.4",
-      "resolved": "https://registry.npmjs.org/rc-tree/-/rc-tree-3.9.4.tgz",
-      "integrity": "sha512-uzgpQL4LLoriYE7xTro2tzb5rd6Eg9lhjWZlN/MaWn+lsFw2nnlLbMULejHd7RQXdYB7t3tTCwk7DiKSN+udrA==",
+      "version": "3.9.5",
+      "resolved": "https://registry.npmjs.org/rc-tree/-/rc-tree-3.9.5.tgz",
+      "integrity": "sha512-ZGVl1o83hZoz971pzY9Y7yZM+f9qcia1Gym+QNyc3zMGQVshbr6CX2WZ8xUK18tTkdRSqbTXmZFnvYf1lfqT8A==",
       "requires": {
         "@babel/runtime": "^7.10.1",
         "classnames": "2.x",
         "rc-motion": "^1.0.0",
         "rc-util": "^5.0.0",
         "rc-virtual-list": "^3.0.1"
+      },
+      "dependencies": {
+        "rc-motion": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/rc-motion/-/rc-motion-1.1.2.tgz",
+          "integrity": "sha512-YC/E7SSWKBFakYg4PENhSRWD4ZLDqkI7FKmutJcrMewZ91/ZIWfoZSDvPaBdKO0hsFrrzWepFhXQIq0FNnCMWA==",
+          "requires": {
+            "@babel/runtime": "^7.11.1",
+            "classnames": "^2.2.1",
+            "raf": "^3.4.1",
+            "rc-util": "^5.0.6"
+          }
+        }
       }
     },
     "rc-tree-select": {
@@ -23667,11 +23682,13 @@
       }
     },
     "rc-upload": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/rc-upload/-/rc-upload-3.2.1.tgz",
-      "integrity": "sha512-gmIy08tco2YFTSiru9zgeTmUcDKPyUMUUBdUIjG2CcHz4jdbpaPx/RL/Wz9CMD6ppQizK0gES0rcQ1+o5frK2Q==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/rc-upload/-/rc-upload-3.3.1.tgz",
+      "integrity": "sha512-KWkJbVM9BwU8qi/2jZwmZpAcdRzDkuyfn/yAOLu+nm47dyd6//MtxzQD3XZDFkC6jQ6D5FmlKn6DhmOfV3v43w==",
       "requires": {
-        "classnames": "^2.2.5"
+        "@babel/runtime": "^7.10.1",
+        "classnames": "^2.2.5",
+        "rc-util": "^5.2.0"
       }
     },
     "rc-util": {
@@ -23684,9 +23701,9 @@
       }
     },
     "rc-virtual-list": {
-      "version": "3.0.12",
-      "resolved": "https://registry.npmjs.org/rc-virtual-list/-/rc-virtual-list-3.0.12.tgz",
-      "integrity": "sha512-CSl/QFkLzuq84rqKi1GcrDnQgnYGdsfDiGtISIX8ZE2Uc4ZmUA2exQ/4lXmX2Hnex/sQK4oO+NJuQYfY3CTxxg==",
+      "version": "3.0.16",
+      "resolved": "https://registry.npmjs.org/rc-virtual-list/-/rc-virtual-list-3.0.16.tgz",
+      "integrity": "sha512-3lghwR6AbCsj5JIWlwJ4zK1cS/e7JLYKA+RnC6JrMz11dGgoM0jF4KkK3UzToG1APSSu42Oy4pe2OT42+nRJ2g==",
       "requires": {
         "classnames": "^2.2.6",
         "rc-resize-observer": "^0.2.3",
@@ -23948,9 +23965,9 @@
           }
         },
         "rxjs": {
-          "version": "6.6.2",
-          "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.2.tgz",
-          "integrity": "sha512-BHdBMVoWC2sL26w//BCu3YzKT4s2jip/WhwsGEDmeKYBhKDZeYezVUnHatYB7L85v5xs0BAQmg6BEYJEKxBabg==",
+          "version": "6.6.3",
+          "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.3.tgz",
+          "integrity": "sha512-trsQc+xYYXZ3urjOiJOuCOa5N3jAZ3eiSpQB5hIT8zGlL2QfnHLJ2r7GMkBGuIausdJN1OneaI6gQlsqNHHmZQ==",
           "requires": {
             "tslib": "^1.9.0"
           }
@@ -24127,14 +24144,14 @@
       }
     },
     "react-helmet-async": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/react-helmet-async/-/react-helmet-async-1.0.6.tgz",
-      "integrity": "sha512-t+bhAI4NgxfEv8ez4r77cLfR4O4Z55E/FH2DT+uiE4U7yfWgAk7OAOi7IxHxuYEVLI26bqjZvlVCkpC5/5AoNA==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/react-helmet-async/-/react-helmet-async-1.0.7.tgz",
+      "integrity": "sha512-By90p5uxAriGukbyejq2poK41DwTxpNWOpOjN8mIyX/BKrCd3+sXZ5pHUZXjHyjR5OYS7PGsOD9dbM61YxfFmA==",
       "requires": {
-        "@babel/runtime": "^7.9.2",
+        "@babel/runtime": "^7.11.2",
         "invariant": "^2.2.4",
         "prop-types": "^15.7.2",
-        "react-fast-compare": "^3.0.1",
+        "react-fast-compare": "^3.2.0",
         "shallowequal": "^1.1.0"
       }
     },
@@ -24310,9 +24327,9 @@
       }
     },
     "react-resizable": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/react-resizable/-/react-resizable-1.10.1.tgz",
-      "integrity": "sha512-Jd/bKOKx6+19NwC4/aMLRu/J9/krfxlDnElP41Oc+oLiUWs/zwV1S9yBfBZRnqAwQb6vQ/HRSk3bsSWGSgVbpw==",
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/react-resizable/-/react-resizable-1.11.0.tgz",
+      "integrity": "sha512-VoGz2ddxUFvildS8r8/29UZJeyiM3QJnlmRZSuXm+FpTqq/eIrMPc796Y9XQLg291n2hFZJtIoP1xC3hSTw/jg==",
       "requires": {
         "prop-types": "15.x",
         "react-draggable": "^4.0.3"
@@ -24856,19 +24873,20 @@
       }
     },
     "redux-devtools": {
-      "version": "3.6.1",
-      "resolved": "https://registry.npmjs.org/redux-devtools/-/redux-devtools-3.6.1.tgz",
-      "integrity": "sha512-z0OFPb3WGmYgJ1KOAGVH3Ri7KLmH1HPax3ZelOzu2S3PqzXmLegaO6/LpvEiH6ZUQc07lHpSrHCFNKCRBRwEiQ==",
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/redux-devtools/-/redux-devtools-3.7.0.tgz",
+      "integrity": "sha512-Lnx3UX7mnJij2Xs+RicPK1GyKkbuodrCKtfYmJsN603wC0mc99W//xCAskGVNmRhIXg4e57m2k1CyX0kVzCsBg==",
       "requires": {
+        "@types/prop-types": "^15.7.3",
         "lodash": "^4.17.19",
         "prop-types": "^15.7.2",
-        "redux-devtools-instrument": "^1.9.7"
+        "redux-devtools-instrument": "^1.10.0"
       }
     },
     "redux-devtools-instrument": {
-      "version": "1.9.7",
-      "resolved": "https://registry.npmjs.org/redux-devtools-instrument/-/redux-devtools-instrument-1.9.7.tgz",
-      "integrity": "sha512-QUc2GwRy7I1zhUVsrsRzopptOzT7kTYkLhKoO2Z1sNChVRrbzV0BKwyyQPShpsRrxvpl2ZF1qn93I688AWn4dg==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/redux-devtools-instrument/-/redux-devtools-instrument-1.10.0.tgz",
+      "integrity": "sha512-X8JRBCzX2ADSMp+iiV7YQ8uoTNyEm0VPFPd4T854coz6lvRiBrFSqAr9YAS2n8Kzxx8CJQotR0QF9wsMM+3DvA==",
       "requires": {
         "lodash": "^4.17.19",
         "symbol-observable": "^1.2.0"
@@ -24997,9 +25015,9 @@
       "dev": true
     },
     "regexpu-core": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-4.7.0.tgz",
-      "integrity": "sha512-TQ4KXRnIn6tz6tjnrXEkD/sshygKH/j5KzK86X8MkeHyZ8qst/LZ89j3X4/8HEIfHANTFIP/AbXakeRhWIl5YQ==",
+      "version": "4.7.1",
+      "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-4.7.1.tgz",
+      "integrity": "sha512-ywH2VUraA44DZQuRKzARmw6S66mr48pQVva4LBeRhcOltJ6hExvWly5ZjFLYo67xbIxb6W1q4bAGtgfEl20zfQ==",
       "requires": {
         "regenerate": "^1.4.0",
         "regenerate-unicode-properties": "^8.2.0",
@@ -25135,114 +25153,25 @@
       }
     },
     "remark-footnotes": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/remark-footnotes/-/remark-footnotes-1.0.0.tgz",
-      "integrity": "sha512-X9Ncj4cj3/CIvLI2Z9IobHtVi8FVdUrdJkCNaL9kdX8ohfsi18DXHsCVd/A7ssARBdccdDb5ODnt62WuEWaM/g==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/remark-footnotes/-/remark-footnotes-2.0.0.tgz",
+      "integrity": "sha512-3Clt8ZMH75Ayjp9q4CorNeyjwIxHFcTkaektplKGl2A1jNGEUey8cKL0ZC5vJwfcD5GFGsNLImLG/NGzWIzoMQ==",
       "dev": true
     },
     "remark-mdx": {
-      "version": "1.6.16",
-      "resolved": "https://registry.npmjs.org/remark-mdx/-/remark-mdx-1.6.16.tgz",
-      "integrity": "sha512-xqZhBQ4TonFiSFpVt6SnTLRnxstu7M6pcaOibKZhqzk4zMRVacVenD7iECjfESK+72LkPm/NW+0r5ahJAg7zlQ==",
+      "version": "1.6.18",
+      "resolved": "https://registry.npmjs.org/remark-mdx/-/remark-mdx-1.6.18.tgz",
+      "integrity": "sha512-xNhjv4kJZ8L6RV68yK8fQ6XWlvSIFOE5VPmM7wMKSwkvwBu6tlUJy0gRF2WiZ4fPPOj6jpqlVB9QakipvZuEqg==",
       "dev": true,
       "requires": {
-        "@babel/core": "7.10.5",
+        "@babel/core": "7.11.6",
         "@babel/helper-plugin-utils": "7.10.4",
-        "@babel/plugin-proposal-object-rest-spread": "7.10.4",
+        "@babel/plugin-proposal-object-rest-spread": "7.11.0",
         "@babel/plugin-syntax-jsx": "7.10.4",
-        "@mdx-js/util": "1.6.16",
+        "@mdx-js/util": "1.6.18",
         "is-alphabetical": "1.0.4",
         "remark-parse": "8.0.3",
-        "unified": "9.1.0"
-      },
-      "dependencies": {
-        "@babel/core": {
-          "version": "7.10.5",
-          "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.10.5.tgz",
-          "integrity": "sha512-O34LQooYVDXPl7QWCdW9p4NR+QlzOr7xShPPJz8GsuCU3/8ua/wqTr7gmnxXv+WBESiGU/G5s16i6tUvHkNb+w==",
-          "dev": true,
-          "requires": {
-            "@babel/code-frame": "^7.10.4",
-            "@babel/generator": "^7.10.5",
-            "@babel/helper-module-transforms": "^7.10.5",
-            "@babel/helpers": "^7.10.4",
-            "@babel/parser": "^7.10.5",
-            "@babel/template": "^7.10.4",
-            "@babel/traverse": "^7.10.5",
-            "@babel/types": "^7.10.5",
-            "convert-source-map": "^1.7.0",
-            "debug": "^4.1.0",
-            "gensync": "^1.0.0-beta.1",
-            "json5": "^2.1.2",
-            "lodash": "^4.17.19",
-            "resolve": "^1.3.2",
-            "semver": "^5.4.1",
-            "source-map": "^0.5.0"
-          }
-        },
-        "@babel/plugin-proposal-object-rest-spread": {
-          "version": "7.10.4",
-          "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.10.4.tgz",
-          "integrity": "sha512-6vh4SqRuLLarjgeOf4EaROJAHjvu9Gl+/346PbDH9yWbJyfnJ/ah3jmYKYtswEyCoWZiidvVHjHshd4WgjB9BA==",
-          "dev": true,
-          "requires": {
-            "@babel/helper-plugin-utils": "^7.10.4",
-            "@babel/plugin-syntax-object-rest-spread": "^7.8.0",
-            "@babel/plugin-transform-parameters": "^7.10.4"
-          }
-        },
-        "@babel/types": {
-          "version": "7.11.5",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.11.5.tgz",
-          "integrity": "sha512-bvM7Qz6eKnJVFIn+1LPtjlBFPVN5jNDc1XmN15vWe7Q3DPBufWWsLiIvUu7xW87uTG6QoggpIDnUgLQvPheU+Q==",
-          "dev": true,
-          "requires": {
-            "@babel/helper-validator-identifier": "^7.10.4",
-            "lodash": "^4.17.19",
-            "to-fast-properties": "^2.0.0"
-          }
-        },
-        "debug": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-          "dev": true,
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
-        "is-buffer": {
-          "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.4.tgz",
-          "integrity": "sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A==",
-          "dev": true
-        },
-        "is-plain-obj": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
-          "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
-          "dev": true
-        },
-        "ms": {
-          "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-          "dev": true
-        },
-        "unified": {
-          "version": "9.1.0",
-          "resolved": "https://registry.npmjs.org/unified/-/unified-9.1.0.tgz",
-          "integrity": "sha512-VXOv7Ic6twsKGJDeZQ2wwPqXs2hM0KNu5Hkg9WgAZbSD1pxhZ7p8swqg583nw1Je2fhwHy6U8aEjiI79x1gvag==",
-          "dev": true,
-          "requires": {
-            "bail": "^1.0.0",
-            "extend": "^3.0.0",
-            "is-buffer": "^2.0.0",
-            "is-plain-obj": "^2.0.0",
-            "trough": "^1.0.0",
-            "vfile": "^4.0.0"
-          }
-        }
+        "unified": "9.2.0"
       }
     },
     "remark-parse": {
@@ -25845,12 +25774,12 @@
       "dev": true
     },
     "selfsigned": {
-      "version": "1.10.7",
-      "resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-1.10.7.tgz",
-      "integrity": "sha512-8M3wBCzeWIJnQfl43IKwOmC4H/RAp50S8DF60znzjW5GVqTcSe2vWclt7hmYVPkKPlHWOu5EaWOMZ2Y6W8ZXTA==",
+      "version": "1.10.8",
+      "resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-1.10.8.tgz",
+      "integrity": "sha512-2P4PtieJeEwVgTU9QEcwIRDQ/mXJLX8/+I3ur+Pg16nS8oNbrGxEso9NyYWy8NAmXiNl4dlAp5MwoNeCWzON4w==",
       "dev": true,
       "requires": {
-        "node-forge": "0.9.0"
+        "node-forge": "^0.10.0"
       }
     },
     "semantic-ui-css": {
@@ -26741,9 +26670,9 @@
       }
     },
     "spdx-license-ids": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.5.tgz",
-      "integrity": "sha512-J+FWzZoynJEXGphVIS+XEh3kFSjZX/1i9gFBaWQcB+/tmpe2qUsSBABpcxqxnAxFdiUFEgAX1bjYGQvIZmoz9Q=="
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.6.tgz",
+      "integrity": "sha512-+orQK83kyMva3WyPf59k1+Y525csj5JejicWut55zeTWANuN17qSiSLUXWtzHeNWORSvT7GLDJ/E/XiIWoXBTw=="
     },
     "spdy": {
       "version": "4.0.2",
@@ -27064,14 +26993,35 @@
       }
     },
     "string.prototype.trim": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.1.tgz",
-      "integrity": "sha512-MjGFEeqixw47dAMFMtgUro/I0+wNqZB5GKXGt1fFr24u3TzDXCPu7J9Buppzoe3r/LqkSDLDDJzE15RGWDGAVw==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.2.tgz",
+      "integrity": "sha512-b5yrbl3BXIjHau9Prk7U0RRYcUYdN4wGSVaqoBQS50CCE3KBuYU0TYRNPFCP7aVoNMX87HKThdMRVIP3giclKg==",
       "dev": true,
       "requires": {
         "define-properties": "^1.1.3",
-        "es-abstract": "^1.17.0-next.1",
-        "function-bind": "^1.1.1"
+        "es-abstract": "^1.18.0-next.0"
+      },
+      "dependencies": {
+        "es-abstract": {
+          "version": "1.18.0-next.0",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0-next.0.tgz",
+          "integrity": "sha512-elZXTZXKn51hUBdJjSZGYRujuzilgXo8vSPQzjGYXLvSlGiCo8VO8ZGV3kjo9a0WNJJ57hENagwbtlRuHuzkcQ==",
+          "dev": true,
+          "requires": {
+            "es-to-primitive": "^1.2.1",
+            "function-bind": "^1.1.1",
+            "has": "^1.0.3",
+            "has-symbols": "^1.0.1",
+            "is-callable": "^1.2.0",
+            "is-negative-zero": "^2.0.0",
+            "is-regex": "^1.1.1",
+            "object-inspect": "^1.8.0",
+            "object-keys": "^1.1.1",
+            "object.assign": "^4.1.0",
+            "string.prototype.trimend": "^1.0.1",
+            "string.prototype.trimstart": "^1.0.1"
+          }
+        }
       }
     },
     "string.prototype.trimend": {
@@ -27392,9 +27342,9 @@
           }
         },
         "dot-prop": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-5.2.0.tgz",
-          "integrity": "sha512-uEUyaDKoSQ1M4Oq8l45hSE26SnTxL6snNnqvK/VWx5wJhmff5z0FUVJDKDanor/6w3kzE3i7XZOk+7wC0EXr1A==",
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-5.3.0.tgz",
+          "integrity": "sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q==",
           "dev": true,
           "requires": {
             "is-obj": "^2.0.0"
@@ -27992,9 +27942,9 @@
       }
     },
     "table": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/table/-/table-6.0.1.tgz",
-      "integrity": "sha512-fmr6168splcy/3XIvhSm5w6hYYOqyr3plAsd7OqoerzyoMnIpoxYuwrpdO2Cm22dh6KCnvirvigPrFZp+tdWFA==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/table/-/table-6.0.3.tgz",
+      "integrity": "sha512-8321ZMcf1B9HvVX/btKv8mMZahCjn2aYrDlpqHaBFCfnox64edeH9kEid0vTLTRR8gWR2A20aDgeuTTea4sVtw==",
       "requires": {
         "ajv": "^6.12.4",
         "lodash": "^4.17.20",
@@ -28498,12 +28448,6 @@
       "resolved": "https://registry.npmjs.org/trim/-/trim-0.0.1.tgz",
       "integrity": "sha1-WFhUf2spB1fulczMZm+1AITEYN0="
     },
-    "trim-lines": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-1.1.3.tgz",
-      "integrity": "sha512-E0ZosSWYK2mkSu+KEtQ9/KqarVjA9HztOSX+9FDdNacRAq29RRV6ZQNgob3iuW8Htar9vAfEa6yyt5qBAHZDBA==",
-      "dev": true
-    },
     "trim-newlines": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-3.0.0.tgz",
@@ -28630,10 +28574,15 @@
         "is-typedarray": "^1.0.0"
       }
     },
+    "typescript": {
+      "version": "3.9.7",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.7.tgz",
+      "integrity": "sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw=="
+    },
     "ua-parser-js": {
-      "version": "0.7.21",
-      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.21.tgz",
-      "integrity": "sha512-+O8/qh/Qj8CgC6eYBVBykMrNtp5Gebn4dlGD/kKXVkJNDwyrAwSIqwz8CDf+tsAIWVycKcku6gIXJ0qwx/ZXaQ=="
+      "version": "0.7.22",
+      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.22.tgz",
+      "integrity": "sha512-YUxzMjJ5T71w6a8WWVcMGM6YWOTX27rCoIQgLXiWaxqXSx9D7DNjiGWn1aJIRSQ5qr0xuhra77bSIh6voR/46Q=="
     },
     "uc.micro": {
       "version": "1.0.6",
@@ -29684,9 +29633,9 @@
       "dev": true
     },
     "webpack": {
-      "version": "4.44.1",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-4.44.1.tgz",
-      "integrity": "sha512-4UOGAohv/VGUNQJstzEywwNxqX417FnjZgZJpJQegddzPmTvph37eBIRbRTfdySXzVtJXLJfbMN3mMYhM6GdmQ==",
+      "version": "4.44.2",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-4.44.2.tgz",
+      "integrity": "sha512-6KJVGlCxYdISyurpQ0IPTklv+DULv05rs2hseIXer6D7KrUicRDLFb4IUM1S6LUAKypPM/nSiVSuv8jHu1m3/Q==",
       "requires": {
         "@webassemblyjs/ast": "1.9.0",
         "@webassemblyjs/helper-module-context": "1.9.0",

--- a/src/Index/covid19Page.jsx
+++ b/src/Index/covid19Page.jsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import { ReduxIndexButtonBar } from './reduxer';
+import ReduxCovid19Dashboard from '../Covid19Dashboard/ReduxCovid19Dashboard';
+import './page.less';
+
+class IndexPageComponent extends React.Component {
+  render() {
+    return (
+      <div className='index-page'>
+        <ReduxCovid19Dashboard
+          {...this.props}
+        />
+        <ReduxIndexButtonBar {...this.props} />
+      </div>
+    );
+  }
+}
+
+IndexPageComponent.propTypes = {
+  history: PropTypes.object.isRequired,
+};
+
+const Covid19IndexPage = IndexPageComponent;
+
+export default Covid19IndexPage;

--- a/src/Index/page.jsx
+++ b/src/Index/page.jsx
@@ -9,9 +9,8 @@ import { ReduxIndexButtonBar, ReduxIndexBarChart, ReduxIndexCounts, ReduxIntrodu
 import dictIcons from '../img/icons';
 import { components } from '../params';
 import { loadHomepageChartDataFromDatasets, loadHomepageChartDataFromGraphQL } from './utils';
-import { breakpoints, customHomepageChartConfig, indexPublic, enableCovid19Dashboard } from '../localconf';
+import { breakpoints, customHomepageChartConfig, indexPublic } from '../localconf';
 import HomepageCustomCharts from '../components/charts/HomepageCustomCharts';
-import ReduxCovid19Dashboard from '../Covid19Dashboard/ReduxCovid19Dashboard';
 import './page.less';
 
 class IndexPageComponent extends React.Component {
@@ -67,28 +66,22 @@ class IndexPageComponent extends React.Component {
 
     return (
       <div className='index-page'>
-        {!enableCovid19Dashboard ?
-          <div className='index-page__top'>
-            <div className='index-page__introduction'>
-              <ReduxIntroduction data={components.index.introduction} dictIcons={dictIcons} />
-              <MediaQuery query={`(max-width: ${breakpoints.tablet}px)`}>
-                <ReduxIndexCounts />
-              </MediaQuery>
-            </div>
-            <div className='index-page__bar-chart'>
-              <MediaQuery query={`(min-width: ${breakpoints.tablet + 1}px)`}>
-                <Slider {...sliderSettings}>
-                  <div className='index-page__slider-chart'><ReduxIndexBarChart /></div>
-                  {customCharts}
-                </Slider>
-              </MediaQuery>
-            </div>
+        <div className='index-page__top'>
+          <div className='index-page__introduction'>
+            <ReduxIntroduction data={components.index.introduction} dictIcons={dictIcons} />
+            <MediaQuery query={`(max-width: ${breakpoints.tablet}px)`}>
+              <ReduxIndexCounts />
+            </MediaQuery>
           </div>
-          :
-          <ReduxCovid19Dashboard
-            {...this.props}
-          />
-        }
+          <div className='index-page__bar-chart'>
+            <MediaQuery query={`(min-width: ${breakpoints.tablet + 1}px)`}>
+              <Slider {...sliderSettings}>
+                <div className='index-page__slider-chart'><ReduxIndexBarChart /></div>
+                {customCharts}
+              </Slider>
+            </MediaQuery>
+          </div>
+        </div>
         <ReduxIndexButtonBar {...this.props} />
       </div>
     );

--- a/src/covid19Index.jsx
+++ b/src/covid19Index.jsx
@@ -1,0 +1,374 @@
+import React from 'react';
+import { render } from 'react-dom';
+import { Provider } from 'react-redux';
+import { BrowserRouter, Route, Switch, Redirect } from 'react-router-dom';
+import { ThemeProvider } from 'styled-components';
+import 'react-select/dist/react-select.css';
+import querystring from 'querystring';
+import { library } from '@fortawesome/fontawesome-svg-core';
+import { faAngleUp, faAngleDown } from '@fortawesome/free-solid-svg-icons';
+import ReactGA from 'react-ga';
+import { Helmet } from 'react-helmet';
+
+import 'antd/dist/antd.css';
+import '@gen3/ui-component/dist/css/base.less';
+import { fetchDictionary, fetchSchema, fetchVersionInfo, fetchUserAccess, fetchUserAuthMapping } from './actions';
+import ReduxLogin, { fetchLogin } from './Login/ReduxLogin';
+import ProtectedContent from './Login/ProtectedContent';
+import HomePage from './Homepage/page';
+import DocumentPage from './Document/page';
+import ExplorerPage from './Explorer/ExplorerPage';
+import { fetchCoreMetadata, ReduxCoreMetadataPage } from './CoreMetadata/reduxer';
+import Indexing from './Indexing/Indexing';
+import Covid19IndexPage from './Index/covid19Page';
+import DataDictionary from './DataDictionary';
+import ReduxPrivacyPolicy from './PrivacyPolicy/ReduxPrivacyPolicy';
+import ProjectSubmission from './Submission/ReduxProjectSubmission';
+import ReduxMapFiles from './Submission/ReduxMapFiles';
+import ReduxMapDataModel from './Submission/ReduxMapDataModel';
+import UserProfile, { fetchAccess } from './UserProfile/ReduxUserProfile';
+import UserAgreementCert from './UserAgreement/ReduxCertPopup';
+import GraphQLQuery from './GraphQLEditor/ReduxGqlEditor';
+import theme from './theme';
+import getReduxStore from './reduxStore';
+import { ReduxNavBar, ReduxTopBar, ReduxFooter } from './Layout/reduxer';
+import ReduxQueryNode, { submitSearchForm } from './QueryNode/ReduxQueryNode';
+import { basename, dev, gaDebug, workspaceUrl, workspaceErrorUrl,
+  indexPublic, useGuppyForExplorer, explorerPublic, enableResourceBrowser, resourceBrowserPublic,
+} from './localconf';
+import { gaTracking, components } from './params';
+import GA, { RouteTracker } from './components/GoogleAnalytics';
+import DataExplorer from './DataExplorer';
+import GuppyDataExplorer from './GuppyDataExplorer';
+import isEnabled from './helpers/featureFlags';
+import sessionMonitor from './SessionMonitor';
+import Workspace from './Workspace';
+import ResourceBrowser from './ResourceBrowser';
+import ErrorWorkspacePlaceholder from './Workspace/ErrorWorkspacePlaceholder';
+import './index.less';
+import NotFound from './components/NotFound';
+
+
+// monitor user's session
+sessionMonitor.start();
+
+// render the app after the store is configured
+async function init() {
+  const store = await getReduxStore();
+
+  // asyncSetInterval(() => store.dispatch(fetchUser), 60000);
+  ReactGA.initialize(gaTracking);
+  ReactGA.pageview(window.location.pathname + window.location.search);
+  await Promise.all(
+    [
+      store.dispatch(fetchSchema),
+      store.dispatch(fetchDictionary),
+      store.dispatch(fetchVersionInfo),
+      // resources can be open to anonymous users, so fetch access:
+      store.dispatch(fetchUserAccess),
+      store.dispatch(fetchUserAuthMapping),
+    ],
+  );
+  // FontAwesome icons
+  library.add(faAngleUp, faAngleDown);
+
+  render(
+    <div>
+      <Provider store={store}>
+        <ThemeProvider theme={theme}>
+          <BrowserRouter basename={basename}>
+            <div>
+              {GA.init(gaTracking, dev, gaDebug) && <RouteTracker />}
+              {isEnabled('noIndex') ?
+                <Helmet>
+                  <meta name='robots' content='noindex,nofollow' />
+                </Helmet>
+                : null
+              }
+              <ReduxTopBar />
+              <ReduxNavBar />
+              <div className='main-content'>
+                <Switch>
+                  {/* process with trailing and duplicate slashes first */}
+                  {/* see https://github.com/ReactTraining/react-router/issues/4841#issuecomment-523625186 */}
+                  {/* Removes trailing slashes */}
+                  <Route
+                    path='/:url*(/+)'
+                    exact
+                    strict
+                    render={({ location }) => (
+                      <Redirect to={location.pathname.replace(/\/+$/, '')} />
+                    )}
+                  />
+                  {/* Removes duplicate slashes in the middle of the URL */}
+                  <Route
+                    path='/:url(.*//+.*)'
+                    exact
+                    strict
+                    render={({ match }) => (
+                      <Redirect to={`/${match.params.url.replace(/\/\/+/, '/')}`} />
+                    )}
+                  />
+                  <Route
+                    exact
+                    path='/login'
+                    component={
+                      (
+                        props => (
+                          <ProtectedContent
+                            public
+                            filter={() => store.dispatch(fetchLogin())}
+                            component={ReduxLogin}
+                            {...props}
+                          />
+                        )
+                      )
+                    }
+                  />
+                  <Route
+                    exact
+                    path='/'
+                    component={
+                      props => (
+                        <ProtectedContent
+                          public={indexPublic}
+                          component={Covid19IndexPage}
+                          {...props}
+                        />
+                      )
+                    }
+                  />
+                  <Route
+                    exact
+                    path='/submission'
+                    component={
+                      props => <ProtectedContent component={HomePage} {...props} />
+                    }
+                  />
+                  <Route
+                    exact
+                    path='/submission/files'
+                    component={
+                      props => <ProtectedContent component={ReduxMapFiles} {...props} />
+                    }
+                  />
+                  <Route
+                    exact
+                    path='/submission/map'
+                    component={
+                      props => <ProtectedContent component={ReduxMapDataModel} {...props} />
+                    }
+                  />
+                  <Route
+                    exact
+                    path='/document'
+                    component={
+                      props => <ProtectedContent component={DocumentPage} {...props} />
+                    }
+                  />
+                  <Route
+                    exact
+                    path='/query'
+                    component={
+                      props => <ProtectedContent component={GraphQLQuery} {...props} />
+                    }
+                  />
+                  <Route
+                    exact
+                    path='/identity'
+                    component={
+                      props => (<ProtectedContent
+                        filter={() => store.dispatch(fetchAccess())}
+                        component={UserProfile}
+                        {...props}
+                      />)
+                    }
+                  />
+                  <Route
+                    exact
+                    path='/indexing'
+                    component={
+                      props => (<ProtectedContent
+                        component={Indexing}
+                        {...props}
+                      />)
+                    }
+                  />
+                  <Route
+                    exact
+                    path='/quiz'
+                    component={
+                      props => (<ProtectedContent
+                        component={UserAgreementCert}
+                        {...props}
+                      />)
+                    }
+                  />
+                  <Route
+                    exact
+                    path='/dd/:node'
+                    component={
+                      props => (<ProtectedContent
+                        public
+                        component={DataDictionary}
+                        {...props}
+                      />)
+                    }
+                  />
+                  <Route
+                    exact
+                    path='/dd'
+                    component={
+                      props => (<ProtectedContent
+                        public
+                        component={DataDictionary}
+                        {...props}
+                      />)
+                    }
+                  />
+                  <Route
+                    exact
+                    path='/files/*'
+                    component={
+                      props => (<ProtectedContent
+                        filter={() =>
+                          store.dispatch(fetchCoreMetadata(props.match.params[0]))
+                        }
+                        component={ReduxCoreMetadataPage}
+                        {...props}
+                      />)
+                    }
+                  />
+                  <Route
+                    exact
+                    path='/files'
+                    component={
+                      props => (
+                        <ProtectedContent
+                          public={explorerPublic}
+                          component={useGuppyForExplorer ? GuppyDataExplorer : ExplorerPage}
+                          {...props}
+                        />
+                      )
+                    }
+                  />
+                  <Route
+                    exact
+                    path='/workspace'
+                    component={
+                      props => <ProtectedContent component={Workspace} {...props} />
+                    }
+                  />
+                  <Route
+                    exact
+                    path={workspaceUrl}
+                    component={ErrorWorkspacePlaceholder}
+                  />
+                  <Route
+                    exact
+                    path={workspaceErrorUrl}
+                    component={ErrorWorkspacePlaceholder}
+                  />
+                  <Route
+                    path='/:project/search'
+                    component={
+                      (props) => {
+                        const queryFilter = () => {
+                          const location = props.location;
+                          const queryParams = querystring.parse(location.search ? location.search.replace(/^\?+/, '') : '');
+                          if (Object.keys(queryParams).length > 0) {
+                            // Linking directly to a search result,
+                            // so kick-off search here (rather than on button click)
+                            return store.dispatch(
+                              submitSearchForm({
+                                project: props.match.params.project, ...queryParams,
+                              }),
+                            );
+                          }
+                          return Promise.resolve('ok');
+                        };
+                        return (
+                          <ProtectedContent
+                            filter={queryFilter}
+                            component={ReduxQueryNode}
+                            {...props}
+                          />);
+                      }
+                    }
+                  />
+                  {isEnabled('explorer') ?
+                    <Route
+                      exact
+                      path='/explorer'
+                      component={
+                        props => (
+                          <ProtectedContent
+                            public={explorerPublic}
+                            component={useGuppyForExplorer ? GuppyDataExplorer : DataExplorer}
+                            {...props}
+                          />
+                        )
+                      }
+                    />
+                    : null
+                  }
+                  {components.privacyPolicy &&
+                    (!!components.privacyPolicy.file || !!components.privacyPolicy.routeHref) ?
+                    <Route
+                      exact
+                      path='/privacy-policy'
+                      component={ReduxPrivacyPolicy}
+                    />
+                    : null
+                  }
+                  {enableResourceBrowser ?
+                    <Route
+                      exact
+                      path='/resource-browser'
+                      component={
+                        props => (<ProtectedContent
+                          public={resourceBrowserPublic}
+                          component={ResourceBrowser}
+                          {...props}
+                        />)
+                      }
+                    />
+                    : null
+                  }
+                  <Route
+                    path='/not-found'
+                    component={NotFound}
+                  />
+                  <Route
+                    exact
+                    path='/:project'
+                    component={
+                      props =>
+                        (
+                          <ProtectedContent
+                            component={ProjectSubmission}
+                            {...props}
+                          />
+                        )
+                    }
+                  />
+                  <Route
+                    path='*'
+                    component={NotFound}
+                  />
+                </Switch>
+              </div>
+              <ReduxFooter
+                logos={components.footerLogos}
+                privacyPolicy={components.privacyPolicy}
+              />
+            </div>
+          </BrowserRouter>
+        </ThemeProvider>
+      </Provider>
+    </div>,
+    document.getElementById('root'),
+  );
+}
+
+init();

--- a/src/localconf.js
+++ b/src/localconf.js
@@ -187,8 +187,6 @@ function buildConfig(opts) {
   }
 
   const covid19DashboardConfig = config.covid19DashboardConfig;
-  const enableCovid19Dashboard = !!(covid19DashboardConfig &&
-    Object.keys(covid19DashboardConfig).length > 0);
   if (covid19DashboardConfig) {
     covid19DashboardConfig.dataUrl = ensureTrailingSlash(covid19DashboardConfig.dataUrl || '');
   }
@@ -367,7 +365,6 @@ function buildConfig(opts) {
     explorerConfig,
     useNewExplorerConfigFormat,
     dataAvailabilityToolConfig,
-    enableCovid19Dashboard,
     covid19DashboardConfig,
     mapboxAPIToken,
     auspiceUrl,

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -104,16 +104,23 @@ if (process.env.NODE_ENV !== 'dev' && process.env.NODE_ENV !== 'auto') {
 
 const entry = {
   "bundle": ['babel-polyfill', './src/index.jsx'],
-  "workspaceBundle": ['babel-polyfill', './src/workspaceIndex.jsx']
+  "workspaceBundle": ['babel-polyfill', './src/workspaceIndex.jsx'],
+  "covid19Bundle": ['babel-polyfill', './src/covid19Index.jsx']
 };
 
 if (process.env.GEN3_BUNDLE === 'workspace') {
   // Just build the workspace bundle as bundle.js
   entry.bundle = entry.workspaceBundle;
   delete entry.workspaceBundle;
+  delete entry.covid19Bundle;
+} else if (process.env.GEN3_BUNDLE === 'covid19') {
+  entry.bundle = entry.covid19Bundle;
+  delete entry.workspaceBundle;
+  delete entry.covid19Bundle;
 } else if (process.env.GEN3_BUNDLE === 'commons') {
   // optimize webpack build
   delete entry.workspaceBundle;
+  delete entry.covid19Bundle;
 }
 // else - by default build all entry points
 //    note that runWebpack ensures GEN3_BUNDLE is set,


### PR DESCRIPTION
Separate Covid19 dashboard into another bundle to reduce bundle size.

Supply `GEN3_BUNDLE=covid19` as env var to enable covid bundle

There is another ticket to remove Arranger https://ctds-planx.atlassian.net/browse/PXP-6409

### New Features
- Separate Covid19 dashboard into another bundle to reduce bundle size

### Deployment changes
- Add `GEN3_BUNDLE=covid19` as portal env var to enable covid bundle

