### PR TITLE
Feat/topbar email

### DIFF
--- a/src/components/layout/TopBar.jsx
+++ b/src/components/layout/TopBar.jsx
@@ -6,6 +6,12 @@ import './TopBar.less';
 import { useArboristUI } from '../../configs';
 import { userHasMethodOnAnyProject } from '../../authMappingUtils';
 
+const isEmailAddress = (input) => {
+  // regexp for checking if a string is possibly an email address, got from https://www.w3resource.com/javascript/form/email-validation.php
+  const regexp = '^[a-zA-Z0-9.!#$%&\'*+\\/=?^_`{|}~-]+@[a-zA-Z0-9-]+(?:\\.[a-zA-Z0-9-]+)*$';
+  return new RegExp(regexp).test(input);
+};
+
 /**
  * NavBar renders row of nav-items of form { name, icon, link }
  */
@@ -28,21 +34,26 @@ class TopBar extends Component {
                       buttonText = 'Browse Data';
                     }
                   }
-                  return (item.link.startsWith('http')) ?
-                    <a
-                      className='top-bar__link'
-                      key={item.link}
-                      href={item.link}
-                      target='_blank'
-                      rel='noopener noreferrer'
-                    >
-                      <TopIconButton
-                        name={buttonText}
-                        icon={item.icon}
-                        isActive={this.isActive(item.link)}
-                        onActiveTab={() => this.props.onActiveTab(item.link)}
-                      />
-                    </a> :
+                  if (isEmailAddress(item.link) || item.link.startsWith('http')) {
+                    const itemHref = (isEmailAddress(item.link)) ? `mailto:${item.link}` : item.link;
+                    return (
+                      <a
+                        className='top-bar__link'
+                        key={item.link}
+                        href={itemHref}
+                        target='_blank'
+                        rel='noopener noreferrer'
+                      >
+                        <TopIconButton
+                          name={buttonText}
+                          icon={item.icon}
+                          isActive={this.isActive(itemHref)}
+                          onActiveTab={() => this.props.onActiveTab(itemHref)}
+                        />
+                      </a>
+                    );
+                  }
+                  return (
                     <Link
                       className='top-bar__link'
                       key={item.link}
@@ -54,7 +65,8 @@ class TopBar extends Component {
                         isActive={this.isActive(item.link)}
                         onActiveTab={() => this.props.onActiveTab(item.link)}
                       />
-                    </Link>;
+                    </Link>
+                  );
                 },
               )
             }

--- a/src/components/layout/TopBar.jsx
+++ b/src/components/layout/TopBar.jsx
@@ -34,8 +34,9 @@ class TopBar extends Component {
                       buttonText = 'Browse Data';
                     }
                   }
-                  if (isEmailAddress(item.link) || item.link.startsWith('http')) {
-                    const itemHref = (isEmailAddress(item.link)) ? `mailto:${item.link}` : item.link;
+                  const isLinkEmailAddress = isEmailAddress(item.link);
+                  if (isLinkEmailAddress || item.link.startsWith('http')) {
+                    const itemHref = (isLinkEmailAddress) ? `mailto:${item.link}` : item.link;
                     return (
                       <a
                         className='top-bar__link'

--- a/src/components/layout/TopBar.jsx
+++ b/src/components/layout/TopBar.jsx
@@ -39,7 +39,7 @@ class TopBar extends Component {
                     return (
                       <a
                         className='top-bar__link'
-                        key={item.link}
+                        key={itemHref}
                         href={itemHref}
                         target='_blank'
                         rel='noopener noreferrer'


### PR DESCRIPTION
Jira Ticket: [PXP-6941](https://ctds-planx.atlassian.net/browse/PXP-6941)

Allow topbar item to have email links, e.g.:

> {
>      "link": "someone@example.com",
>      "name": "Contact Support"
> }

If `link` is possibly an email address, it will be rendered as `href={'mailto:<link>'}`

### Improvements
- Allow topbar item to have email links
