### PR TITLE
fix: check user access base on both method and service

### DIFF
--- a/src/CoreMetadata/CoreMetadataHeader.jsx
+++ b/src/CoreMetadata/CoreMetadataHeader.jsx
@@ -6,7 +6,7 @@ import Popup from '../components/Popup';
 import { userapiPath, useArboristUI } from '../configs';
 import isEnabled from '../helpers/featureFlags';
 
-import { userHasMethodOnProject } from '../authMappingUtils';
+import { userHasMethodForServiceOnProject } from '../authMappingUtils';
 
 const DOWNLOAD_BTN_CAPTION = 'Download';
 const SIGNED_URL_BTN_CAPTION = 'Generate Signed URL';
@@ -52,7 +52,7 @@ class CoreMetadataHeader extends Component {
       // downloadButton should always render if useArboristUI false. Otherwise according to authz.
       if (
         !useArboristUI
-        || userHasMethodOnProject('read-storage', projectId, this.props.userAuthMapping)
+        || userHasMethodForServiceOnProject('read-storage', '*', projectId, this.props.userAuthMapping)
         || projectIsOpenData(projectAvail, projectId)
       ) {
         const downloadLink = `${userapiPath}/data/download/${this.props.metadata.object_id}?expires_in=900&redirect`;

--- a/src/CoreMetadata/CoreMetadataHeader.jsx
+++ b/src/CoreMetadata/CoreMetadataHeader.jsx
@@ -52,7 +52,7 @@ class CoreMetadataHeader extends Component {
       // downloadButton should always render if useArboristUI false. Otherwise according to authz.
       if (
         !useArboristUI
-        || userHasMethodForServiceOnProject('read-storage', '*', projectId, this.props.userAuthMapping)
+        || userHasMethodForServiceOnProject('read-storage', 'fence', projectId, this.props.userAuthMapping)
         || projectIsOpenData(projectAvail, projectId)
       ) {
         const downloadLink = `${userapiPath}/data/download/${this.props.metadata.object_id}?expires_in=900&redirect`;

--- a/src/QueryNode/QueryNode.jsx
+++ b/src/QueryNode/QueryNode.jsx
@@ -236,7 +236,7 @@ class QueryNode extends React.Component {
           (value) => {
             let showDelete = true;
             if (useArboristUI) {
-              showDelete = userHasMethodForServiceOnProject('delete', '*', this.props.params.project, this.props.userAuthMapping);
+              showDelete = userHasMethodForServiceOnProject('delete', 'sheepdog', this.props.params.project, this.props.userAuthMapping);
             }
             return (
               <Entities

--- a/src/QueryNode/QueryNode.jsx
+++ b/src/QueryNode/QueryNode.jsx
@@ -6,7 +6,7 @@ import Popup from '../components/Popup';
 import QueryForm from './QueryForm';
 import './QueryNode.less';
 import { useArboristUI } from '../configs';
-import { userHasMethodOnProject } from '../authMappingUtils';
+import { userHasMethodForServiceOnProject } from '../authMappingUtils';
 
 const Entity = ({ value, project, onUpdatePopup, onStoreNodeInfo, tabindexStart, showDelete }) => {
   const onDelete = () => {
@@ -236,7 +236,7 @@ class QueryNode extends React.Component {
           (value) => {
             let showDelete = true;
             if (useArboristUI) {
-              showDelete = userHasMethodOnProject('delete', this.props.params.project, this.props.userAuthMapping);
+              showDelete = userHasMethodForServiceOnProject('delete', '*', this.props.params.project, this.props.userAuthMapping);
             }
             return (
               <Entities

--- a/src/StudyViewer/StudyDetails.jsx
+++ b/src/StudyViewer/StudyDetails.jsx
@@ -224,7 +224,7 @@ class StudyDetails extends React.Component {
      if (!accessibleValidationValue) {
        return false;
      }
-     return (userHasMethodForServiceOnResource('read-storage', '*', accessibleValidationValue, this.props.userAuthMapping));
+     return (userHasMethodForServiceOnResource('read-storage', 'fence', accessibleValidationValue, this.props.userAuthMapping));
    };
 
    render() {

--- a/src/StudyViewer/StudyDetails.jsx
+++ b/src/StudyViewer/StudyDetails.jsx
@@ -10,7 +10,7 @@ import {
   // FilePdfOutlined,
   LinkOutlined } from '@ant-design/icons';
 import { capitalizeFirstLetter, humanFileSize } from '../utils';
-import { userHasMethodOnResource } from '../authMappingUtils';
+import { userHasMethodForServiceOnResource } from '../authMappingUtils';
 import { useArboristUI, requestorPath, userapiPath } from '../localconf';
 import { fetchWithCreds } from '../actions';
 import './StudyViewer.css';
@@ -224,7 +224,7 @@ class StudyDetails extends React.Component {
      if (!accessibleValidationValue) {
        return false;
      }
-     return (userHasMethodOnResource('read-storage', accessibleValidationValue, this.props.userAuthMapping));
+     return (userHasMethodForServiceOnResource('read-storage', '*', accessibleValidationValue, this.props.userAuthMapping));
    };
 
    render() {

--- a/src/Submission/ProjectSubmission.jsx
+++ b/src/Submission/ProjectSubmission.jsx
@@ -81,9 +81,8 @@ class ProjectSubmission extends React.Component {
         !useArboristUI
         || (isRootUrl(project) && userHasSheepdogProgramAdmin(userAuthMapping))
         || (isProgramUrl(project) && userHasSheepdogProjectAdmin(userAuthMapping))
-        || userHasMethodForServiceOnProject('create', '*', project, userAuthMapping)
-        || userHasMethodForServiceOnProject('update', '*', project, userAuthMapping)
-        || userHasMethodForServiceOnProject('*', '*', project, userAuthMapping)
+        || userHasMethodForServiceOnProject('create', 'sheepdog', project, userAuthMapping)
+        || userHasMethodForServiceOnProject('update', 'sheepdog', project, userAuthMapping)
       ) {
         return (
           <React.Fragment>

--- a/src/Submission/ProjectSubmission.jsx
+++ b/src/Submission/ProjectSubmission.jsx
@@ -8,7 +8,7 @@ import SubmitForm from './SubmitForm';
 import Spinner from '../components/Spinner';
 import './ProjectSubmission.less';
 import { useArboristUI } from '../configs';
-import { userHasMethodOnProject, isRootUrl, isProgramUrl, userHasSheepdogProgramAdmin, userHasSheepdogProjectAdmin } from '../authMappingUtils';
+import { userHasMethodForServiceOnProject, isRootUrl, isProgramUrl, userHasSheepdogProgramAdmin, userHasSheepdogProjectAdmin } from '../authMappingUtils';
 
 class ProjectSubmission extends React.Component {
   componentDidMount() {
@@ -81,8 +81,9 @@ class ProjectSubmission extends React.Component {
         !useArboristUI
         || (isRootUrl(project) && userHasSheepdogProgramAdmin(userAuthMapping))
         || (isProgramUrl(project) && userHasSheepdogProjectAdmin(userAuthMapping))
-        || userHasMethodOnProject('create', project, userAuthMapping)
-        || userHasMethodOnProject('update', project, userAuthMapping)
+        || userHasMethodForServiceOnProject('create', '*', project, userAuthMapping)
+        || userHasMethodForServiceOnProject('update', '*', project, userAuthMapping)
+        || userHasMethodForServiceOnProject('*', '*', project, userAuthMapping)
       ) {
         return (
           <React.Fragment>

--- a/src/authMappingUtils.js
+++ b/src/authMappingUtils.js
@@ -62,7 +62,16 @@ export const userHasDataUpload = (userAuthMapping = {}) => {
 export const userHasMethodForServiceOnResource =
 (method, service, resourcePath, userAuthMapping = {}) => {
   const actions = userAuthMapping[resourcePath];
-  return actions !== undefined && actions.some(x => (x.service === service && x.method === method));
+  // accommodate for '*' logic
+  // if we need to check for a specific service/method pair for a resource,
+  // e.g.: {service: sheepdog, method: update}
+  // then this function should return true if the user has either of
+  // the following pair for this policy
+  // 1. {service: sheepdog, method: update}
+  // 1. {service: sheepdog, method: *}
+  // 1. {service: *, method: update}
+  // 1. {service: *, method: *}
+  return actions !== undefined && actions.some(x => ((x.service === service || x.service === '*') && (x.method === method || x.method === '*')));
 };
 
 export const userHasMethodForServiceOnProject =

--- a/src/authMappingUtils.js
+++ b/src/authMappingUtils.js
@@ -68,9 +68,9 @@ export const userHasMethodForServiceOnResource =
   // then this function should return true if the user has either of
   // the following pair for this policy
   // 1. {service: sheepdog, method: update}
-  // 1. {service: sheepdog, method: *}
-  // 1. {service: *, method: update}
-  // 1. {service: *, method: *}
+  // 2. {service: sheepdog, method: *}
+  // 3. {service: *, method: update}
+  // 4. {service: *, method: *}
   return actions !== undefined && actions.some(x => ((x.service === service || x.service === '*') && (x.method === method || x.method === '*')));
 };
 

--- a/src/authMappingUtils.js
+++ b/src/authMappingUtils.js
@@ -59,15 +59,17 @@ export const userHasDataUpload = (userAuthMapping = {}) => {
   return resource !== undefined && resource.some(actionIsFileUpload);
 };
 
-export const userHasMethodOnResource = (method, resourcePath, userAuthMapping = {}) => {
+export const userHasMethodForServiceOnResource =
+(method, service, resourcePath, userAuthMapping = {}) => {
   const actions = userAuthMapping[resourcePath];
-  return actions !== undefined && actions.some(x => x.method === method);
+  return actions !== undefined && actions.some(x => (x.service === service && x.method === method));
 };
 
-export const userHasMethodOnProject = (method, projectID, userAuthMapping = {}) => {
+export const userHasMethodForServiceOnProject =
+(method, service, projectID, userAuthMapping = {}) => {
   // method should be a string e.g. 'create'
   const resourcePath = resourcePathFromProjectID(projectID);
-  return userHasMethodOnResource(method, resourcePath, userAuthMapping);
+  return userHasMethodForServiceOnResource(method, service, resourcePath, userAuthMapping);
 };
 
 export const userHasMethodOnAnyProject = (method, userAuthMapping = {}) => {

--- a/src/components/tables/ProjectTable.jsx
+++ b/src/components/tables/ProjectTable.jsx
@@ -27,7 +27,7 @@ class ProjectTable extends React.Component {
   getData = projectList => projectList.map((proj, i) => {
     let buttonText = 'Submit Data';
     if (useArboristUI) {
-      buttonText = userHasMethodForServiceOnProject('create', '*', proj.name, this.props.userAuthMapping) ? 'Submit/Browse Data' : 'Browse Data';
+      buttonText = userHasMethodForServiceOnProject('create', 'sheepdog', proj.name, this.props.userAuthMapping) ? 'Submit/Browse Data' : 'Browse Data';
     }
     return [
       proj.name,

--- a/src/components/tables/ProjectTable.jsx
+++ b/src/components/tables/ProjectTable.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Link } from 'react-router-dom';
 import PropTypes from 'prop-types';
 import Button from '@gen3/ui-component/dist/components/Button';
 import Table from './base/Table';
@@ -31,14 +32,15 @@ class ProjectTable extends React.Component {
     return [
       proj.name,
       ...proj.counts,
-      <Button
-        className='project-table__submit-button'
-        key={i}
-        onClick={() => this.props.history.push(`/${proj.name}`)}
-        label={buttonText}
-        buttonType='primary'
-        rightIcon='upload'
-      />,
+      <Link to={`/${proj.name}`}>
+        <Button
+          className='project-table__submit-button'
+          key={i}
+          label={buttonText}
+          buttonType='primary'
+          rightIcon='upload'
+        />
+      </Link>,
     ];
   });
 
@@ -66,7 +68,6 @@ class ProjectTable extends React.Component {
 ProjectTable.propTypes = {
   projectList: PropTypes.array,
   summaries: PropTypes.array,
-  history: PropTypes.object.isRequired,
   userAuthMapping: PropTypes.object.isRequired,
 };
 

--- a/src/components/tables/ProjectTable.jsx
+++ b/src/components/tables/ProjectTable.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import Button from '@gen3/ui-component/dist/components/Button';
 import Table from './base/Table';
 import { useArboristUI } from '../../configs';
-import { userHasMethodOnProject } from '../../authMappingUtils';
+import { userHasMethodForServiceOnProject } from '../../authMappingUtils';
 import './ProjectTable.less';
 
 function compare(a, b) {
@@ -26,7 +26,7 @@ class ProjectTable extends React.Component {
   getData = projectList => projectList.map((proj, i) => {
     let buttonText = 'Submit Data';
     if (useArboristUI) {
-      buttonText = userHasMethodOnProject('create', proj.name, this.props.userAuthMapping) ? 'Submit/Browse Data' : 'Browse Data';
+      buttonText = userHasMethodForServiceOnProject('create', '*', proj.name, this.props.userAuthMapping) ? 'Submit/Browse Data' : 'Browse Data';
     }
     return [
       proj.name,


### PR DESCRIPTION
Portal's Arborist UI feature should check for both `service` and `method`
User should be able to submit data if has `{ service: *, method: *}` for a project
Also wrapped buttons in project submission table with `Link` so user can use right click to open it in a new tab

### Bug Fixes
- Portal's Arborist UI feature should check for both `service` and `method`
- User should be able to submit data if has `{ service: *, method: *}` for a project

### Improvements
- Make buttons in project submission table be able to get right click