### PR TITLE
PRC charts truncate labels

### DIFF
--- a/src/Covid19Dashboard/PlotChart/index.jsx
+++ b/src/Covid19Dashboard/PlotChart/index.jsx
@@ -208,7 +208,7 @@ class PlotChart extends PureComponent { // eslint-disable-line react/no-multi-co
   }
 
   getLineChartComponent = (chartData, width) => {
-    const { yTitle, axisLabelMaxLength, axisLabelFontSize } = this.props;
+    const { yTitle, axisLabelFontSize } = this.props;
     if (!Object.keys(this.props.plots).length) {
       return null;
     }

--- a/src/Covid19Dashboard/PlotChart/index.jsx
+++ b/src/Covid19Dashboard/PlotChart/index.jsx
@@ -13,7 +13,7 @@ import './PlotChart.less';
 class PlotChartAxisTick extends React.Component {
   render() {
     // type is one of ['date', 'string', 'number']
-    const { x, y, payload, axis, type } = this.props;
+    const { x, y, payload, axis, type, labelMaxLength } = this.props;
     if (!x || !y || !payload) {
       return null;
     }
@@ -23,13 +23,11 @@ class PlotChartAxisTick extends React.Component {
       formattedValue = `${moment(formattedValue).month() + 1}/${moment(formattedValue).date()}`;
     } else if (type === 'number') {
       formattedValue = numberWithCommas(formattedValue);
+    } else if (type === 'string' && labelMaxLength) {
+      // truncate long labels and add "..."
+      formattedValue = formattedValue.slice(0, labelMaxLength)
+        + (formattedValue.length > labelMaxLength ? '...' : '');
     }
-    // else { // type === 'string'
-    //   // TODO: make maxLength configurable per chart to allow truncating labels
-    //   const maxLength = ?;
-    //   formattedValue = formattedValue.slice(0, maxLength)
-    //     + (formattedValue.length > maxLength ? '.' : '');
-    // }
 
     return (
       <g transform={`translate(${x},${y})`}>
@@ -55,12 +53,14 @@ PlotChartAxisTick.propTypes = {
   payload: PropTypes.object,
   axis: PropTypes.string.isRequired,
   type: PropTypes.string.isRequired,
+  labelMaxLength: PropTypes.number,
 };
 
 PlotChartAxisTick.defaultProps = {
   x: undefined,
   y: undefined,
   payload: undefined,
+  labelMaxLength: undefined,
 };
 
 function getDates(startDate, endDate, days) {
@@ -141,7 +141,7 @@ class PlotChart extends PureComponent { // eslint-disable-line react/no-multi-co
   }
 
   getGuppyBarChartComponent = (data) => {
-    const { xTitle, yTitle, layout, barColor, guppyConfig } = this.props;
+    const { xTitle, yTitle, layout, axisLabelMaxLength, barColor, guppyConfig } = this.props;
     if (!data.length) {
       return null;
     }
@@ -167,7 +167,7 @@ class PlotChart extends PureComponent { // eslint-disable-line react/no-multi-co
         dataKey={layout === 'horizontal' ? guppyConfig.xAxisProp : null}
         type={layout === 'horizontal' ? 'category' : 'number'}
         tickLine={layout === 'horizontal' && false}
-        tick={<PlotChartAxisTick axis='x' type={layout === 'vertical' ? 'number' : 'string'} />}
+        tick={<PlotChartAxisTick axis='x' type={layout === 'vertical' ? 'number' : 'string'} labelMaxLength={axisLabelMaxLength} />}
       />
       <YAxis
         label={{
@@ -180,7 +180,7 @@ class PlotChart extends PureComponent { // eslint-disable-line react/no-multi-co
         dataKey={layout === 'vertical' ? guppyConfig.xAxisProp : null}
         type={layout === 'horizontal' ? 'number' : 'category'}
         tickLine={layout === 'vertical' && false}
-        tick={<PlotChartAxisTick axis='y' type={layout === 'horizontal' ? 'number' : 'string'} />}
+        tick={<PlotChartAxisTick axis='y' type={layout === 'horizontal' ? 'number' : 'string'} labelMaxLength={axisLabelMaxLength} />}
       />
       <Tooltip
         formatter={
@@ -333,17 +333,19 @@ PlotChart.propTypes = {
   yTitle: PropTypes.string,
   layout: PropTypes.string,
   maxItems: PropTypes.number,
+  axisLabelMaxLength: PropTypes.number,
   barColor: PropTypes.string,
   guppyConfig: PropTypes.object,
 };
 
 PlotChart.defaultProps = {
   plots: [],
-  xTitle: null,
-  yTitle: null,
+  xTitle: undefined,
+  yTitle: undefined,
   layout: 'horizontal',
-  maxItems: null,
-  barColor: null,
+  maxItems: undefined,
+  axisLabelMaxLength: undefined,
+  barColor: undefined,
   guppyConfig: {},
 };
 

--- a/src/Covid19Dashboard/PlotChart/index.jsx
+++ b/src/Covid19Dashboard/PlotChart/index.jsx
@@ -208,6 +208,7 @@ class PlotChart extends PureComponent { // eslint-disable-line react/no-multi-co
   }
 
   getLineChartComponent = (chartData, width) => {
+    const { yTitle, axisLabelMaxLength, axisLabelFontSize } = this.props;
     if (!Object.keys(this.props.plots).length) {
       return null;
     }
@@ -223,20 +224,30 @@ class PlotChart extends PureComponent { // eslint-disable-line react/no-multi-co
       />
       <XAxis
         dataKey='date'
-        tick={<PlotChartAxisTick axis='x' type='date' />}
+        tick={<PlotChartAxisTick
+          axis='x'
+          type='date'
+          labelMaxLength={axisLabelMaxLength}
+          labelFontSize={axisLabelFontSize}
+        />}
         ticks={chartData.ticks}
         interval={0}
       />
       <YAxis
         label={{
           className: 'plot-chart__y-title',
-          value: this.props.yTitle,
+          value: yTitle,
           angle: -90,
           position: 'insideLeft',
           offset: -10,
         }}
         type='number'
-        tick={<PlotChartAxisTick axis='y' type='number' />}
+        tick={<PlotChartAxisTick
+          axis='y'
+          type='number'
+          labelMaxLength={axisLabelMaxLength}
+          labelFontSize={axisLabelFontSize}
+        />}
       />
       <Tooltip
         content={this.renderTooltip}
@@ -344,10 +355,10 @@ PlotChart.propTypes = {
   title: PropTypes.string.isRequired,
   xTitle: PropTypes.string,
   yTitle: PropTypes.string,
-  layout: PropTypes.string,
-  maxItems: PropTypes.number,
   axisLabelMaxLength: PropTypes.number,
   axisLabelFontSize: PropTypes.number,
+  layout: PropTypes.string,
+  maxItems: PropTypes.number,
   barColor: PropTypes.string,
   guppyConfig: PropTypes.object,
 };
@@ -356,10 +367,10 @@ PlotChart.defaultProps = {
   plots: [],
   xTitle: undefined,
   yTitle: undefined,
-  layout: 'horizontal',
-  maxItems: undefined,
   axisLabelMaxLength: undefined,
   axisLabelFontSize: undefined,
+  layout: 'horizontal',
+  maxItems: undefined,
   barColor: undefined,
   guppyConfig: {},
 };

--- a/src/Covid19Dashboard/PlotChart/index.jsx
+++ b/src/Covid19Dashboard/PlotChart/index.jsx
@@ -227,7 +227,6 @@ class PlotChart extends PureComponent { // eslint-disable-line react/no-multi-co
         tick={<PlotChartAxisTick
           axis='x'
           type='date'
-          labelMaxLength={axisLabelMaxLength}
           labelFontSize={axisLabelFontSize}
         />}
         ticks={chartData.ticks}
@@ -245,7 +244,6 @@ class PlotChart extends PureComponent { // eslint-disable-line react/no-multi-co
         tick={<PlotChartAxisTick
           axis='y'
           type='number'
-          labelMaxLength={axisLabelMaxLength}
           labelFontSize={axisLabelFontSize}
         />}
       />
@@ -368,7 +366,7 @@ PlotChart.defaultProps = {
   xTitle: undefined,
   yTitle: undefined,
   axisLabelMaxLength: undefined,
-  axisLabelFontSize: undefined,
+  axisLabelFontSize: 10,
   layout: 'horizontal',
   maxItems: undefined,
   barColor: undefined,

--- a/src/Covid19Dashboard/PlotChart/index.jsx
+++ b/src/Covid19Dashboard/PlotChart/index.jsx
@@ -13,7 +13,7 @@ import './PlotChart.less';
 class PlotChartAxisTick extends React.Component {
   render() {
     // type is one of ['date', 'string', 'number']
-    const { x, y, payload, axis, type, labelMaxLength } = this.props;
+    const { x, y, payload, axis, type, labelMaxLength, labelFontSize } = this.props;
     if (!x || !y || !payload) {
       return null;
     }
@@ -37,7 +37,7 @@ class PlotChartAxisTick extends React.Component {
           dy={5}
           textAnchor='end'
           fill='#666'
-          fontSize={10}
+          fontSize={labelFontSize}
           transform={axis === 'x' ? 'rotate(-35)' : null}
         >
           {formattedValue}
@@ -54,6 +54,7 @@ PlotChartAxisTick.propTypes = {
   axis: PropTypes.string.isRequired,
   type: PropTypes.string.isRequired,
   labelMaxLength: PropTypes.number,
+  labelFontSize: PropTypes.number,
 };
 
 PlotChartAxisTick.defaultProps = {
@@ -61,6 +62,7 @@ PlotChartAxisTick.defaultProps = {
   y: undefined,
   payload: undefined,
   labelMaxLength: undefined,
+  labelFontSize: 10,
 };
 
 function getDates(startDate, endDate, days) {
@@ -141,7 +143,8 @@ class PlotChart extends PureComponent { // eslint-disable-line react/no-multi-co
   }
 
   getGuppyBarChartComponent = (data) => {
-    const { xTitle, yTitle, layout, axisLabelMaxLength, barColor, guppyConfig } = this.props;
+    const { xTitle, yTitle, layout, axisLabelMaxLength,
+      axisLabelFontSize, barColor, guppyConfig } = this.props;
     if (!data.length) {
       return null;
     }
@@ -167,7 +170,12 @@ class PlotChart extends PureComponent { // eslint-disable-line react/no-multi-co
         dataKey={layout === 'horizontal' ? guppyConfig.xAxisProp : null}
         type={layout === 'horizontal' ? 'category' : 'number'}
         tickLine={layout === 'horizontal' && false}
-        tick={<PlotChartAxisTick axis='x' type={layout === 'vertical' ? 'number' : 'string'} labelMaxLength={axisLabelMaxLength} />}
+        tick={<PlotChartAxisTick
+          axis='x'
+          type={layout === 'vertical' ? 'number' : 'string'}
+          labelMaxLength={axisLabelMaxLength}
+          labelFontSize={axisLabelFontSize}
+        />}
       />
       <YAxis
         label={{
@@ -180,7 +188,12 @@ class PlotChart extends PureComponent { // eslint-disable-line react/no-multi-co
         dataKey={layout === 'vertical' ? guppyConfig.xAxisProp : null}
         type={layout === 'horizontal' ? 'number' : 'category'}
         tickLine={layout === 'vertical' && false}
-        tick={<PlotChartAxisTick axis='y' type={layout === 'horizontal' ? 'number' : 'string'} labelMaxLength={axisLabelMaxLength} />}
+        tick={<PlotChartAxisTick
+          axis='y'
+          type={layout === 'horizontal' ? 'number' : 'string'}
+          labelMaxLength={axisLabelMaxLength}
+          labelFontSize={axisLabelFontSize}
+        />}
       />
       <Tooltip
         formatter={
@@ -334,6 +347,7 @@ PlotChart.propTypes = {
   layout: PropTypes.string,
   maxItems: PropTypes.number,
   axisLabelMaxLength: PropTypes.number,
+  axisLabelFontSize: PropTypes.number,
   barColor: PropTypes.string,
   guppyConfig: PropTypes.object,
 };
@@ -345,6 +359,7 @@ PlotChart.defaultProps = {
   layout: 'horizontal',
   maxItems: undefined,
   axisLabelMaxLength: undefined,
+  axisLabelFontSize: undefined,
   barColor: undefined,
   guppyConfig: {},
 };

--- a/src/Covid19Dashboard/README.md
+++ b/src/Covid19Dashboard/README.md
@@ -45,9 +45,10 @@ And each chart configuration is:
     type (str): one of [lineChart, barChart, image],
     prop (str, optional): name of a Covid19Dashboard property
     path (str, optional): if type==image, path can specified instead of prop
-    layout (str, optional): one of [vertical, horizontal] for bar charts,
-    maxItems (int, optional): for bar charts,
-    axisLabelMaxLength (int, optional): for bar charts, labels longer than this will be truncated,
+    layout (str, optional, default: horizontal): one of [vertical, horizontal] for bar charts,
+    maxItems (int, optional, default: none): for bar charts,
+    axisLabelMaxLength (int, optional, default: none): for bar charts, labels longer than this will be truncated,
+    axisLabelFontSize (int, optional, default: 10): for bar charts, font size to use for axis labels,
     barColor (str, optional): for bar charts,
     guppyConfig (optional): {
         dataType (str),

--- a/src/Covid19Dashboard/README.md
+++ b/src/Covid19Dashboard/README.md
@@ -45,10 +45,10 @@ And each chart configuration is:
     type (str): one of [lineChart, barChart, image],
     prop (str, optional): name of a Covid19Dashboard property
     path (str, optional): if type==image, path can specified instead of prop
+    axisLabelMaxLength (int, optional, default: none): for bar/line charts, labels longer than this will be truncated,
+    axisLabelFontSize (int, optional, default: 10): for bar/line charts, font size to use for axis labels,
     layout (str, optional, default: horizontal): one of [vertical, horizontal] for bar charts,
     maxItems (int, optional, default: none): for bar charts,
-    axisLabelMaxLength (int, optional, default: none): for bar charts, labels longer than this will be truncated,
-    axisLabelFontSize (int, optional, default: 10): for bar charts, font size to use for axis labels,
     barColor (str, optional): for bar charts,
     guppyConfig (optional): {
         dataType (str),

--- a/src/Covid19Dashboard/README.md
+++ b/src/Covid19Dashboard/README.md
@@ -47,6 +47,7 @@ And each chart configuration is:
     path (str, optional): if type==image, path can specified instead of prop
     layout (str, optional): one of [vertical, horizontal] for bar charts,
     maxItems (int, optional): for bar charts,
+    axisLabelMaxLength (int, optional): for bar charts, labels longer than this will be truncated,
     barColor (str, optional): for bar charts,
     guppyConfig (optional): {
         dataType (str),

--- a/src/components/layout/TopBar.jsx
+++ b/src/components/layout/TopBar.jsx
@@ -104,7 +104,7 @@ class TopBar extends Component {
                   content={
                     <React.Fragment>
                       <Link to='/identity'>View Profile</Link>
-                      <br/>
+                      <br />
                       <Link to='#' onClick={this.props.onLogoutClick}>Logout</Link>
                     </React.Fragment>
                   }


### PR DESCRIPTION
Jira Ticket: COV-461

### Improvements
- The font size and label length of the COVID19 Dashboard charts is configurable
