### PR TITLE
fix: index bar chart missing if no homepageChartNodes

### DIFF
--- a/src/Index/nctPage.jsx
+++ b/src/Index/nctPage.jsx
@@ -70,9 +70,14 @@ class IndexPageComponent extends React.Component {
       });
     }
 
-    if (homepageChartNodes && homepageChartNodes.length > 0) {
+    /* eslint-disable max-len */
+    if ((homepageChartNodes && homepageChartNodes.length > 0)
+    || (components.charts && components.charts.indexChartNames && components.charts.indexChartNames.length > 0)
+    || (components.charts && components.charts.chartNames && components.charts.chartNames.length > 0)
+    ) {
       homepageCharts.push(<div key={homepageCharts.length} className='index-page__slider-chart'><ReduxIndexBarChart /></div>);
     }
+    /* eslint-enable max-len */
 
     return (
       <div className='index-page'>

--- a/src/Index/page.jsx
+++ b/src/Index/page.jsx
@@ -70,9 +70,14 @@ class IndexPageComponent extends React.Component {
       });
     }
 
-    if (homepageChartNodes && homepageChartNodes.length > 0) {
+    /* eslint-disable max-len */
+    if ((homepageChartNodes && homepageChartNodes.length > 0)
+    || (components.charts && components.charts.indexChartNames && components.charts.indexChartNames.length > 0)
+    || (components.charts && components.charts.chartNames && components.charts.chartNames.length > 0)
+    ) {
       homepageCharts.push(<div key={homepageCharts.length} className='index-page__slider-chart'><ReduxIndexBarChart /></div>);
     }
+    /* eslint-enable max-len */
 
     return (
       <div className='index-page'>


### PR DESCRIPTION
Fixed a bug introduced by https://github.com/uc-cdis/data-portal/pull/742 causing index bar chart to disppear if there is no `homepageChartNodes` but only `boardCounts` and `chartCounts` in portal config

### Bug Fixes
- Fixed a bug causing index bar chart to disappear
