### PR TITLE
(PXP-6184): refactor/nodeCountTitle: make nodeCountTitle field optional

### DIFF
--- a/docs/multi_tab_explorer.md
+++ b/docs/multi_tab_explorer.md
@@ -152,7 +152,7 @@ An example of this new `explorerConfig` is (some contents are omitted for concis
 - `filters`: Required.
 - `guppyConfig`: Required.
   - `dataType`: Required. Must match the index “type” in the guppy configuration block in the manifest.json.
-  - `nodeCountTitle`: Optional. Plural of root node.
+  - `nodeCountTitle`: Optional. If omitted, will default to use plural of `guppyConfig.dataType` of this tab.
 
 For a complete list of required and optional fields for a tab configuration object, please refer to [Portal Config](https://github.com/uc-cdis/data-portal/blob/master/docs/portal_config.md).
 

--- a/docs/multi_tab_explorer.md
+++ b/docs/multi_tab_explorer.md
@@ -152,7 +152,7 @@ An example of this new `explorerConfig` is (some contents are omitted for concis
 - `filters`: Required.
 - `guppyConfig`: Required.
   - `dataType`: Required. Must match the index “type” in the guppy configuration block in the manifest.json.
-  - `nodeCountTitle`: Required. Plural of root node.
+  - `nodeCountTitle`: Optional. Plural of root node.
 
 For a complete list of required and optional fields for a tab configuration object, please refer to [Portal Config](https://github.com/uc-cdis/data-portal/blob/master/docs/portal_config.md).
 

--- a/docs/portal_config.md
+++ b/docs/portal_config.md
@@ -265,7 +265,7 @@ Below is an example, with inline comments describing what each JSON block config
     ],
     "guppyConfig": { // required; how to configure Guppy to work with the Data Explorer
       "dataType": "case", // required; must match the index “type” in the guppy configuration block in the manifest.json
-      "nodeCountTitle": "Cases", // required; plural of root node
+      "nodeCountTitle": "Cases", // optional; plural of root node
       "fieldMapping": [ // optional; a way to rename GraphQL fields to be more human readable
         { "field": "consent_codes", "name": "Data Use Restriction" },
         { "field": "bmi", "name": "BMI" }
@@ -319,7 +319,7 @@ Below is an example, with inline comments describing what each JSON block config
       "fieldMapping": [ // optional; a way to rename GraphQL fields to be more human readable
         { "field": "object_id", "name": "GUID" } // required; the file index should always include this one
       ],
-      "nodeCountTitle": "Files", // required; plural of root node
+      "nodeCountTitle": "Files", // optional; plural of root node
       "manifestMapping": { // optional; how to configure the mapping between cases/subjects/participants and files. This is used to export or download files that are associated with a cohort. It is basically joining two indices on specific GraphQL fields
         "resourceIndexType": "case", // required; joining this index with the case index
         "resourceIdField": "case_id", // required; which field should is the main identifier in the other index?

--- a/docs/portal_config.md
+++ b/docs/portal_config.md
@@ -265,7 +265,7 @@ Below is an example, with inline comments describing what each JSON block config
     ],
     "guppyConfig": { // required; how to configure Guppy to work with the Data Explorer
       "dataType": "case", // required; must match the index “type” in the guppy configuration block in the manifest.json
-      "nodeCountTitle": "Cases", // optional; plural of root node
+      "nodeCountTitle": "Cases", // optional; If omitted, will default to use plural of `guppyConfig.dataType` of this tab.
       "fieldMapping": [ // optional; a way to rename GraphQL fields to be more human readable
         { "field": "consent_codes", "name": "Data Use Restriction" },
         { "field": "bmi", "name": "BMI" }
@@ -319,7 +319,7 @@ Below is an example, with inline comments describing what each JSON block config
       "fieldMapping": [ // optional; a way to rename GraphQL fields to be more human readable
         { "field": "object_id", "name": "GUID" } // required; the file index should always include this one
       ],
-      "nodeCountTitle": "Files", // optional; plural of root node
+      "nodeCountTitle": "Files", // optional; If omitted, will default to use plural of `guppyConfig.dataType` of this tab.
       "manifestMapping": { // optional; how to configure the mapping between cases/subjects/participants and files. This is used to export or download files that are associated with a cohort. It is basically joining two indices on specific GraphQL fields
         "resourceIndexType": "case", // required; joining this index with the case index
         "resourceIdField": "case_id", // required; which field should is the main identifier in the other index?

--- a/src/GuppyDataExplorer/ExplorerFilter/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerFilter/index.jsx
@@ -9,6 +9,7 @@ import {
   GuppyConfigType,
 } from '../configTypeDef';
 import { checkForNoAccessibleProject, checkForFullAccessibleProject } from '../GuppyDataExplorerHelper';
+import { labelToTitle } from '../utils';
 
 /**
  * For selectedAccessFilter the default value is 'Data with Access'
@@ -127,7 +128,11 @@ class ExplorerFilter extends React.Component {
       onUpdateAccessLevel: this.props.onUpdateAccessLevel,
       adminAppliedPreFilters: this.props.adminAppliedPreFilters,
       lockedTooltipMessage: this.props.tierAccessLevel === 'regular' ? `You may only view summary information for this project. You do not have ${this.props.guppyConfig.dataType}-level access.` : '',
-      disabledTooltipMessage: this.props.tierAccessLevel === 'regular' ? `This resource is currently disabled because you are exploring restricted data. When exploring restricted data you are limited to exploring cohorts of ${this.props.tierAccessLimit} ${this.props.guppyConfig.nodeCountTitle.toLowerCase() || this.props.guppyConfig.dataType} or more.` : '',
+      disabledTooltipMessage: this.props.tierAccessLevel === 'regular' ? `This resource is currently disabled because you are exploring restricted data. When exploring restricted data you are limited to exploring cohorts of ${this.props.tierAccessLimit} ${
+        this.props.guppyConfig.nodeCountTitle? 
+          this.props.guppyConfig.nodeCountTitle.toLowerCase() : 
+          labelToTitle(this.props.guppyConfig.dataType, false)
+        } or more.` : '',
       accessibleFieldCheckList: this.props.accessibleFieldCheckList,
     };
     let filterFragment;

--- a/src/GuppyDataExplorer/ExplorerFilter/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerFilter/index.jsx
@@ -129,10 +129,10 @@ class ExplorerFilter extends React.Component {
       adminAppliedPreFilters: this.props.adminAppliedPreFilters,
       lockedTooltipMessage: this.props.tierAccessLevel === 'regular' ? `You may only view summary information for this project. You do not have ${this.props.guppyConfig.dataType}-level access.` : '',
       disabledTooltipMessage: this.props.tierAccessLevel === 'regular' ? `This resource is currently disabled because you are exploring restricted data. When exploring restricted data you are limited to exploring cohorts of ${this.props.tierAccessLimit} ${
-        this.props.guppyConfig.nodeCountTitle? 
-          this.props.guppyConfig.nodeCountTitle.toLowerCase() : 
+        this.props.guppyConfig.nodeCountTitle ?
+          this.props.guppyConfig.nodeCountTitle.toLowerCase() :
           labelToTitle(this.props.guppyConfig.dataType, false)
-        } or more.` : '',
+      } or more.` : '',
       accessibleFieldCheckList: this.props.accessibleFieldCheckList,
     };
     let filterFragment;

--- a/src/GuppyDataExplorer/ExplorerFilter/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerFilter/index.jsx
@@ -9,7 +9,7 @@ import {
   GuppyConfigType,
 } from '../configTypeDef';
 import { checkForNoAccessibleProject, checkForFullAccessibleProject } from '../GuppyDataExplorerHelper';
-import { labelToTitle } from '../utils';
+import { labelToPlural } from '../utils';
 
 /**
  * For selectedAccessFilter the default value is 'Data with Access'
@@ -131,7 +131,7 @@ class ExplorerFilter extends React.Component {
       disabledTooltipMessage: this.props.tierAccessLevel === 'regular' ? `This resource is currently disabled because you are exploring restricted data. When exploring restricted data you are limited to exploring cohorts of ${this.props.tierAccessLimit} ${
         this.props.guppyConfig.nodeCountTitle ?
           this.props.guppyConfig.nodeCountTitle.toLowerCase() :
-          labelToTitle(this.props.guppyConfig.dataType, false)
+          labelToPlural(this.props.guppyConfig.dataType)
       } or more.` : '',
       accessibleFieldCheckList: this.props.accessibleFieldCheckList,
     };

--- a/src/GuppyDataExplorer/ExplorerTopMessageBanner/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerTopMessageBanner/index.jsx
@@ -4,7 +4,7 @@ import Button from '@gen3/ui-component/dist/components/Button';
 import './ExplorerTopMessageBanner.css';
 import { checkForNoAccessibleProject } from '../GuppyDataExplorerHelper';
 import { GuppyConfigType } from '../configTypeDef';
-import { labelToTitle } from '../utils';
+import { labelToPlural } from '../utils';
 
 class ExplorerTopMessageBanner extends React.Component {
   render() {
@@ -41,7 +41,7 @@ class ExplorerTopMessageBanner extends React.Component {
                   <span className='top-message-banner__normal-text'>
                     {this.props.guppyConfig.nodeCountTitle ?
                       this.props.guppyConfig.nodeCountTitle.toLowerCase() :
-                      labelToTitle(this.props.guppyConfig.dataType, false)
+                      labelToPlural(this.props.guppyConfig.dataType)
                     }.
                   Please request additional access if necessary.
                   </span>

--- a/src/GuppyDataExplorer/ExplorerTopMessageBanner/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerTopMessageBanner/index.jsx
@@ -39,10 +39,10 @@ class ExplorerTopMessageBanner extends React.Component {
                   <span className='top-message-banner__normal-text'>Due to lack of access, you are only able to narrow the cohort down to </span>
                   <span className='top-message-banner__bold-text'>{ this.props.tierAccessLimit } </span>
                   <span className='top-message-banner__normal-text'>
-                    {this.props.guppyConfig.nodeCountTitle? 
-                      this.props.guppyConfig.nodeCountTitle.toLowerCase() : 
+                    {this.props.guppyConfig.nodeCountTitle ?
+                      this.props.guppyConfig.nodeCountTitle.toLowerCase() :
                       labelToTitle(this.props.guppyConfig.dataType, false)
-                  }.
+                    }.
                   Please request additional access if necessary.
                   </span>
                 </div>

--- a/src/GuppyDataExplorer/ExplorerTopMessageBanner/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerTopMessageBanner/index.jsx
@@ -4,6 +4,7 @@ import Button from '@gen3/ui-component/dist/components/Button';
 import './ExplorerTopMessageBanner.css';
 import { checkForNoAccessibleProject } from '../GuppyDataExplorerHelper';
 import { GuppyConfigType } from '../configTypeDef';
+import { labelToTitle } from '../utils';
 
 class ExplorerTopMessageBanner extends React.Component {
   render() {
@@ -38,8 +39,10 @@ class ExplorerTopMessageBanner extends React.Component {
                   <span className='top-message-banner__normal-text'>Due to lack of access, you are only able to narrow the cohort down to </span>
                   <span className='top-message-banner__bold-text'>{ this.props.tierAccessLimit } </span>
                   <span className='top-message-banner__normal-text'>
-                    {this.props.guppyConfig.nodeCountTitle.toLowerCase()
-                  || this.props.guppyConfig.dataType}.
+                    {this.props.guppyConfig.nodeCountTitle? 
+                      this.props.guppyConfig.nodeCountTitle.toLowerCase() : 
+                      labelToTitle(this.props.guppyConfig.dataType, false)
+                  }.
                   Please request additional access if necessary.
                   </span>
                 </div>

--- a/src/GuppyDataExplorer/ExplorerVisualization/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerVisualization/index.jsx
@@ -18,6 +18,7 @@ import {
 } from '../configTypeDef';
 import { checkForAnySelectedUnaccessibleField } from '../GuppyDataExplorerHelper';
 import './ExplorerVisualization.css';
+import { labelToTitle } from '../utils';
 
 
 class ExplorerVisualization extends React.Component {
@@ -31,7 +32,7 @@ class ExplorerVisualization extends React.Component {
     let countItems = [];
     const stackedBarCharts = [];
     countItems.push({
-      label: this.props.nodeCountTitle,
+      label: this.props.nodeCountTitle || labelToTitle(this.props.dataType),
       value: this.props.totalCount,
     });
     Object.keys(chartConfig).forEach((field) => {
@@ -102,7 +103,11 @@ class ExplorerVisualization extends React.Component {
     // don't lock components for libre commons
     const isComponentLocked = (tierAccessLevel !== 'regular') ? false : checkForAnySelectedUnaccessibleField(this.props.aggsData,
       this.props.accessibleFieldObject, this.props.guppyConfig.accessibleValidationField);
-    const lockMessage = `The chart is hidden because you are exploring restricted access data and one or more of the values within the chart has a count below the access limit of ${this.props.tierAccessLimit} ${this.props.guppyConfig.nodeCountTitle.toLowerCase() || this.props.guppyConfig.dataType}.`;
+    const lockMessage = `The chart is hidden because you are exploring restricted access data and one or more of the values within the chart has a count below the access limit of ${this.props.tierAccessLimit} ${
+      this.props.guppyConfig.nodeCountTitle? 
+        this.props.guppyConfig.nodeCountTitle.toLowerCase() : 
+        labelToTitle(this.props.guppyConfig.dataType, false)
+      }.`;
     const barChartColor = components.categorical2Colors ? components.categorical2Colors[0] : null;
 
     // heatmap config
@@ -264,7 +269,7 @@ ExplorerVisualization.propTypes = {
   buttonConfig: ButtonConfigType,
   heatMapConfig: PropTypes.object,
   guppyConfig: GuppyConfigType,
-  nodeCountTitle: PropTypes.string.isRequired,
+  nodeCountTitle: PropTypes.string,
   tierAccessLimit: PropTypes.number.isRequired,
 };
 

--- a/src/GuppyDataExplorer/ExplorerVisualization/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerVisualization/index.jsx
@@ -32,7 +32,7 @@ class ExplorerVisualization extends React.Component {
     let countItems = [];
     const stackedBarCharts = [];
     countItems.push({
-      label: this.props.nodeCountTitle || labelToTitle(this.props.dataType),
+      label: this.props.nodeCountTitle || labelToTitle(this.props.guppyConfig.dataType),
       value: this.props.totalCount,
     });
     Object.keys(chartConfig).forEach((field) => {
@@ -104,10 +104,10 @@ class ExplorerVisualization extends React.Component {
     const isComponentLocked = (tierAccessLevel !== 'regular') ? false : checkForAnySelectedUnaccessibleField(this.props.aggsData,
       this.props.accessibleFieldObject, this.props.guppyConfig.accessibleValidationField);
     const lockMessage = `The chart is hidden because you are exploring restricted access data and one or more of the values within the chart has a count below the access limit of ${this.props.tierAccessLimit} ${
-      this.props.guppyConfig.nodeCountTitle? 
-        this.props.guppyConfig.nodeCountTitle.toLowerCase() : 
+      this.props.guppyConfig.nodeCountTitle ?
+        this.props.guppyConfig.nodeCountTitle.toLowerCase() :
         labelToTitle(this.props.guppyConfig.dataType, false)
-      }.`;
+    }.`;
     const barChartColor = components.categorical2Colors ? components.categorical2Colors[0] : null;
 
     // heatmap config
@@ -292,6 +292,7 @@ ExplorerVisualization.defaultProps = {
   buttonConfig: {},
   heatMapConfig: {},
   guppyConfig: {},
+  nodeCountTitle: '',
 };
 
 export default ExplorerVisualization;

--- a/src/GuppyDataExplorer/ExplorerVisualization/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerVisualization/index.jsx
@@ -18,7 +18,7 @@ import {
 } from '../configTypeDef';
 import { checkForAnySelectedUnaccessibleField } from '../GuppyDataExplorerHelper';
 import './ExplorerVisualization.css';
-import { labelToTitle } from '../utils';
+import { labelToPlural } from '../utils';
 
 
 class ExplorerVisualization extends React.Component {
@@ -32,7 +32,7 @@ class ExplorerVisualization extends React.Component {
     let countItems = [];
     const stackedBarCharts = [];
     countItems.push({
-      label: this.props.nodeCountTitle || labelToTitle(this.props.guppyConfig.dataType),
+      label: this.props.nodeCountTitle || labelToPlural(this.props.guppyConfig.dataType, true),
       value: this.props.totalCount,
     });
     Object.keys(chartConfig).forEach((field) => {
@@ -106,7 +106,7 @@ class ExplorerVisualization extends React.Component {
     const lockMessage = `The chart is hidden because you are exploring restricted access data and one or more of the values within the chart has a count below the access limit of ${this.props.tierAccessLimit} ${
       this.props.guppyConfig.nodeCountTitle ?
         this.props.guppyConfig.nodeCountTitle.toLowerCase() :
-        labelToTitle(this.props.guppyConfig.dataType, false)
+        labelToPlural(this.props.guppyConfig.dataType)
     }.`;
     const barChartColor = components.categorical2Colors ? components.categorical2Colors[0] : null;
 

--- a/src/GuppyDataExplorer/GuppyDataExplorer.jsx
+++ b/src/GuppyDataExplorer/GuppyDataExplorer.jsx
@@ -4,7 +4,7 @@ import GuppyWrapper from '@gen3/guppy/dist/components/GuppyWrapper';
 import ExplorerVisualization from './ExplorerVisualization';
 import ExplorerFilter from './ExplorerFilter';
 import ExplorerTopMessageBanner from './ExplorerTopMessageBanner';
-import { labelToTitle } from './utils';
+import { labelToPlural } from './utils';
 import {
   GuppyConfigType,
   FilterConfigType,
@@ -65,7 +65,7 @@ class GuppyDataExplorer extends React.Component {
             history={this.props.history}
             nodeCountTitle={
               this.props.guppyConfig.nodeCountTitle
-              || labelToTitle(this.props.guppyConfig.dataType)}
+              || labelToPlural(this.props.guppyConfig.dataType, true)}
             tierAccessLimit={this.props.tierAccessLimit}
           />
         </GuppyWrapper>

--- a/src/GuppyDataExplorer/GuppyDataExplorer.jsx
+++ b/src/GuppyDataExplorer/GuppyDataExplorer.jsx
@@ -4,7 +4,7 @@ import GuppyWrapper from '@gen3/guppy/dist/components/GuppyWrapper';
 import ExplorerVisualization from './ExplorerVisualization';
 import ExplorerFilter from './ExplorerFilter';
 import ExplorerTopMessageBanner from './ExplorerTopMessageBanner';
-import { capitalizeFirstLetter } from '../utils';
+import { labelToTitle } from '../utils';
 import {
   GuppyConfigType,
   FilterConfigType,
@@ -63,8 +63,7 @@ class GuppyDataExplorer extends React.Component {
             heatMapConfig={this.props.heatMapConfig}
             guppyConfig={this.props.guppyConfig}
             history={this.props.history}
-            nodeCountTitle={this.props.guppyConfig.nodeCountTitle || capitalizeFirstLetter(
-              this.props.guppyConfig.dataType)}
+            nodeCountTitle={this.props.guppyConfig.nodeCountTitle || labelToTitle(this.props.guppyConfig.dataType)}
             tierAccessLimit={this.props.tierAccessLimit}
           />
         </GuppyWrapper>

--- a/src/GuppyDataExplorer/GuppyDataExplorer.jsx
+++ b/src/GuppyDataExplorer/GuppyDataExplorer.jsx
@@ -4,7 +4,7 @@ import GuppyWrapper from '@gen3/guppy/dist/components/GuppyWrapper';
 import ExplorerVisualization from './ExplorerVisualization';
 import ExplorerFilter from './ExplorerFilter';
 import ExplorerTopMessageBanner from './ExplorerTopMessageBanner';
-import { labelToTitle } from '../utils';
+import { labelToTitle } from './utils';
 import {
   GuppyConfigType,
   FilterConfigType,

--- a/src/GuppyDataExplorer/GuppyDataExplorer.jsx
+++ b/src/GuppyDataExplorer/GuppyDataExplorer.jsx
@@ -63,7 +63,9 @@ class GuppyDataExplorer extends React.Component {
             heatMapConfig={this.props.heatMapConfig}
             guppyConfig={this.props.guppyConfig}
             history={this.props.history}
-            nodeCountTitle={this.props.guppyConfig.nodeCountTitle || labelToTitle(this.props.guppyConfig.dataType)}
+            nodeCountTitle={
+              this.props.guppyConfig.nodeCountTitle
+              || labelToTitle(this.props.guppyConfig.dataType)}
             tierAccessLimit={this.props.tierAccessLimit}
           />
         </GuppyWrapper>

--- a/src/GuppyDataExplorer/utils.js
+++ b/src/GuppyDataExplorer/utils.js
@@ -57,3 +57,18 @@ export const humanizeNumber = (number, fixedPoint = 2) => {
   // 10^15+, number is too large
   return Number.parseFloat(number).toExponential(fixedPoint);
 };
+
+/*
+* Convert label to pluralized Title
+* @param {label} string - a label to convert to title
+* @param {titleCase} boolean - Should first letter be capitalized 
+* @returns {string} Pluralized formatted word
+*/
+import pluralize from 'pluralize';
+export const labelToTitle = (label, titleCase = true) => {
+  const pluralizedLabel = pluralize(label);
+  if (titleCase) {
+    return pluralizedLabel.charAt(0).toUpperCase() + pluralizedLabel.slice(1);
+  }
+  return pluralizedLabel.toLowerCase();
+};

--- a/src/GuppyDataExplorer/utils.js
+++ b/src/GuppyDataExplorer/utils.js
@@ -61,12 +61,12 @@ export const humanizeNumber = (number, fixedPoint = 2) => {
 };
 
 /*
-* Convert label to pluralized Title
+* Convert label to pluralized (optional title case)
 * @param {label} string - a label to convert to title
-* @param {titleCase} boolean - Should first letter be capitalized
+* @param {titleCase} boolean - Should first letter be capitalized default false
 * @returns {string} Pluralized formatted word
 */
-export const labelToTitle = (label, titleCase = true) => {
+export const labelToPlural = (label, titleCase = false) => {
   const pluralizedLabel = pluralize(label);
   if (titleCase) {
     return pluralizedLabel.charAt(0).toUpperCase() + pluralizedLabel.slice(1);

--- a/src/GuppyDataExplorer/utils.js
+++ b/src/GuppyDataExplorer/utils.js
@@ -6,6 +6,8 @@
 *   dropdownConfig: infos for this dropdown, e.g. "title"
 *   buttonConfigs: a list of button configs (includes buttion title, button type, etc.)
 */
+import pluralize from 'pluralize';
+
 export const calculateDropdownButtonConfigs = (config) => {
   const dropdownConfig = config
     && config.dropdowns
@@ -61,10 +63,9 @@ export const humanizeNumber = (number, fixedPoint = 2) => {
 /*
 * Convert label to pluralized Title
 * @param {label} string - a label to convert to title
-* @param {titleCase} boolean - Should first letter be capitalized 
+* @param {titleCase} boolean - Should first letter be capitalized
 * @returns {string} Pluralized formatted word
 */
-import pluralize from 'pluralize';
 export const labelToTitle = (label, titleCase = true) => {
   const pluralizedLabel = pluralize(label);
   if (titleCase) {

--- a/src/GuppyDataExplorer/utils.test.js
+++ b/src/GuppyDataExplorer/utils.test.js
@@ -1,4 +1,4 @@
-import { labelToTitle, calculateDropdownButtonConfigs, humanizeNumber } from './utils';
+import { labelToPlural, calculateDropdownButtonConfigs, humanizeNumber } from './utils';
 
 describe('utils for data visualization explorer', () => {
   it('calculate dropdown button configurations correctly', () => {
@@ -70,12 +70,12 @@ describe('utils for data visualization explorer', () => {
   });
 
   it('Convert label to Title', () => {
-    expect(labelToTitle('test')).toBe('Tests');
-    expect(labelToTitle('case')).toBe('Cases');
-    expect(labelToTitle('file')).toBe('Files');
-    expect(labelToTitle('test', false)).toBe('tests');
-    expect(labelToTitle('case', false)).toBe('cases');
-    expect(labelToTitle('file', false)).toBe('files');
-    expect(labelToTitle('test case with odd stuff_21file')).toBe('Test case with odd stuff_21files');
+    expect(labelToPlural('test', true)).toBe('Tests', true);
+    expect(labelToPlural('case', true)).toBe('Cases');
+    expect(labelToPlural('file', true)).toBe('Files');
+    expect(labelToPlural('test', false)).toBe('tests');
+    expect(labelToPlural('case')).toBe('cases');
+    expect(labelToPlural('file')).toBe('files');
+    expect(labelToPlural('test case with odd stuff_21file', true)).toBe('Test case with odd stuff_21files');
   });
 });

--- a/src/GuppyDataExplorer/utils.test.js
+++ b/src/GuppyDataExplorer/utils.test.js
@@ -1,4 +1,4 @@
-import { calculateDropdownButtonConfigs, humanizeNumber } from './utils';
+import { labelToTitle, calculateDropdownButtonConfigs, humanizeNumber } from './utils';
 
 describe('utils for data visualization explorer', () => {
   it('calculate dropdown button configurations correctly', () => {
@@ -67,5 +67,15 @@ describe('utils for data visualization explorer', () => {
     expect(humanizeNumber(1200000000, 1)).toBe('1.2B');
     expect(humanizeNumber(1200000000000, 1)).toBe('1.2T');
     expect(humanizeNumber(1200000000000000, 1)).toBe('1.2Qa');
+  });
+
+  it('Convert label to Title', () => {
+    expect(labelToTitle('test')).toBe('Tests');
+    expect(labelToTitle('case')).toBe('Cases');
+    expect(labelToTitle('file')).toBe('Files');
+    expect(labelToTitle('test', false)).toBe('tests');
+    expect(labelToTitle('case', false)).toBe('cases');
+    expect(labelToTitle('file', false)).toBe('files');
+    expect(labelToTitle('test case with odd stuff_21file')).toBe('Test case with odd stuff_21files');
   });
 });


### PR DESCRIPTION
Jira Ticket: [PXP-6184](https://ctds-planx.atlassian.net/browse/PXP-6184)

### Improvements
make the nodeCountTitle field optional by using a reformatted dataType if not filled out
Adds a labelToTitle helper function for styling dataType as well as tests for this new function 
