### PR TITLE
(COV-649): Style/world map view

### DIFF
--- a/src/Covid19Dashboard/ChartCarousel/ChartCarousel.less
+++ b/src/Covid19Dashboard/ChartCarousel/ChartCarousel.less
@@ -1,5 +1,4 @@
 .chart-carousel__container {
-  width: 550px;
   padding: 10px 30px 30px 30px; // space for arrows and dots
   margin-left: 10px;
   margin-bottom: 10px;

--- a/src/Covid19Dashboard/Covid19Dashboard.less
+++ b/src/Covid19Dashboard/Covid19Dashboard.less
@@ -32,13 +32,12 @@
 .covid19-dashboard_visualizations {
   padding: 10px;
   padding-top: 0; // counts above visualizations already padded
-  display: grid;
-  grid-auto-columns: 1fr 550px;
+  display: flex;
 }
 
 .covid19-dashboard_charts {
-  grid-column: 2;
-  display: grid;
+  width: 100%;
+  min-width: 550px;
 }
 
 .covid19-dashboard__location-info__click {
@@ -76,8 +75,9 @@
 // end location popup
 
 .map-chart {
-  grid-column: 1;
   width: 100%;
+  flex-basis: 200%;
+  max-width: 1080px;
 }
 
 .map-chart__mapgl-map {

--- a/src/Covid19Dashboard/IllinoisMapChart/index.jsx
+++ b/src/Covid19Dashboard/IllinoisMapChart/index.jsx
@@ -51,12 +51,11 @@ function filterCountyGeoJson(selectedFips) {
 class IllinoisMapChart extends React.Component {
   constructor(props) {
     super(props);
-    this.updateDimensions = this.updateDimensions.bind(this);
     this.choroCountyGeoJson = null;
     this.state = {
       mapSize: {
         width: '100%',
-        height: window.innerHeight - 221,
+        height: '100%',
       },
       viewport: {
         // start centered on Chicago
@@ -68,10 +67,6 @@ class IllinoisMapChart extends React.Component {
       },
       hoverInfo: null,
     };
-  }
-
-  componentDidMount() {
-    window.addEventListener('resize', this.updateDimensions);
   }
 
   onHover = (event) => {
@@ -134,12 +129,6 @@ class IllinoisMapChart extends React.Component {
           this.props.modeledFipsList.includes(feature.properties.FIPS),
         );
       }
-    });
-  }
-
-  updateDimensions() {
-    this.setState({
-      mapSize: { width: '100%', height: window.innerHeight - 221 },
     });
   }
 

--- a/src/Covid19Dashboard/WorldMapChart/index.jsx
+++ b/src/Covid19Dashboard/WorldMapChart/index.jsx
@@ -107,7 +107,6 @@ function filterCountyGeoJson(selectedFips) {
 class WorldMapChart extends React.Component {
   constructor(props) {
     super(props);
-    this.updateDimensions = this.updateDimensions.bind(this);
     this.choroCountryGeoJson = null;
     this.choroStateGeoJson = null;
     this.choroCountyGeoJson = null;
@@ -115,7 +114,7 @@ class WorldMapChart extends React.Component {
       selectedLayer: 'confirmed-dots',
       mapSize: {
         width: '100%',
-        height: window.innerHeight - 221,
+        height: '100%',
       },
       viewport: {
         longitude: 0,
@@ -126,10 +125,6 @@ class WorldMapChart extends React.Component {
       },
       hoverInfo: null,
     };
-  }
-
-  componentDidMount() {
-    window.addEventListener('resize', this.updateDimensions);
   }
 
   onHover = (event) => {
@@ -233,12 +228,6 @@ class WorldMapChart extends React.Component {
       return 'visible';
     }
     return 'none';
-  }
-
-  updateDimensions() {
-    this.setState({
-      mapSize: { width: '100%', height: window.innerHeight - 221 },
-    });
   }
 
   renderHoverPopup() {


### PR DESCRIPTION
Jira Ticket: [COV-649](https://occ-data.atlassian.net/browse/COV-649)

### Improvements
Change maps to take up 100% height instead of calculating based on window.innerHeight
Removed unneeded related code 
Changed css from grid to flexbox for better flexibility in the layout, constrained main maps width to only show globe once

