### PR TITLE
(PXP-7799): feat/ui-component-update: Responsive Explorer charts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1967,9 +1967,9 @@
       }
     },
     "node_modules/@gen3/guppy": {
-      "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/@gen3/guppy/-/guppy-0.11.1.tgz",
-      "integrity": "sha512-M4YVIRMYbSu9VQT88SGt/wTHUSzxX+VK4rLSqkjrQA6sCG3vvz1QDN/gIDdj8c6OhF1SlbX3kTjKXG13rpN91A==",
+      "version": "0.11.2",
+      "resolved": "https://registry.npmjs.org/@gen3/guppy/-/guppy-0.11.2.tgz",
+      "integrity": "sha512-k3NsPtrgEpoui5pbLYyhHwEfnq9NkhBF8fwehcJ8oO7SUCOD7domhWqDhGZLnXxkDbKSuJVAO8BTy2wZU8Q6XA==",
       "dependencies": {
         "@elastic/elasticsearch": "^7.0.0-rc.1",
         "@gen3/ui-component": "^0.6.5",
@@ -2003,10 +2003,9 @@
       "license": "MIT"
     },
     "node_modules/@gen3/ui-component": {
-      "version": "0.6.5",
-      "resolved": "https://registry.npmjs.org/@gen3/ui-component/-/ui-component-0.6.5.tgz",
-      "integrity": "sha512-dYqR9ZA818/Hhrb56s/DUO8gFaZfEfR0I01sJUJLrZeKuxfgVPoqRd6U4onuKMhHI1HJvPnrG3CtxcpMbxMzSQ==",
-      "license": "ISC",
+      "version": "0.6.6",
+      "resolved": "https://registry.npmjs.org/@gen3/ui-component/-/ui-component-0.6.6.tgz",
+      "integrity": "sha512-OcO8syLCYWrSeIB2v3ss4LGWHfivrG+SLQklzNj+jxm6xIMkk6/2Bn8hXVvuky9TDMkOF+S2IXOzqsV0hApUUQ==",
       "dependencies": {
         "@storybook/addon-actions": "^5.0.0",
         "@storybook/react": "^5.0.0",
@@ -2023,14 +2022,13 @@
         "react-select": "^3.1.0",
         "react-select-async-paginate": "^0.4.0",
         "recharts": "^1.5.0",
-        "stylelint": "^13.6.1"
+        "stylelint": "^13.11.0"
       }
     },
     "node_modules/@gen3/ui-component/node_modules/@nodelib/fs.stat": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.4.tgz",
       "integrity": "sha512-IYlHJA0clt2+Vg7bccq+TzRdJvv19c2INqBSsoOLp1je7xjtr7J26+WXR72MCdvU9q1qTzIWDfhMf+DRvQJK4Q==",
-      "license": "MIT",
       "engines": {
         "node": ">= 8"
       }
@@ -2039,7 +2037,6 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
       "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
-      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
@@ -2048,7 +2045,6 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
       },
@@ -2063,7 +2059,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
       "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
-      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
@@ -2072,7 +2067,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
       "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
-      "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -2088,7 +2082,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
       },
@@ -2099,14 +2092,12 @@
     "node_modules/@gen3/ui-component/node_modules/color-name": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "license": "MIT"
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
     },
     "node_modules/@gen3/ui-component/node_modules/cosmiconfig": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.0.0.tgz",
       "integrity": "sha512-pondGvTuVYDk++upghXJabWzL6Kxu6f26ljFw64Swq9v6sQPUL3EUlVDV56diOjpCayKihL6hVe8exIACU4XcA==",
-      "license": "MIT",
       "dependencies": {
         "@types/parse-json": "^4.0.0",
         "import-fresh": "^3.2.1",
@@ -2122,7 +2113,6 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
       "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
-      "license": "MIT",
       "dependencies": {
         "path-type": "^4.0.0"
       },
@@ -2133,14 +2123,12 @@
     "node_modules/@gen3/ui-component/node_modules/emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "license": "MIT"
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
     },
     "node_modules/@gen3/ui-component/node_modules/fast-glob": {
       "version": "3.2.5",
       "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.5.tgz",
       "integrity": "sha512-2DtFcgT68wiTTiwZ2hNdJfcHNke9XOfnwmBRWXhmeKM8rF0TGwmC/Qto3S7RoZKp5cilZbxzO5iTNTQsJ+EeDg==",
-      "license": "MIT",
       "dependencies": {
         "@nodelib/fs.stat": "^2.0.2",
         "@nodelib/fs.walk": "^1.2.3",
@@ -2157,7 +2145,6 @@
       "version": "11.0.2",
       "resolved": "https://registry.npmjs.org/globby/-/globby-11.0.2.tgz",
       "integrity": "sha512-2ZThXDvvV8fYFRVIxnrMQBipZQDr7MxKAmQK1vujaj9/7eF0efG7BPUKJ7jP7G5SLF37xKDXvO4S/KKLj/Z0og==",
-      "license": "MIT",
       "dependencies": {
         "array-union": "^2.1.0",
         "dir-glob": "^3.0.1",
@@ -2177,7 +2164,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
@@ -2186,7 +2172,6 @@
       "version": "5.1.8",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.8.tgz",
       "integrity": "sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==",
-      "license": "MIT",
       "engines": {
         "node": ">= 4"
       }
@@ -2195,7 +2180,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
@@ -2204,16 +2188,14 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
       "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
-      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
     },
     "node_modules/@gen3/ui-component/node_modules/string-width": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
-      "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
-      "license": "MIT",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.2.tgz",
+      "integrity": "sha512-XBJbT3N4JhVumXE0eoLU9DCjcaF92KLNqTmFCnG1pf8duUxFGwtP6AD6nkjw9a3IdiRtL3E2w3JDiE/xi3vOeA==",
       "dependencies": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
@@ -2227,7 +2209,6 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
       "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
-      "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.0"
       },
@@ -2236,10 +2217,9 @@
       }
     },
     "node_modules/@gen3/ui-component/node_modules/stylelint": {
-      "version": "13.9.0",
-      "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-13.9.0.tgz",
-      "integrity": "sha512-VVWH2oixOAxpWL1vH+V42ReCzBjW2AeqskSAbi8+3OjV1Xg3VZkmTcAqBZfRRvJeF4BvYuDLXebW3tIHxgZDEg==",
-      "license": "MIT",
+      "version": "13.12.0",
+      "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-13.12.0.tgz",
+      "integrity": "sha512-P8O1xDy41B7O7iXaSlW+UuFbE5+ZWQDb61ndGDxKIt36fMH50DtlQTbwLpFLf8DikceTAb3r6nPrRv30wBlzXw==",
       "dependencies": {
         "@stylelint/postcss-css-in-js": "^0.37.2",
         "@stylelint/postcss-markdown": "^0.36.2",
@@ -2251,7 +2231,7 @@
         "execall": "^2.0.0",
         "fast-glob": "^3.2.5",
         "fastest-levenshtein": "^1.0.12",
-        "file-entry-cache": "^6.0.0",
+        "file-entry-cache": "^6.0.1",
         "get-stdin": "^8.0.0",
         "global-modules": "^2.0.0",
         "globby": "^11.0.2",
@@ -2260,8 +2240,8 @@
         "ignore": "^5.1.8",
         "import-lazy": "^4.0.0",
         "imurmurhash": "^0.1.4",
-        "known-css-properties": "^0.20.0",
-        "lodash": "^4.17.20",
+        "known-css-properties": "^0.21.0",
+        "lodash": "^4.17.21",
         "log-symbols": "^4.0.0",
         "mathml-tag-names": "^2.1.3",
         "meow": "^9.0.0",
@@ -2281,7 +2261,7 @@
         "resolve-from": "^5.0.0",
         "slash": "^3.0.0",
         "specificity": "^0.4.1",
-        "string-width": "^4.2.0",
+        "string-width": "^4.2.2",
         "strip-ansi": "^6.0.0",
         "style-search": "^0.1.0",
         "sugarss": "^2.0.0",
@@ -2305,7 +2285,6 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
       },
@@ -4794,7 +4773,6 @@
       "version": "0.37.2",
       "resolved": "https://registry.npmjs.org/@stylelint/postcss-css-in-js/-/postcss-css-in-js-0.37.2.tgz",
       "integrity": "sha512-nEhsFoJurt8oUmieT8qy4nk81WRHmJynmVwn/Vts08PL9fhgIsMhk1GId5yAN643OzqEEb5S/6At2TZW7pqPDA==",
-      "license": "MIT",
       "dependencies": {
         "@babel/core": ">=7.9.0"
       },
@@ -4807,7 +4785,6 @@
       "version": "0.36.2",
       "resolved": "https://registry.npmjs.org/@stylelint/postcss-markdown/-/postcss-markdown-0.36.2.tgz",
       "integrity": "sha512-2kGbqUVJUGE8dM+bMzXG/PYUWKkjLIkRLWNh39OaADkiabDRdw8ATFCgbMz5xdIcvwspPAluSL7uY+ZiTWdWmQ==",
-      "license": "MIT",
       "dependencies": {
         "remark": "^13.0.0",
         "unist-util-find-all-after": "^3.0.2"
@@ -5648,8 +5625,7 @@
     "node_modules/@types/minimist": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.1.tgz",
-      "integrity": "sha512-fZQQafSREFyuZcdWFAExYjBiCL7AUCdgsk80iO0q4yihYYdcIiH28CcuPTGFgLOCC8RlW49GSQxdHwZP+I7CNg==",
-      "license": "MIT"
+      "integrity": "sha512-fZQQafSREFyuZcdWFAExYjBiCL7AUCdgsk80iO0q4yihYYdcIiH28CcuPTGFgLOCC8RlW49GSQxdHwZP+I7CNg=="
     },
     "node_modules/@types/node": {
       "version": "14.14.20",
@@ -9954,7 +9930,6 @@
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-6.2.2.tgz",
       "integrity": "sha512-YrwaA0vEKazPBkn0ipTiMpSajYDSe+KjQfrjhcBMxJt/znbvlHd8Pw/Vamaz5EB4Wfhs3SUR3Z9mwRu/P3s3Yg==",
-      "license": "MIT",
       "dependencies": {
         "camelcase": "^5.3.1",
         "map-obj": "^4.0.0",
@@ -10679,7 +10654,6 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/clone-regexp/-/clone-regexp-2.2.0.tgz",
       "integrity": "sha512-beMpP7BOtTipFuW8hrJvREQ2DrRu3BE7by0ZpibtfBA+qfHYvMGTc2Yb1JMYPKg/JUw0CHYvpg796aNTSW9z7Q==",
-      "license": "MIT",
       "dependencies": {
         "is-regexp": "^2.0.0"
       },
@@ -14236,7 +14210,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/execall/-/execall-2.0.0.tgz",
       "integrity": "sha512-0FU2hZ5Hh6iQnarpRtQurM/aAvp3RIbfvgLHrcqJYzhXyV2KFruhuChf9NC6waAhiUR7FFtlugkI4p7f2Fqlow==",
-      "license": "MIT",
       "dependencies": {
         "clone-regexp": "^2.1.0"
       },
@@ -14658,8 +14631,7 @@
     "node_modules/fastest-levenshtein": {
       "version": "1.0.12",
       "resolved": "https://registry.npmjs.org/fastest-levenshtein/-/fastest-levenshtein-1.0.12.tgz",
-      "integrity": "sha512-On2N+BpYJ15xIC974QNVuYGMOlEVt4s0EOI3wwMqOmK1fdDY+FN/zltPV8vosq4ad4c/gJ1KHScUn/6AWIgiow==",
-      "license": "MIT"
+      "integrity": "sha512-On2N+BpYJ15xIC974QNVuYGMOlEVt4s0EOI3wwMqOmK1fdDY+FN/zltPV8vosq4ad4c/gJ1KHScUn/6AWIgiow=="
     },
     "node_modules/fastq": {
       "version": "1.10.0",
@@ -14748,10 +14720,9 @@
       }
     },
     "node_modules/file-entry-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.0.tgz",
-      "integrity": "sha512-fqoO76jZ3ZnYrXLDRxBR1YvOvc0k844kcOg40bgsPrE25LAb/PDqTY+ho64Xh2c8ZXgIKldchCFHczG2UVRcWA==",
-      "license": "MIT",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
+      "integrity": "sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==",
       "dependencies": {
         "flat-cache": "^3.0.4"
       },
@@ -15668,7 +15639,6 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-8.0.0.tgz",
       "integrity": "sha512-sY22aA6xchAzprjyqmSEQv4UbAAzRN0L2dQB0NlN5acTTK9Don6nhoc3eAbUnpZiCANAMfd/+40kVdKfFygohg==",
-      "license": "MIT",
       "engines": {
         "node": ">=10"
       },
@@ -16333,7 +16303,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/hard-rejection/-/hard-rejection-2.1.0.tgz",
       "integrity": "sha512-VIZB+ibDhx7ObhAe7OVtoEbuP4h/MuOTHJ+J8h/eBXotJYl0fBgR72xDFCKgIh22OJZIOVNxBMWuhAr10r8HdA==",
-      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
@@ -16695,10 +16664,9 @@
       }
     },
     "node_modules/hosted-git-info": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-3.0.7.tgz",
-      "integrity": "sha512-fWqc0IcuXs+BmE9orLDyVykAG9GJtGLGuZAAqgcckPgv5xad4AcXGIv8galtQvlwutxSlaMcdw7BUtq2EIvqCQ==",
-      "license": "ISC",
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-3.0.8.tgz",
+      "integrity": "sha512-aXpmwoOhRBrw6X3j0h5RloK4x1OzsxMPyxqIHyNfSe2pypkVTZFpEiRoSipPEPlMrh0HW/XsjkJ5WgnCirpNUw==",
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -16710,7 +16678,6 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
       "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "license": "ISC",
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -16721,8 +16688,7 @@
     "node_modules/hosted-git-info/node_modules/yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "license": "ISC"
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/hpack.js": {
       "version": "2.1.6",
@@ -16902,7 +16868,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/html-tags/-/html-tags-3.1.0.tgz",
       "integrity": "sha512-1qYz89hW3lFDEazhjW0yVAV87lw8lVkrJocr72XmBkMKsoSVJCQx3W8BXsC7hO2qAt8BoVjYjtAcZ9perqGnNg==",
-      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
@@ -17369,7 +17334,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/import-lazy/-/import-lazy-4.0.0.tgz",
       "integrity": "sha512-rKtvo6a868b5Hu3heneU+L4yEQ4jYKLtjpnPeUdK7h0yzXGmyBTypknlkCvHFBqfX9YlorEiMM6Dnq/5atfHkw==",
-      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
@@ -18237,7 +18201,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-regexp/-/is-regexp-2.1.0.tgz",
       "integrity": "sha512-OZ4IlER3zmRIoB9AqNhEggVxqIH4ofDns5nRrPS6yQxXE1TPCUpFznBfRQmQa8uC+pXqjMnukiJBxCisIxiLGA==",
-      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
@@ -20120,10 +20083,9 @@
       }
     },
     "node_modules/known-css-properties": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/known-css-properties/-/known-css-properties-0.20.0.tgz",
-      "integrity": "sha512-URvsjaA9ypfreqJ2/ylDr5MUERhJZ+DhguoWRr2xgS5C7aGCalXo+ewL+GixgKBfhT2vuL02nbIgNGqVWgTOYw==",
-      "license": "MIT"
+      "version": "0.21.0",
+      "resolved": "https://registry.npmjs.org/known-css-properties/-/known-css-properties-0.21.0.tgz",
+      "integrity": "sha512-sZLUnTqimCkvkgRS+kbPlYW5o8q5w1cu+uIisKpEWkj31I8mx8kNG162DwRav8Zirkva6N5uoFsm9kzK4mUXjw=="
     },
     "node_modules/latest-version": {
       "version": "3.1.0",
@@ -20906,10 +20868,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.20",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
-      "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
-      "license": "MIT"
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "node_modules/lodash-es": {
       "version": "4.17.20",
@@ -20988,7 +20949,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.0.0.tgz",
       "integrity": "sha512-FN8JBzLx6CzeMrB0tg6pqlGU1wCrXW+ZXGH481kfsBqer0hToTIiHdjH4Mq8xJUbvATujKCvaREGWpGUionraA==",
-      "license": "MIT",
       "dependencies": {
         "chalk": "^4.0.0"
       },
@@ -21000,7 +20960,6 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "license": "MIT",
       "dependencies": {
         "color-convert": "^2.0.1"
       },
@@ -21015,7 +20974,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
       "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
-      "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -21031,7 +20989,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "license": "MIT",
       "dependencies": {
         "color-name": "~1.1.4"
       },
@@ -21042,14 +20999,12 @@
     "node_modules/log-symbols/node_modules/color-name": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "license": "MIT"
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
     },
     "node_modules/log-symbols/node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
@@ -21058,7 +21013,6 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
       },
@@ -21221,7 +21175,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-4.1.0.tgz",
       "integrity": "sha512-glc9y00wgtwcDmp7GaE/0b0OnxpNJsVf3ael/An6Fe2Q51LLwN1er6sdomLRzz5h0+yMpiYLhWYF5R7HeqVd4g==",
-      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
@@ -21434,10 +21387,9 @@
       }
     },
     "node_modules/mdast-util-from-markdown": {
-      "version": "0.8.4",
-      "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-0.8.4.tgz",
-      "integrity": "sha512-jj891B5pV2r63n2kBTFh8cRI2uR9LQHsXG1zSDqfhXkIlDzrTcIlbB5+5aaYEkl8vOPIOPLf8VT7Ere1wWTMdw==",
-      "license": "MIT",
+      "version": "0.8.5",
+      "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-0.8.5.tgz",
+      "integrity": "sha512-2hkTXtYYnr+NubD/g6KGBS/0mFmBcifAsI0yIWRiRo0PjVs6SSOSOdtzbp6kSGnShDN6G5aWZpKQ2lWRy27mWQ==",
       "dependencies": {
         "@types/mdast": "^3.0.0",
         "mdast-util-to-string": "^2.0.0",
@@ -21454,7 +21406,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-2.0.0.tgz",
       "integrity": "sha512-kkywGpCcRYhqQIchaWqZ875wzpS/bMKhz5HnN3p7wveJTkTtyAB/AlnS0f8DFSqYW1T82t6yEAkEcB+A1I3MbQ==",
-      "license": "MIT",
       "dependencies": {
         "character-entities": "^1.0.0",
         "character-entities-legacy": "^1.0.0",
@@ -21490,10 +21441,9 @@
       }
     },
     "node_modules/mdast-util-to-markdown": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-0.6.2.tgz",
-      "integrity": "sha512-iRczns6WMvu0hUw02LXsPDJshBIwtUPbvHBWo19IQeU0YqmzlA8Pd30U8V7uiI0VPkxzS7A/NXBXH6u+HS87Zg==",
-      "license": "MIT",
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-0.6.5.tgz",
+      "integrity": "sha512-XeV9sDE7ZlOQvs45C9UKMtfTcctcaj/pGwH8YLbMHoMOXNNCn2LsqVQOqrF1+/NU8lKDAqozme9SCXWyo9oAcQ==",
       "dependencies": {
         "@types/unist": "^2.0.0",
         "longest-streak": "^2.0.0",
@@ -21511,7 +21461,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-2.0.0.tgz",
       "integrity": "sha512-kkywGpCcRYhqQIchaWqZ875wzpS/bMKhz5HnN3p7wveJTkTtyAB/AlnS0f8DFSqYW1T82t6yEAkEcB+A1I3MbQ==",
-      "license": "MIT",
       "dependencies": {
         "character-entities": "^1.0.0",
         "character-entities-legacy": "^1.0.0",
@@ -21529,7 +21478,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-2.0.0.tgz",
       "integrity": "sha512-AW4DRS3QbBayY/jJmD8437V1Gombjf8RSOUCMFBuo5iHi58AGEgVCKQ+ezHkZZDpAQS75hcBMpLqjpJTjtUL7w==",
-      "license": "MIT",
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
@@ -21606,7 +21554,6 @@
       "version": "9.0.0",
       "resolved": "https://registry.npmjs.org/meow/-/meow-9.0.0.tgz",
       "integrity": "sha512-+obSblOQmRhcyBt62furQqRAQpNyWXo8BuQ5bN7dG8wmwQ+vwHKp/rCFD4CrTP8CsDQD1sjoZ94K417XEUk8IQ==",
-      "license": "MIT",
       "dependencies": {
         "@types/minimist": "^1.2.0",
         "camelcase-keys": "^6.2.2",
@@ -21632,7 +21579,6 @@
       "version": "0.18.1",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.18.1.tgz",
       "integrity": "sha512-OIAYXk8+ISY+qTOwkHtKqzAuxchoMiD9Udx+FSGQDuiRR+PJKJHc2NJAXlbhkGwTt/4/nKZxELY1w3ReWOL8mw==",
-      "license": "(MIT OR CC0-1.0)",
       "engines": {
         "node": ">=10"
       },
@@ -21703,9 +21649,9 @@
       "license": "MIT"
     },
     "node_modules/micromark": {
-      "version": "2.11.2",
-      "resolved": "https://registry.npmjs.org/micromark/-/micromark-2.11.2.tgz",
-      "integrity": "sha512-IXuP76p2uj8uMg4FQc1cRE7lPCLsfAXuEfdjtdO55VRiFO1asrCSQ5g43NmPqFtRwzEnEhafRVzn2jg0UiKArQ==",
+      "version": "2.11.4",
+      "resolved": "https://registry.npmjs.org/micromark/-/micromark-2.11.4.tgz",
+      "integrity": "sha512-+WoovN/ppKolQOFIAajxi7Lu9kInbPxFuTBVEavFcL8eAfVstoc5MocPmqBeAdBOJV00uaVjegzH4+MA0DN/uA==",
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -21716,7 +21662,6 @@
           "url": "https://opencollective.com/unified"
         }
       ],
-      "license": "MIT",
       "dependencies": {
         "debug": "^4.0.0",
         "parse-entities": "^2.0.0"
@@ -21726,7 +21671,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-2.0.0.tgz",
       "integrity": "sha512-kkywGpCcRYhqQIchaWqZ875wzpS/bMKhz5HnN3p7wveJTkTtyAB/AlnS0f8DFSqYW1T82t6yEAkEcB+A1I3MbQ==",
-      "license": "MIT",
       "dependencies": {
         "character-entities": "^1.0.0",
         "character-entities-legacy": "^1.0.0",
@@ -21952,7 +21896,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/minimist-options/-/minimist-options-4.1.0.tgz",
       "integrity": "sha512-Q4r8ghd80yhO/0j1O3B2BjweX3fiHg9cdOwjJd2J76Q135c+NDxGCqdYKQ1SKBuFfgWbAUzBfvYjPUEeNgqN1A==",
-      "license": "MIT",
       "dependencies": {
         "arrify": "^1.0.1",
         "is-plain-obj": "^1.1.0",
@@ -22519,7 +22462,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-3.0.0.tgz",
       "integrity": "sha512-6lUjEI0d3v6kFrtgA/lOx4zHCWULXsFNIjHolnZCKCTLA6m/G625cdn3O7eNmT0iD3jfo6HZ9cdImGZwf21prw==",
-      "license": "BSD-2-Clause",
       "dependencies": {
         "hosted-git-info": "^3.0.6",
         "resolve": "^1.17.0",
@@ -22534,7 +22476,6 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
       "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "license": "ISC",
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -22546,7 +22487,6 @@
       "version": "7.3.4",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz",
       "integrity": "sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==",
-      "license": "ISC",
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -22560,8 +22500,7 @@
     "node_modules/normalize-package-data/node_modules/yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "license": "ISC"
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/normalize-path": {
       "version": "3.0.0",
@@ -24878,7 +24817,6 @@
       "version": "5.1.5",
       "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.5.tgz",
       "integrity": "sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==",
-      "deprecated": "this library is no longer supported",
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -30054,7 +29992,6 @@
       "version": "0.4.4",
       "resolved": "https://registry.npmjs.org/postcss-sass/-/postcss-sass-0.4.4.tgz",
       "integrity": "sha512-BYxnVYx4mQooOhr+zer0qWbSPYnarAy8ZT7hAQtbxtgVf8gy+LSLT/hHGe35h14/pZDTw1DsxdbrwxBN++H+fg==",
-      "license": "MIT",
       "dependencies": {
         "gonzales-pe": "^4.3.0",
         "postcss": "^7.0.21"
@@ -30633,7 +30570,6 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-4.0.1.tgz",
       "integrity": "sha512-ARhCpm70fzdcvNQfPoy49IaanKkTlRWF2JMzqhcJbhSFRZv7nPTvZJdcY7301IPmvW+/p0RgIWnQDLJxifsQ7g==",
-      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
@@ -32545,7 +32481,6 @@
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-7.0.1.tgz",
       "integrity": "sha512-zK0TB7Xd6JpCLmlLmufqykGE+/TlOePD6qKClNW7hHDKFh/J7/7gCWGR7joEQEW1bKq3a3yUZSObOoWLFQ4ohg==",
-      "license": "MIT",
       "dependencies": {
         "find-up": "^4.1.0",
         "read-pkg": "^5.2.0",
@@ -32735,7 +32670,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
       "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
-      "license": "MIT",
       "dependencies": {
         "indent-string": "^4.0.0",
         "strip-indent": "^3.0.0"
@@ -33201,7 +33135,6 @@
       "version": "13.0.0",
       "resolved": "https://registry.npmjs.org/remark/-/remark-13.0.0.tgz",
       "integrity": "sha512-HDz1+IKGtOyWN+QgBiAT0kn+2s6ovOxHyPAFGKVE81VSzJ+mq7RwHFledEvB5F1p4iJvOah/LOKdFuzvRnNLCA==",
-      "license": "MIT",
       "dependencies": {
         "remark-parse": "^9.0.0",
         "remark-stringify": "^9.0.0",
@@ -33328,7 +33261,6 @@
       "version": "9.0.0",
       "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-9.0.0.tgz",
       "integrity": "sha512-geKatMwSzEXKHuzBNU1z676sGcDcFoChMK38TgdHJNAYfFtsfHDQG7MoJAjs6sgYMqyLduCYWDIWZIxiPeafEw==",
-      "license": "MIT",
       "dependencies": {
         "mdast-util-from-markdown": "^0.8.0"
       },
@@ -33355,7 +33287,6 @@
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/remark-stringify/-/remark-stringify-9.0.1.tgz",
       "integrity": "sha512-mWmNg3ZtESvZS8fv5PTvaPckdL4iNlCHTt8/e/8oN08nArHRHjNZMKzA/YW3+p7/lYqIw4nx1XsjCBo/AxNChg==",
-      "license": "MIT",
       "dependencies": {
         "mdast-util-to-markdown": "^0.6.0"
       },
@@ -37502,7 +37433,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-3.0.0.tgz",
       "integrity": "sha512-C4+gOpvmxaSMKuEf9Qc134F1ZuOHVXKRbtEflf4NTtuuJDEIJ9p5PXsalL8SkeRw+qit1Mo+yuvMPAKwWg/1hA==",
-      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
@@ -37694,7 +37624,6 @@
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz",
       "integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
-      "license": "MIT",
       "dependencies": {
         "is-typedarray": "^1.0.0"
       }
@@ -37963,7 +37892,6 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/unist-util-find-all-after/-/unist-util-find-all-after-3.0.2.tgz",
       "integrity": "sha512-xaTC/AGZ0rIM2gM28YVRAFPIZpzbpDtU3dRmp7EXlNVA8ziQc4hY3H7BHXM1J49nEmiqc3svnqMReW+PGqbZKQ==",
-      "license": "MIT",
       "dependencies": {
         "unist-util-is": "^4.0.0"
       },
@@ -40354,7 +40282,6 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-3.0.3.tgz",
       "integrity": "sha512-AvHcyZ5JnSfq3ioSyjrBkH9yW4m7Ayk8/9My/DD9onKeu/94fwrMocemO2QAJFAlnnDN+ZDS+ZjAR5ua1/PV/Q==",
-      "license": "ISC",
       "dependencies": {
         "imurmurhash": "^0.1.4",
         "is-typedarray": "^1.0.0",
@@ -40477,10 +40404,9 @@
       }
     },
     "node_modules/yargs-parser": {
-      "version": "20.2.4",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.4.tgz",
-      "integrity": "sha512-WOkpgNhPTlE73h4VFAFsOnomJVaovO8VqLDzy5saChRBFQFBoMYirowyW+Q9HB4HFF4Z7VZTiG3iSzJJA29yRA==",
-      "license": "ISC",
+      "version": "20.2.6",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.6.tgz",
+      "integrity": "sha512-AP1+fQIWSM/sMiET8fyayjx/J+JmTPt2Mr0FkrgqB4todtfa53sOsrSAcIrJRD5XS20bKUwaDIuMkWKCEiQLKA==",
       "engines": {
         "node": ">=10"
       }
@@ -42081,9 +42007,9 @@
       }
     },
     "@gen3/guppy": {
-      "version": "0.11.1",
-      "resolved": "https://registry.npmjs.org/@gen3/guppy/-/guppy-0.11.1.tgz",
-      "integrity": "sha512-M4YVIRMYbSu9VQT88SGt/wTHUSzxX+VK4rLSqkjrQA6sCG3vvz1QDN/gIDdj8c6OhF1SlbX3kTjKXG13rpN91A==",
+      "version": "0.11.2",
+      "resolved": "https://registry.npmjs.org/@gen3/guppy/-/guppy-0.11.2.tgz",
+      "integrity": "sha512-k3NsPtrgEpoui5pbLYyhHwEfnq9NkhBF8fwehcJ8oO7SUCOD7domhWqDhGZLnXxkDbKSuJVAO8BTy2wZU8Q6XA==",
       "requires": {
         "@elastic/elasticsearch": "^7.0.0-rc.1",
         "@gen3/ui-component": "^0.6.5",
@@ -42118,9 +42044,9 @@
       }
     },
     "@gen3/ui-component": {
-      "version": "0.6.5",
-      "resolved": "https://registry.npmjs.org/@gen3/ui-component/-/ui-component-0.6.5.tgz",
-      "integrity": "sha512-dYqR9ZA818/Hhrb56s/DUO8gFaZfEfR0I01sJUJLrZeKuxfgVPoqRd6U4onuKMhHI1HJvPnrG3CtxcpMbxMzSQ==",
+      "version": "0.6.6",
+      "resolved": "https://registry.npmjs.org/@gen3/ui-component/-/ui-component-0.6.6.tgz",
+      "integrity": "sha512-OcO8syLCYWrSeIB2v3ss4LGWHfivrG+SLQklzNj+jxm6xIMkk6/2Bn8hXVvuky9TDMkOF+S2IXOzqsV0hApUUQ==",
       "requires": {
         "@storybook/addon-actions": "^5.0.0",
         "@storybook/react": "^5.0.0",
@@ -42137,7 +42063,7 @@
         "react-select": "^3.1.0",
         "react-select-async-paginate": "^0.4.0",
         "recharts": "^1.5.0",
-        "stylelint": "^13.6.1"
+        "stylelint": "^13.11.0"
       },
       "dependencies": {
         "@nodelib/fs.stat": {
@@ -42257,9 +42183,9 @@
           "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q=="
         },
         "string-width": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
-          "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
+          "version": "4.2.2",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.2.tgz",
+          "integrity": "sha512-XBJbT3N4JhVumXE0eoLU9DCjcaF92KLNqTmFCnG1pf8duUxFGwtP6AD6nkjw9a3IdiRtL3E2w3JDiE/xi3vOeA==",
           "requires": {
             "emoji-regex": "^8.0.0",
             "is-fullwidth-code-point": "^3.0.0",
@@ -42275,9 +42201,9 @@
           }
         },
         "stylelint": {
-          "version": "13.9.0",
-          "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-13.9.0.tgz",
-          "integrity": "sha512-VVWH2oixOAxpWL1vH+V42ReCzBjW2AeqskSAbi8+3OjV1Xg3VZkmTcAqBZfRRvJeF4BvYuDLXebW3tIHxgZDEg==",
+          "version": "13.12.0",
+          "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-13.12.0.tgz",
+          "integrity": "sha512-P8O1xDy41B7O7iXaSlW+UuFbE5+ZWQDb61ndGDxKIt36fMH50DtlQTbwLpFLf8DikceTAb3r6nPrRv30wBlzXw==",
           "requires": {
             "@stylelint/postcss-css-in-js": "^0.37.2",
             "@stylelint/postcss-markdown": "^0.36.2",
@@ -42289,7 +42215,7 @@
             "execall": "^2.0.0",
             "fast-glob": "^3.2.5",
             "fastest-levenshtein": "^1.0.12",
-            "file-entry-cache": "^6.0.0",
+            "file-entry-cache": "^6.0.1",
             "get-stdin": "^8.0.0",
             "global-modules": "^2.0.0",
             "globby": "^11.0.2",
@@ -42298,8 +42224,8 @@
             "ignore": "^5.1.8",
             "import-lazy": "^4.0.0",
             "imurmurhash": "^0.1.4",
-            "known-css-properties": "^0.20.0",
-            "lodash": "^4.17.20",
+            "known-css-properties": "^0.21.0",
+            "lodash": "^4.17.21",
             "log-symbols": "^4.0.0",
             "mathml-tag-names": "^2.1.3",
             "meow": "^9.0.0",
@@ -42319,7 +42245,7 @@
             "resolve-from": "^5.0.0",
             "slash": "^3.0.0",
             "specificity": "^0.4.1",
-            "string-width": "^4.2.0",
+            "string-width": "^4.2.2",
             "strip-ansi": "^6.0.0",
             "style-search": "^0.1.0",
             "sugarss": "^2.0.0",
@@ -42952,7 +42878,8 @@
     "@mapbox/mapbox-gl-supported": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/@mapbox/mapbox-gl-supported/-/mapbox-gl-supported-1.5.0.tgz",
-      "integrity": "sha512-/PT1P6DNf7vjEEiPkVIRJkvibbqWtqnyGaBz3nfRdcxclNSnSdaLU5tfAgcD7I8Yt5i+L19s406YLl1koLnLbg=="
+      "integrity": "sha512-/PT1P6DNf7vjEEiPkVIRJkvibbqWtqnyGaBz3nfRdcxclNSnSdaLU5tfAgcD7I8Yt5i+L19s406YLl1koLnLbg==",
+      "requires": {}
     },
     "@mapbox/point-geometry": {
       "version": "0.1.0",
@@ -45524,7 +45451,8 @@
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.1.tgz",
       "integrity": "sha512-K0Ptm/47OKfQRpNQ2J/oIN/3QYiK6FwW+eJbILhsdxh2WTLdl+30o8aGdTbm5JbffpFFAg/g+zi1E+jvJha5ng==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "acorn-walk": {
       "version": "6.2.0",
@@ -45633,12 +45561,14 @@
     "ajv-errors": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/ajv-errors/-/ajv-errors-1.0.1.tgz",
-      "integrity": "sha512-DCRfO/4nQ+89p/RK43i8Ezd41EqdGIU4ld7nGF8OQ14oc/we5rEntLCUa7+jrn3nn83BosfwZA0wb4pon2o8iQ=="
+      "integrity": "sha512-DCRfO/4nQ+89p/RK43i8Ezd41EqdGIU4ld7nGF8OQ14oc/we5rEntLCUa7+jrn3nn83BosfwZA0wb4pon2o8iQ==",
+      "requires": {}
     },
     "ajv-keywords": {
       "version": "3.5.2",
       "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
-      "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ=="
+      "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
+      "requires": {}
     },
     "amdefine": {
       "version": "1.0.1",
@@ -45976,7 +45906,8 @@
     "apollo-server-errors": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/apollo-server-errors/-/apollo-server-errors-2.4.2.tgz",
-      "integrity": "sha512-FeGxW3Batn6sUtX3OVVUm7o56EgjxDlmgpTLNyWcLb0j6P8mw9oLNyAm3B+deHA4KNdNHO5BmHS2g1SJYjqPCQ=="
+      "integrity": "sha512-FeGxW3Batn6sUtX3OVVUm7o56EgjxDlmgpTLNyWcLb0j6P8mw9oLNyAm3B+deHA4KNdNHO5BmHS2g1SJYjqPCQ==",
+      "requires": {}
     },
     "apollo-server-express": {
       "version": "2.19.2",
@@ -46544,7 +46475,8 @@
       "version": "7.0.0-bridge.0",
       "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-7.0.0-bridge.0.tgz",
       "integrity": "sha512-poPX9mZH/5CSanm50Q+1toVci6pv5KSRv/5TWCwtzQS5XEwn40BcCrgIeMFWP9CKKIniKXNxoIOnOq4VVlGXhg==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "babel-eslint": {
       "version": "7.2.3",
@@ -46771,7 +46703,8 @@
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/babel-plugin-dev-expression/-/babel-plugin-dev-expression-0.2.2.tgz",
       "integrity": "sha512-y32lfBif+c2FIh5dwGfcc/IfX5aw/Bru7Du7W2n17sJE/GJGAsmIk5DPW/8JOoeKpXW5evJfJOvRq5xkiS6vng==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "babel-plugin-dynamic-import-node": {
       "version": "2.3.3",
@@ -46935,7 +46868,8 @@
     "babel-plugin-named-asset-import": {
       "version": "0.3.7",
       "resolved": "https://registry.npmjs.org/babel-plugin-named-asset-import/-/babel-plugin-named-asset-import-0.3.7.tgz",
-      "integrity": "sha512-squySRkf+6JGnvjoUtDEjSREJEBirnXi9NqP6rjSYsylxQxqBTz+pkmf395i9E2zsvmYUaI40BHo6SqZUdydlw=="
+      "integrity": "sha512-squySRkf+6JGnvjoUtDEjSREJEBirnXi9NqP6rjSYsylxQxqBTz+pkmf395i9E2zsvmYUaI40BHo6SqZUdydlw==",
+      "requires": {}
     },
     "babel-plugin-react-docgen": {
       "version": "4.2.1",
@@ -46950,7 +46884,8 @@
     "babel-plugin-react-svg": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/babel-plugin-react-svg/-/babel-plugin-react-svg-3.0.3.tgz",
-      "integrity": "sha512-Pst1RWjUIiV0Ykv1ODSeceCBsFOP2Y4dusjq7/XkjuzJdvS9CjpkPMUIoO4MLlvp5PiLCeMlsOC7faEUA0gm3Q=="
+      "integrity": "sha512-Pst1RWjUIiV0Ykv1ODSeceCBsFOP2Y4dusjq7/XkjuzJdvS9CjpkPMUIoO4MLlvp5PiLCeMlsOC7faEUA0gm3Q==",
+      "requires": {}
     },
     "babel-plugin-relay": {
       "version": "1.7.0",
@@ -51682,9 +51617,9 @@
       }
     },
     "file-entry-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.0.tgz",
-      "integrity": "sha512-fqoO76jZ3ZnYrXLDRxBR1YvOvc0k844kcOg40bgsPrE25LAb/PDqTY+ho64Xh2c8ZXgIKldchCFHczG2UVRcWA==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
+      "integrity": "sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==",
       "requires": {
         "flat-cache": "^3.0.4"
       }
@@ -52669,7 +52604,8 @@
     "graphql-language-service-types": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/graphql-language-service-types/-/graphql-language-service-types-1.8.0.tgz",
-      "integrity": "sha512-dEn3vZoQmEIB5jgiIPcKN2a9QYvmOp0kxNirEI0pSVugNvGEgZzgiUQQLyJ4wDoUfp6M1xQDLVaFf8zbATxYzg=="
+      "integrity": "sha512-dEn3vZoQmEIB5jgiIPcKN2a9QYvmOp0kxNirEI0pSVugNvGEgZzgiUQQLyJ4wDoUfp6M1xQDLVaFf8zbATxYzg==",
+      "requires": {}
     },
     "graphql-language-service-utils": {
       "version": "1.2.2",
@@ -52723,7 +52659,8 @@
     "graphql-tag": {
       "version": "2.11.0",
       "resolved": "https://registry.npmjs.org/graphql-tag/-/graphql-tag-2.11.0.tgz",
-      "integrity": "sha512-VmsD5pJqWJnQZMUeRwrDhfgoyqcfwEkvtpANqcoUG8/tOLkwNgU9mzub/Mc78OJMhHjx7gfAMTxzdG43VGg3bA=="
+      "integrity": "sha512-VmsD5pJqWJnQZMUeRwrDhfgoyqcfwEkvtpANqcoUG8/tOLkwNgU9mzub/Mc78OJMhHjx7gfAMTxzdG43VGg3bA==",
+      "requires": {}
     },
     "graphql-tools": {
       "version": "4.0.8",
@@ -52740,7 +52677,8 @@
     "graphql-type-json": {
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/graphql-type-json/-/graphql-type-json-0.2.4.tgz",
-      "integrity": "sha512-/tq02ayMQjrG4oDFDRLLrPk0KvJXue0nVXoItBe7uAdbNXjQUu+HYCBdAmPLQoseVzUKKMzrhq2P/sfI76ON6w=="
+      "integrity": "sha512-/tq02ayMQjrG4oDFDRLLrPk0KvJXue0nVXoItBe7uAdbNXjQUu+HYCBdAmPLQoseVzUKKMzrhq2P/sfI76ON6w==",
+      "requires": {}
     },
     "graphql-upload": {
       "version": "8.1.0",
@@ -53080,9 +53018,9 @@
       }
     },
     "hosted-git-info": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-3.0.7.tgz",
-      "integrity": "sha512-fWqc0IcuXs+BmE9orLDyVykAG9GJtGLGuZAAqgcckPgv5xad4AcXGIv8galtQvlwutxSlaMcdw7BUtq2EIvqCQ==",
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-3.0.8.tgz",
+      "integrity": "sha512-aXpmwoOhRBrw6X3j0h5RloK4x1OzsxMPyxqIHyNfSe2pypkVTZFpEiRoSipPEPlMrh0HW/XsjkJ5WgnCirpNUw==",
       "requires": {
         "lru-cache": "^6.0.0"
       },
@@ -54916,7 +54854,8 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.2.tgz",
       "integrity": "sha512-olV41bKSMm8BdnuMsewT4jqlZ8+3TCARAXjZGT9jcoSnrfUnRCqnMoF9XEeoWjbzObpqF9dRhHQj0Xb9QdF6/w==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "jest-regex-util": {
       "version": "24.9.0",
@@ -55591,9 +55530,9 @@
       "dev": true
     },
     "known-css-properties": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/known-css-properties/-/known-css-properties-0.20.0.tgz",
-      "integrity": "sha512-URvsjaA9ypfreqJ2/ylDr5MUERhJZ+DhguoWRr2xgS5C7aGCalXo+ewL+GixgKBfhT2vuL02nbIgNGqVWgTOYw=="
+      "version": "0.21.0",
+      "resolved": "https://registry.npmjs.org/known-css-properties/-/known-css-properties-0.21.0.tgz",
+      "integrity": "sha512-sZLUnTqimCkvkgRS+kbPlYW5o8q5w1cu+uIisKpEWkj31I8mx8kNG162DwRav8Zirkva6N5uoFsm9kzK4mUXjw=="
     },
     "latest-version": {
       "version": "3.1.0",
@@ -56163,9 +56102,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.20",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
-      "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "lodash-es": {
       "version": "4.17.20",
@@ -56557,9 +56496,9 @@
       }
     },
     "mdast-util-from-markdown": {
-      "version": "0.8.4",
-      "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-0.8.4.tgz",
-      "integrity": "sha512-jj891B5pV2r63n2kBTFh8cRI2uR9LQHsXG1zSDqfhXkIlDzrTcIlbB5+5aaYEkl8vOPIOPLf8VT7Ere1wWTMdw==",
+      "version": "0.8.5",
+      "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-0.8.5.tgz",
+      "integrity": "sha512-2hkTXtYYnr+NubD/g6KGBS/0mFmBcifAsI0yIWRiRo0PjVs6SSOSOdtzbp6kSGnShDN6G5aWZpKQ2lWRy27mWQ==",
       "requires": {
         "@types/mdast": "^3.0.0",
         "mdast-util-to-string": "^2.0.0",
@@ -56600,9 +56539,9 @@
       }
     },
     "mdast-util-to-markdown": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-0.6.2.tgz",
-      "integrity": "sha512-iRczns6WMvu0hUw02LXsPDJshBIwtUPbvHBWo19IQeU0YqmzlA8Pd30U8V7uiI0VPkxzS7A/NXBXH6u+HS87Zg==",
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-0.6.5.tgz",
+      "integrity": "sha512-XeV9sDE7ZlOQvs45C9UKMtfTcctcaj/pGwH8YLbMHoMOXNNCn2LsqVQOqrF1+/NU8lKDAqozme9SCXWyo9oAcQ==",
       "requires": {
         "@types/unist": "^2.0.0",
         "longest-streak": "^2.0.0",
@@ -56756,9 +56695,9 @@
       "integrity": "sha512-jo1OfR4TaEwd5HOrt5+tAZ9mqT4jmpNAusXtyfNzqVm9uiSYFZlKM1wYL4oU7azZW/PxQW53wM0S6OR1JHNa2g=="
     },
     "micromark": {
-      "version": "2.11.2",
-      "resolved": "https://registry.npmjs.org/micromark/-/micromark-2.11.2.tgz",
-      "integrity": "sha512-IXuP76p2uj8uMg4FQc1cRE7lPCLsfAXuEfdjtdO55VRiFO1asrCSQ5g43NmPqFtRwzEnEhafRVzn2jg0UiKArQ==",
+      "version": "2.11.4",
+      "resolved": "https://registry.npmjs.org/micromark/-/micromark-2.11.4.tgz",
+      "integrity": "sha512-+WoovN/ppKolQOFIAajxi7Lu9kInbPxFuTBVEavFcL8eAfVstoc5MocPmqBeAdBOJV00uaVjegzH4+MA0DN/uA==",
       "requires": {
         "debug": "^4.0.0",
         "parse-entities": "^2.0.0"
@@ -63052,7 +62991,8 @@
     "postcss-syntax": {
       "version": "0.36.2",
       "resolved": "https://registry.npmjs.org/postcss-syntax/-/postcss-syntax-0.36.2.tgz",
-      "integrity": "sha512-nBRg/i7E3SOHWxF3PpF5WnJM/jQ1YpY9000OaVXlAQj6Zp/kIqJxEDWIZ67tAd7NLuk7zqN4yqe9nc0oNAOs1w=="
+      "integrity": "sha512-nBRg/i7E3SOHWxF3PpF5WnJM/jQ1YpY9000OaVXlAQj6Zp/kIqJxEDWIZ67tAd7NLuk7zqN4yqe9nc0oNAOs1w==",
+      "requires": {}
     },
     "postcss-value-parser": {
       "version": "4.1.0",
@@ -64329,7 +64269,8 @@
     "react-ga": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/react-ga/-/react-ga-2.7.0.tgz",
-      "integrity": "sha512-AjC7UOZMvygrWTc2hKxTDvlMXEtbmA0IgJjmkhgmQQ3RkXrWR11xEagLGFGaNyaPnmg24oaIiaNPnEoftUhfXA=="
+      "integrity": "sha512-AjC7UOZMvygrWTc2hKxTDvlMXEtbmA0IgJjmkhgmQQ3RkXrWR11xEagLGFGaNyaPnmg24oaIiaNPnEoftUhfXA==",
+      "requires": {}
     },
     "react-helmet": {
       "version": "5.2.1",
@@ -64365,7 +64306,8 @@
       "version": "0.4.7",
       "resolved": "https://registry.npmjs.org/react-hot-api/-/react-hot-api-0.4.7.tgz",
       "integrity": "sha1-p+IqVtJS4Rq9k2a2EmTPRJLFgXE=",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "react-hot-loader": {
       "version": "1.3.1",
@@ -64422,7 +64364,8 @@
     "react-is-mounted-hook": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/react-is-mounted-hook/-/react-is-mounted-hook-1.0.3.tgz",
-      "integrity": "sha512-YCCYcTVYMPfTi6WhWIwM9EYBcpHoivjjkE90O5ScsE9wXSbeXGZvLDMGt4mdSNcWshhc8JD0AzgBmsleCSdSFA=="
+      "integrity": "sha512-YCCYcTVYMPfTi6WhWIwM9EYBcpHoivjjkE90O5ScsE9wXSbeXGZvLDMGt4mdSNcWshhc8JD0AzgBmsleCSdSFA==",
+      "requires": {}
     },
     "react-lifecycles-compat": {
       "version": "3.0.4",
@@ -64753,7 +64696,8 @@
     "react-virtualized-auto-sizer": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/react-virtualized-auto-sizer/-/react-virtualized-auto-sizer-1.0.3.tgz",
-      "integrity": "sha512-HnJo3Hk5Ky2TUL2GpLOs5sKiyskFwdNllI3P5Mp0tgFatz6ClnEG1gnK76/NhSkd/3YtYPTVjIsINYVBd/fRxw=="
+      "integrity": "sha512-HnJo3Hk5Ky2TUL2GpLOs5sKiyskFwdNllI3P5Mp0tgFatz6ClnEG1gnK76/NhSkd/3YtYPTVjIsINYVBd/fRxw==",
+      "requires": {}
     },
     "read-cmd-shim": {
       "version": "1.0.5",
@@ -66412,7 +66356,8 @@
     "slick-carousel": {
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/slick-carousel/-/slick-carousel-1.8.1.tgz",
-      "integrity": "sha512-XB9Ftrf2EEKfzoQXt3Nitrt/IPbT+f1fgqBdoxO3W/+JYvtEOW6EgxnWfr9GH6nmULv7Y2tPmEX3koxThVmebA=="
+      "integrity": "sha512-XB9Ftrf2EEKfzoQXt3Nitrt/IPbT+f1fgqBdoxO3W/+JYvtEOW6EgxnWfr9GH6nmULv7Y2tPmEX3koxThVmebA==",
+      "requires": {}
     },
     "slide": {
       "version": "1.1.6",
@@ -67848,7 +67793,8 @@
     "stylis-rule-sheet": {
       "version": "0.0.10",
       "resolved": "https://registry.npmjs.org/stylis-rule-sheet/-/stylis-rule-sheet-0.0.10.tgz",
-      "integrity": "sha512-nTbZoaqoBnmK+ptANthb10ZRZOGC+EmTLLUxeYIuHNkEKcmKgXX1XWKkUBT2Ac4es3NybooPe0SmvKdhKJZAuw=="
+      "integrity": "sha512-nTbZoaqoBnmK+ptANthb10ZRZOGC+EmTLLUxeYIuHNkEKcmKgXX1XWKkUBT2Ac4es3NybooPe0SmvKdhKJZAuw==",
+      "requires": {}
     },
     "subscriptions-transport-ws": {
       "version": "0.9.18",
@@ -69301,7 +69247,8 @@
     "use-callback-ref": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.2.4.tgz",
-      "integrity": "sha512-rXpsyvOnqdScyied4Uglsp14qzag1JIemLeTWGKbwpotWht57hbP78aNT+Q4wdFKQfQibbUX4fb6Qb4y11aVOQ=="
+      "integrity": "sha512-rXpsyvOnqdScyied4Uglsp14qzag1JIemLeTWGKbwpotWht57hbP78aNT+Q4wdFKQfQibbUX4fb6Qb4y11aVOQ==",
+      "requires": {}
     },
     "use-sidecar": {
       "version": "1.0.3",
@@ -70803,9 +70750,9 @@
       }
     },
     "yargs-parser": {
-      "version": "20.2.4",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.4.tgz",
-      "integrity": "sha512-WOkpgNhPTlE73h4VFAFsOnomJVaovO8VqLDzy5saChRBFQFBoMYirowyW+Q9HB4HFF4Z7VZTiG3iSzJJA29yRA=="
+      "version": "20.2.6",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.6.tgz",
+      "integrity": "sha512-AP1+fQIWSM/sMiET8fyayjx/J+JmTPt2Mr0FkrgqB4todtfa53sOsrSAcIrJRD5XS20bKUwaDIuMkWKCEiQLKA=="
     },
     "zen-observable": {
       "version": "0.8.15",


### PR DESCRIPTION
[COV-671](https://occ-data.atlassian.net/browse/COV-671) [PXP-7799](https://ctds-planx.atlassian.net/browse/PXP-7799) update in @gen3/ui-component

### New Features
- make gray slightly darker to pass WCAG AAA accessibility guidelines
- allow charts to wrap when they do not have room to display
- update stylelint to newer version

### Dependency Update
- Update @gen3/ui-component dependency to version 0.6.6
- Update @gen3/guppy dependency to version 0.11.2