### PR TITLE
(PXP-6570): refactor/dictionaryBtnColor: change dictionary btn to use defined global colors

### DIFF
--- a/src/DataDictionary/DataDictionary.css
+++ b/src/DataDictionary/DataDictionary.css
@@ -58,8 +58,8 @@
 }
 
 .data-dictionary__switch-button:hover {
-  background-color: var(--g3-color__base-blue-light);
-  color: var(--g3-color__white);
+  background-color: var(--g3-secondary-btn__bg-color--hover);
+  color: var(--g3-secondary-btn__color);
 }
 
 .data-dictionary__switch-button:first-child {
@@ -74,6 +74,6 @@
 }
 
 .data-dictionary__switch-button--active {
-  background-color: var(--g3-color__base-blue);
-  color: var(--g3-color__white);
+  background-color: var(--g3-secondary-btn__bg-color);
+  color: var(--g3-secondary-btn__color);
 }


### PR DESCRIPTION
Jira Ticket: [PXP-6570](https://ctds-planx.atlassian.net/browse/PXP-6570)

### Improvements
- make data dictionary button color will honor the secondary button color

### Deployment Changes
- envs with customized color schemes no longer need to overwrite dictionary button color in their `gitops.css`