### PR TITLE
fix: single level router

### DIFF
--- a/src/index.jsx
+++ b/src/index.jsx
@@ -384,7 +384,7 @@ async function init() {
                       />)
                     }
                   />
-                  {isEnabled('discovery') && <React.Fragment>
+                  {isEnabled('discovery') &&
                     <Route
                       exact
                       path='/discovery'
@@ -396,6 +396,8 @@ async function init() {
                         />)
                       }
                     />
+                  }
+                  {isEnabled('discovery') &&
                     <Route
                       exact
                       path='/discovery/:studyUID'
@@ -407,7 +409,6 @@ async function init() {
                         />)
                       }
                     />
-                  </React.Fragment>
                   }
                   <Route
                     path='/not-found'


### PR DESCRIPTION
React router `Switch` component can only work with 1st level components only https://stackoverflow.com/q/63073469

If put something nested using `<React.Fragment>` under it then it may fail on resolving routes

This shows up in some envs (e.g: bloodpac) as if you navigate to a project page, you only get a header and footer 🤦  

Verify this bug at: https://data.bloodpac.org/Exhale-Fluxion (notice there is no `main-content`)

Deployed and tested: https://qa-bloodpac.planx-pla.net/DEV-test

This fix should be picked into `2021.03` and `2021.04` release 


### Bug Fixes
- Fixed a bug causing page routes cannot be correctly resolved by react router
