### PR TITLE
Fix/npm7 build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,9 @@ cache:
 services:
     - docker
 
+before_install:
+    - npm install -g npm@7.6.3
+
 install:
     - npm install --force
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,11 @@
 env:
   - REACT_APP_DISABLE_SOCKET=true
-  
+
 language: node_js
 git:
   depth: 1
 node_js:
-  - "12"
+  - "14"
 
 cache:
   directories:

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,12 +21,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/* \
     && ln -sf /dev/stdout /var/log/nginx/access.log \
     && ln -sf /dev/stderr /var/log/nginx/error.log \
-    && npm install -g npm@7
-
-# The following settings are for NPM 7
-# Need to reduce maxsockets to avoid intermittent EFILE error
-RUN npm config set unsafe-perm=true \
-    && npm config set maxsockets=5
+    && npm install -g npm@7.6.3
 
 ARG APP=dev
 ARG BASENAME
@@ -38,6 +33,7 @@ RUN COMMIT=`git rev-parse HEAD` && echo "export const portalCommit = \"${COMMIT}
     && VERSION=`git describe --always --tags` && echo "export const portalVersion =\"${VERSION}\";" >>src/versions.js \
     && /bin/rm -rf .git \
     && /bin/rm -rf node_modules \
+    && npm config set unsafe-perm=true \
     && npm ci \
     && npm run relay \
     && npm run params \

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,11 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && ln -sf /dev/stderr /var/log/nginx/error.log \
     && npm install -g npm@7
 
+# The following settings are for NPM 7
+# Need to reduce maxsockets to avoid intermittent EFILE error
+RUN npm config set unsafe-perm=true \
+    && npm config set maxsockets=5
+
 ARG APP=dev
 ARG BASENAME
 
@@ -33,7 +38,7 @@ RUN COMMIT=`git rev-parse HEAD` && echo "export const portalCommit = \"${COMMIT}
     && VERSION=`git describe --always --tags` && echo "export const portalVersion =\"${VERSION}\";" >>src/versions.js \
     && /bin/rm -rf .git \
     && /bin/rm -rf node_modules \
-    && npm config set unsafe-perm=true && npm ci \
+    && npm ci \
     && npm run relay \
     && npm run params \
     # see https://stackoverflow.com/questions/48387040/nodejs-recommended-max-old-space-size


### PR DESCRIPTION
Update NPM config to address intermittent quay.io build failures.

It appears NPM 7 would have open more concurrent file descriptors and/or sockets during `npm i`. Quay.io builds after updating to NPM 7 frequently fails on `EMFILE` error. This behavior is not observed if downgrade to NPM 6, and I also cannot reproduce this issue locally with `docker build`. It appears that this issue only occurs frequently when building images on Quay.io.

~There is no option for NPM to config how many files it can open concurrently, but they have a config to control the max number of socket it can use. In NPM 7, the default value of this `maxsockets` field has changed from `50` to `infinity`, but changing it back to `50` didn't solve the build failure issue. I have to further decrease it to `5` to stabilize the Quay building process. 🤦~

Update: it looks like NPM has introduced a regression in version `7.7.0`, and they are working on it. But until that fix has been released and tested by us, let's juts pin NPM to `7.6.3` for now. 

Also updated NodeJS to 14 in Travis to match our local dev env and dockerfile

