### PR TITLE
PXP-7919 Feat/workspace status

### DIFF
--- a/runWebpack.sh
+++ b/runWebpack.sh
@@ -136,8 +136,6 @@ fi
 # on the current APP environment - ugh
 #
 bash custom/customize.sh
-echo "INFO: NPM config"
-npm config list
 
 # workspace bundle does not currently deploy sheepdog
 if [[ "$GEN3_BUNDLE" != "workspace" ]]; then

--- a/src/Workspace/Workspace.less
+++ b/src/Workspace/Workspace.less
@@ -84,5 +84,5 @@ div.workspace--fullpage {
 }
 
 .workspace__spinner-spin {
-  padding-bottom: 20px;
+  padding-top: 20px;
 }

--- a/src/Workspace/Workspace.less
+++ b/src/Workspace/Workspace.less
@@ -74,9 +74,15 @@ div.workspace--fullpage {
 }
 
 .workspace__spinner-container {
+  width: 50%;
+  margin: auto;
   flex: 1 0 60vh;
   display: flex;
   flex-direction: column;
   justify-content: center;
   align-items: center;
+}
+
+.workspace__spinner-spin {
+  padding-bottom: 20px;
 }

--- a/src/Workspace/Workspace.less
+++ b/src/Workspace/Workspace.less
@@ -82,7 +82,3 @@ div.workspace--fullpage {
   justify-content: center;
   align-items: center;
 }
-
-.workspace__spinner-spin {
-  padding-top: 20px;
-}

--- a/src/Workspace/index.jsx
+++ b/src/Workspace/index.jsx
@@ -134,7 +134,6 @@ class Workspace extends React.Component {
     || !workspaceStatusData.conditions || workspaceStatusData.conditions.length === 0) {
       // if status is not 'Launching', or 'Stopped',
       // or we don't have conditions array, don't display steps bar
-      console.log(workspaceStatusData);
       return undefined;
     }
     const workspaceLaunchStepsConfig = {
@@ -258,7 +257,6 @@ class Workspace extends React.Component {
         const data = await this.getWorkspaceStatus();
         if (this.workspaceStates.includes(data.status)) {
           const workspaceLaunchStepsConfig = this.getWorkspaceLaunchSteps(data);
-          console.log(workspaceLaunchStepsConfig);
           this.setState({
             workspaceStatus: data.status,
             workspaceLaunchStepsConfig,

--- a/src/Workspace/index.jsx
+++ b/src/Workspace/index.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import parse from 'html-react-parser';
 import Button from '@gen3/ui-component/dist/components/Button';
-import { Popconfirm, Spin, Steps } from 'antd';
+import { Popconfirm, Steps } from 'antd';
 
 import {
   workspaceUrl,
@@ -16,6 +16,7 @@ import {
 } from '../localconf';
 import './Workspace.less';
 import { fetchWithCreds } from '../actions';
+import Spinner from '../components/Spinner';
 import jupyterIcon from '../img/icons/jupyter.svg';
 import rStudioIcon from '../img/icons/rstudio.svg';
 import galaxyIcon from '../img/icons/galaxy.svg';
@@ -371,7 +372,7 @@ class Workspace extends React.Component {
                     </Steps>
                     : null}
                   {(this.state.workspaceStatus === 'Launching') ?
-                    <Spin className='workspace__spinner-spin' tip='Launching Workspace, this process may take several minutes' />
+                    <Spinner text='Launching Workspace, this process may take several minutes' />
                     : null}
                 </div>
                 <div className='workspace__buttongroup'>
@@ -383,7 +384,7 @@ class Workspace extends React.Component {
           {
             this.state.workspaceStatus === 'Terminating' ?
               <div className='workspace__spinner-container'>
-                <Spin tip='Terminating workspace...' />
+                <Spinner text='Terminating workspace...' />
               </div>
               : null
           }
@@ -449,7 +450,7 @@ class Workspace extends React.Component {
         </div>
       );
     }
-    return <Spin />;
+    return <Spinner />;
   }
 }
 

--- a/src/Workspace/index.jsx
+++ b/src/Workspace/index.jsx
@@ -36,7 +36,7 @@ class Workspace extends React.Component {
       interval: null,
       workspaceType: null,
       defaultWorkspace: false,
-      workspaceIsfullpage: false,
+      workspaceIsFullpage: false,
       externalLoginOptions: [],
     };
     this.workspaceStates = [
@@ -276,14 +276,14 @@ class Workspace extends React.Component {
 
   handleTerminateButtonClick = () => {
     // exit full page
-    this.setState({ workspaceIsfullpage: false });
+    this.setState({ workspaceIsFullpage: false });
     // terminate workspace
     this.terminateWorkspace();
   }
 
-  handleFullpageButtonClick = () => {
+  handleFullageButtonClick = () => {
     this.setState({
-      workspaceIsfullpage: !this.state.workspaceIsfullpage,
+      workspaceIsFullpage: !this.state.workspaceIsFullpage,
     });
   }
 
@@ -319,9 +319,9 @@ class Workspace extends React.Component {
       <Button
         className='workspace__button'
         onClick={this.handleFullpageButtonClick}
-        label={this.state.workspaceIsfullpage ? 'Exit Fullscreen' : 'Make Fullscreen'}
+        label={this.state.workspaceIsFullpage ? 'Exit Fullscreen' : 'Make Fullscreen'}
         buttonType='secondary'
-        rightIcon={this.state.workspaceIsfullpage ? 'back' : 'external-link'}
+        rightIcon={this.state.workspaceIsFullpage ? 'back' : 'external-link'}
       />
     );
 
@@ -331,7 +331,7 @@ class Workspace extends React.Component {
       // is for backwards compatibility with Jenkins integration tests that select by classname.
       return (
         <div
-          className={`workspace ${this.state.workspaceIsfullpage ? 'workspace--fullpage' : ''}`}
+          className={`workspace ${this.state.workspaceIsFullpage ? 'workspace--fullpage' : ''}`}
         >
           {
             this.state.workspaceStatus === 'Running' ?

--- a/src/Workspace/index.jsx
+++ b/src/Workspace/index.jsx
@@ -130,7 +130,8 @@ class Workspace extends React.Component {
   }
 
   getWorkspaceLaunchSteps = (workspaceStatusData) => {
-    if (!(workspaceStatusData.status !== 'Launching' || workspaceStatusData.status !== 'Stopped')) {
+    if (!(workspaceStatusData.status !== 'Launching' || workspaceStatusData.status !== 'Stopped')
+    || !workspaceStatusData.conditions || workspaceStatusData.conditions.length === 0) {
       console.log(workspaceStatusData);
       return undefined;
     }
@@ -155,46 +156,43 @@ class Workspace extends React.Component {
     if (workspaceStatusData.status === 'Stopped') {
       workspaceLaunchStepsConfig.currentStepsStatus = 'error';
     }
-    if (workspaceStatusData.conditions && workspaceStatusData.conditions.length > 0) {
-      if (workspaceStatusData.conditions.some(element => (
-        (element.type === 'PodScheduled' && element.status === 'True')
-      ))) {
-        workspaceLaunchStepsConfig.steps[0].description = 'Pod scheduled';
-      }
-      if (workspaceStatusData.conditions.some(element => (
-        (element.type === 'Initialized' && element.status === 'True')
-      ))) {
-        workspaceLaunchStepsConfig.steps[1].description = 'Pod initialized';
-      }
+    if (workspaceStatusData.conditions.some(element => (
+      (element.type === 'PodScheduled' && element.status === 'True')
+    ))) {
+      workspaceLaunchStepsConfig.steps[0].description = 'Pod scheduled';
+    }
+    if (workspaceStatusData.conditions.some(element => (
+      (element.type === 'Initialized' && element.status === 'True')
+    ))) {
+      workspaceLaunchStepsConfig.steps[1].description = 'Pod initialized';
+    }
 
-      if (workspaceStatusData.conditions.some(element => (element.type === 'PodScheduled' && element.status === 'False'))) {
-        workspaceLaunchStepsConfig.steps[0].description = 'In progress';
-        return workspaceLaunchStepsConfig;
-      }
+    if (workspaceStatusData.conditions.some(element => (element.type === 'PodScheduled' && element.status === 'False'))) {
+      workspaceLaunchStepsConfig.steps[0].description = 'In progress';
+      return workspaceLaunchStepsConfig;
+    }
 
-      if (workspaceStatusData.conditions.some(element => (element.type === 'Initialized' && element.status === 'False'))) {
-        workspaceLaunchStepsConfig.currentIndex = 1;
-        workspaceLaunchStepsConfig.steps[1].description = 'In progress';
-        return workspaceLaunchStepsConfig;
-      }
+    if (workspaceStatusData.conditions.some(element => (element.type === 'Initialized' && element.status === 'False'))) {
+      workspaceLaunchStepsConfig.currentIndex = 1;
+      workspaceLaunchStepsConfig.steps[1].description = 'In progress';
+      return workspaceLaunchStepsConfig;
+    }
 
-      if (workspaceStatusData.conditions.some(element => (
-        (element.type === 'ContainersReady' && element.status === 'True')
-      ))) {
-        workspaceLaunchStepsConfig.currentIndex = 2;
-        workspaceLaunchStepsConfig.currentStepsStatus = 'finish';
-        workspaceLaunchStepsConfig.steps[2].description = 'All containers are ready';
-        return workspaceLaunchStepsConfig;
-      }
+    if (workspaceStatusData.conditions.some(element => (
+      (element.type === 'ContainersReady' && element.status === 'True')
+    ))) {
+      workspaceLaunchStepsConfig.currentIndex = 2;
+      workspaceLaunchStepsConfig.currentStepsStatus = 'finish';
+      workspaceLaunchStepsConfig.steps[2].description = 'All containers are ready';
+      return workspaceLaunchStepsConfig;
+    }
 
-      const containerReadyStatus = workspaceStatusData.conditions.some(element => (
-        (element.type === 'ContainersReady' && element.status === 'False')
-      ));
-      if (containerReadyStatus) {
-        workspaceLaunchStepsConfig.currentIndex = 2;
-        workspaceLaunchStepsConfig.steps[2].description = 'In progress';
-        return workspaceLaunchStepsConfig;
-      }
+    const containerReadyStatus = workspaceStatusData.conditions.some(element => (
+      (element.type === 'ContainersReady' && element.status === 'False')
+    ));
+    if (containerReadyStatus) {
+      workspaceLaunchStepsConfig.currentIndex = 2;
+      workspaceLaunchStepsConfig.steps[2].description = 'In progress';
     }
     return workspaceLaunchStepsConfig;
   }
@@ -355,9 +353,6 @@ class Workspace extends React.Component {
             this.state.workspaceStatus === 'Stopped' ?
               <React.Fragment>
                 <div className='workspace__spinner-container'>
-                  {(this.state.workspaceStatus === 'Launching') ?
-                    <Spin className='workspace__spinner-spin' tip='Launching Workspace, this process may take several minutes' />
-                    : null}
                   {(this.state.workspaceLaunchStepsConfig) ?
                     <Steps
                       current={this.state.workspaceLaunchStepsConfig.currentIndex}
@@ -370,6 +365,9 @@ class Workspace extends React.Component {
                           description={step.description}
                         />))) }
                     </Steps>
+                    : null}
+                  {(this.state.workspaceStatus === 'Launching') ?
+                    <Spin className='workspace__spinner-spin' tip='Launching Workspace, this process may take several minutes' />
                     : null}
                 </div>
                 <div className='workspace__buttongroup'>


### PR DESCRIPTION
Jira Ticket: [PXP-7919](https://ctds-planx.atlassian.net/browse/PXP-7919)

Add steps to workspace launching page to visualize progress of spinning up a workspace pod

<img width="1178" alt="Screen Shot 2021-05-05 at 5 43 56 PM" src="https://user-images.githubusercontent.com/2475897/117218977-ebbd1000-adc9-11eb-80ca-7e57a4891bc1.png">

Require a newer Hatchery, PR: https://github.com/uc-cdis/hatchery/pull/11

Also backward compatiable with older Hatchery (no step progress display)

Deployed and tested in: https://mingfei.planx-pla.net/workspace

### New Features
- Add steps to workspace launching page to visualize progress of spinning up a workspace pod

