### PR TITLE
PXP-8062 Feat/disco download

### DIFF
--- a/src/Analysis/AnalysisJob.js
+++ b/src/Analysis/AnalysisJob.js
@@ -1,10 +1,10 @@
 import { fetchWithCreds } from '../actions';
 import { asyncSetInterval } from '../utils';
-import { userapiPath, jobapiPath } from '../localconf';
+import { userApiPath, jobapiPath } from '../localconf';
 
 
 export const getPresignedUrl = (did, method) => {
-  const urlPath = `${userapiPath}data/${method}/${did}`;
+  const urlPath = `${userApiPath}data/${method}/${did}`;
   return fetchWithCreds({ path: urlPath, method: 'GET' },
   ).then(
     ({ data }) => data.url,

--- a/src/CoreMetadata/CoreMetadataHeader.jsx
+++ b/src/CoreMetadata/CoreMetadataHeader.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import copy from 'clipboard-plus';
 import React, { Component } from 'react';
 import Popup from '../components/Popup';
-import { userapiPath, useArboristUI } from '../configs';
+import { userApiPath, useArboristUI } from '../configs';
 import isEnabled from '../helpers/featureFlags';
 
 import { userHasMethodForServiceOnProject } from '../authMappingUtils';
@@ -55,7 +55,7 @@ class CoreMetadataHeader extends Component {
         || userHasMethodForServiceOnProject('read-storage', 'fence', projectId, this.props.userAuthMapping)
         || projectIsOpenData(projectAvail, projectId)
       ) {
-        const downloadLink = `${userapiPath}/data/download/${this.props.metadata.object_id}?expires_in=900&redirect`;
+        const downloadLink = `${userApiPath}/data/download/${this.props.metadata.object_id}?expires_in=900&redirect`;
 
         downloadButton = (
           <a href={downloadLink}>

--- a/src/CoreMetadata/reduxer.js
+++ b/src/CoreMetadata/reduxer.js
@@ -3,13 +3,13 @@ import CoreMetadataHeader from './CoreMetadataHeader';
 import FileTypePicture from '../components/FileTypePicture';
 import CoreMetadataTable from './CoreMetadataTable';
 import CoreMetadataPage from './page';
-import { coreMetadataPath, userapiPath } from '../localconf';
+import { coreMetadataPath, userApiPath } from '../localconf';
 import { fetchWithCreds, updatePopup } from '../actions';
 
 export const generateSignedURL = objectId =>
   dispatch =>
     fetchWithCreds({
-      path: `${userapiPath}/data/download/${objectId}?expires_in=3600`,
+      path: `${userApiPath}/data/download/${objectId}?expires_in=3600`,
       dispatch,
     })
       .then(

--- a/src/Discovery/Discovery.tsx
+++ b/src/Discovery/Discovery.tsx
@@ -673,9 +673,8 @@ const Discovery: React.FunctionComponent<DiscoveryBetaProps> = (props: Discovery
                       href={`${userApiPath}/data/download/${item.guid}?expires_in=900&redirect`}
                       target='_blank'
                       type='text'
-                      // disable button if user don't have access, or data has no GUID
-                      disabled={!(config.features.authorization.enabled
-                        && modalData[accessibleFieldName]) || !item.guid}
+                      // disable button if data has no GUID
+                      disabled={!item.guid}
                       icon={<DownloadOutlined />}
                     >
                       Download File

--- a/src/Discovery/Discovery.tsx
+++ b/src/Discovery/Discovery.tsx
@@ -13,12 +13,16 @@ import {
   Alert,
   Popover,
   Button,
+  Collapse,
+  List,
 } from 'antd';
 
 import { fetchWithCreds } from '../actions';
-import { manifestServiceApiPath } from '../localconf';
+import { manifestServiceApiPath, userApiPath } from '../localconf';
 import { DiscoveryConfig } from './DiscoveryConfig';
 import './Discovery.css';
+
+const { Panel } = Collapse;
 
 const accessibleFieldName = '__accessible';
 
@@ -37,6 +41,12 @@ interface AggregationConfig {
   name: string
   field: string
   type: 'sum' | 'count'
+}
+
+interface ListItem {
+  title: string,
+  description: string,
+  guid: string
 }
 
 const renderAggregation = (aggregation: AggregationConfig, studies: any[] | null): string => {
@@ -650,6 +660,38 @@ const Discovery: React.FunctionComponent<DiscoveryBetaProps> = (props: Discovery
             })}
           </div>
         ))}
+        { (config.studyPageFields.downloadLinks && config.studyPageFields.downloadLinks.field &&
+        modalData[config.studyPageFields.downloadLinks.field]) ?
+          <Collapse defaultActiveKey={['1']}>
+            <Panel header={config.studyPageFields.downloadLinks.name || 'Data Download Links'} key='1'>
+              <List
+                itemLayout='horizontal'
+                dataSource={modalData[config.studyPageFields.downloadLinks.field]}
+                renderItem={(item:ListItem) => (
+                  <List.Item
+                    actions={[<Button
+                      href={`${userApiPath}/data/download/${item.guid}?expires_in=900&redirect`}
+                      target='_blank'
+                      type='text'
+                      // disable button if user don't have access, or data has no GUID
+                      disabled={!(config.features.authorization.enabled
+                        && modalData[accessibleFieldName]) || !item.guid}
+                      icon={<DownloadOutlined />}
+                    >
+                      Download File
+                    </Button>]}
+                  >
+                    <List.Item.Meta
+                      title={item.title}
+                      description={item.description || ''}
+                    />
+                  </List.Item>
+                )}
+              />
+            </Panel>
+          </Collapse>
+          : null
+        }
       </Space>
     </Modal>
   </div>);

--- a/src/Discovery/DiscoveryConfig.d.ts
+++ b/src/Discovery/DiscoveryConfig.d.ts
@@ -67,6 +67,10 @@ export interface DiscoveryConfig {
         header?: {
             field: string
         },
+        downloadLinks?: {
+            field: string
+            name?: string
+        },
         fieldsToShow: {
             groupName?: string
             includeName?: boolean,

--- a/src/Indexing/Indexing.jsx
+++ b/src/Indexing/Indexing.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import Button from '@gen3/ui-component/dist/components/Button';
-import { userapiPath, fenceDownloadPath, jobapiPath, hostname } from '../localconf';
+import { userApiPath, fenceDownloadPath, jobapiPath, hostname } from '../localconf';
 import { fetchWithCreds } from '../actions';
 import './Indexing.less';
 import Popup from '../components/Popup';
@@ -63,7 +63,7 @@ class Indexing extends React.Component {
       file_name: this.state.uploadedFile.name,
     });
     return fetchWithCreds({
-      path: `${userapiPath}data/upload`,
+      path: `${userApiPath}data/upload`,
       method: 'POST',
       customHeaders: { 'Content-Type': 'application/json' },
       body: JSONbody,

--- a/src/StudyViewer/StudyDetails.jsx
+++ b/src/StudyViewer/StudyDetails.jsx
@@ -11,7 +11,7 @@ import {
   LinkOutlined } from '@ant-design/icons';
 import { capitalizeFirstLetter, humanFileSize } from '../utils';
 import { userHasMethodForServiceOnResource } from '../authMappingUtils';
-import { useArboristUI, requestorPath, userapiPath } from '../localconf';
+import { useArboristUI, requestorPath, userApiPath } from '../localconf';
 import { fetchWithCreds } from '../actions';
 import './StudyViewer.css';
 
@@ -293,7 +293,7 @@ class StudyDetails extends React.Component {
                bordered
                dataSource={this.props.fileData}
                renderItem={(item) => {
-                 const downloadLink = (item.object_id) ? `${userapiPath}data/download/${item.object_id}?expires_in=900&redirect` : '';
+                 const downloadLink = (item.object_id) ? `${userApiPath}data/download/${item.object_id}?expires_in=900&redirect` : '';
                  return (<List.Item
                    key={item.file_name}
                    actions={[<a key='modal-list-download-link' href={downloadLink}>download</a>]}

--- a/src/UserAgreement/ReduxCertPopup.js
+++ b/src/UserAgreement/ReduxCertPopup.js
@@ -1,6 +1,6 @@
 import { connect } from 'react-redux';
 import CertPopup from './CertPopup';
-import { requiredCerts, userapiPath } from '../configs';
+import { requiredCerts, userApiPath } from '../configs';
 import { fetchWithCreds, refreshUser } from '../actions';
 import { minus } from '../utils';
 import { certs, hostname } from '../localconf';
@@ -13,7 +13,7 @@ import { certs, hostname } from '../localconf';
  * @param {*} history
  */
 export const submitForm = (data, questionList, quiz) => dispatch => fetchWithCreds({
-  path: `${userapiPath}/user/cert/${quiz}?extension=txt`,
+  path: `${userApiPath}/user/cert/${quiz}?extension=txt`,
   method: 'PUT',
   body: JSON.stringify({
     answers: data, certificate_form: questionList,

--- a/src/actions.js
+++ b/src/actions.js
@@ -1,7 +1,7 @@
 import 'isomorphic-fetch';
 import {
   apiPath,
-  userapiPath,
+  userApiPath,
   headers,
   hostname,
   submissionApiPath,
@@ -49,7 +49,7 @@ const getJsonOrText = (path, response, useCache, method = 'GET') => response.tex
 let pendingRequest = null;
 export const fetchCreds = (opts) => {
   if (pendingRequest) { return pendingRequest; }
-  const { path = `${userapiPath}user/`, method = 'GET', dispatch } = opts;
+  const { path = `${userApiPath}user/`, method = 'GET', dispatch } = opts;
   const request = {
     credentials: 'include',
     headers: { ...headers },
@@ -263,7 +263,7 @@ export const fetchUser = dispatch => fetchCreds({
 export const refreshUser = () => fetchUser;
 
 export const logoutAPI = (displayAuthPopup = false) => (dispatch) => {
-  fetch(`${userapiPath}/logout?next=${hostname}`).then((response) => {
+  fetch(`${userApiPath}/logout?next=${hostname}`).then((response) => {
     if (displayAuthPopup) {
       dispatch({
         type: 'UPDATE_POPUP',

--- a/src/localconf.js
+++ b/src/localconf.js
@@ -74,20 +74,20 @@ function buildConfig(opts) {
   const apiPath = `${hostname}api/`;
   const graphqlPath = `${hostname}api/v0/submission/graphql/`;
   const dataDictionaryTemplatePath = `${hostname}api/v0/submission/template/`;
-  let userapiPath = typeof fenceURL === 'undefined' ? `${hostname}user/` : ensureTrailingSlash(fenceURL);
+  let userApiPath = typeof fenceURL === 'undefined' ? `${hostname}user/` : ensureTrailingSlash(fenceURL);
   const jobapiPath = `${hostname}job/`;
-  const credentialCdisPath = `${userapiPath}credentials/cdis/`;
+  const credentialCdisPath = `${userApiPath}credentials/cdis/`;
   const coreMetadataPath = `${hostname}coremetadata/`;
   const indexdPath = typeof indexdURL === 'undefined' ? `${hostname}index/` : ensureTrailingSlash(indexdURL);
   const wtsPath = typeof wtsURL === 'undefined' ? `${hostname}wts/oauth2/` : ensureTrailingSlash(wtsURL);
   const externalLoginOptionsUrl = `${hostname}wts/external_oidc/`;
   let login = {
-    url: `${userapiPath}login/google?redirect=`,
+    url: `${userApiPath}login/google?redirect=`,
     title: 'Login from Google',
   };
   const authzPath = typeof arboristURL === 'undefined' ? `${hostname}authz` : `${arboristURL}authz`;
   const authzMappingPath = typeof arboristURL === 'undefined' ? `${hostname}authz/mapping` : `${arboristURL}authz/mapping`;
-  const loginPath = `${userapiPath}login/`;
+  const loginPath = `${userApiPath}login/`;
   const logoutInactiveUsers = !(process.env.LOGOUT_INACTIVE_USERS === 'false');
   const useIndexdAuthz = !(process.env.USE_INDEXD_AUTHZ === 'false');
   const workspaceTimeoutInMinutes = process.env.WORKSPACE_TIMEOUT_IN_MINUTES || 480;
@@ -252,14 +252,14 @@ function buildConfig(opts) {
   };
 
   if (app === 'gdc' && typeof fenceURL === 'undefined') {
-    userapiPath = dev === true ? `${hostname}user/` : `${hostname}api/`;
+    userApiPath = dev === true ? `${hostname}user/` : `${hostname}api/`;
     login = {
       url: 'https://itrusteauth.nih.gov/affwebservices/public/saml2sso?SPID=https://bionimbus-pdc.opensciencedatacloud.org/shibboleth&RelayState=',
       title: 'Login from NIH',
     };
   }
 
-  const fenceDataPath = `${userapiPath}data/`;
+  const fenceDataPath = `${userApiPath}data/`;
   const fenceDownloadPath = `${fenceDataPath}download`;
 
   const defaultLineLimit = 30;
@@ -377,7 +377,7 @@ function buildConfig(opts) {
     dev,
     hostname,
     gaDebug,
-    userapiPath,
+    userApiPath,
     jobapiPath,
     apiPath,
     submissionApiPath,

--- a/src/localconf.test.js
+++ b/src/localconf.test.js
@@ -7,7 +7,7 @@ describe('The localconf', () => {
     'app',
     'basename',
     'hostname',
-    'userapiPath',
+    'userApiPath',
     'submissionApiPath',
     'credentialCdisPath',
     'graphqlPath',


### PR DESCRIPTION
Jira Ticket: [PXP-8062](https://ctds-planx.atlassian.net/browse/PXP-8062)

Add download object files feature to discovery page

For BPA, this is going to help with replacing the dashboard based publication pages with discovery page

It requires MDS record to contain a special field in a format of an JSON object array, example:
```
[
   {
      "title": "CNA Data",
      "guid": "0a2ea71e-6f43-4588-8703-361cfe67add4",
      "description": "fastq files of low pass whole genome sequencing data for copy number alteration (CNA) analysis of FFPE tissue, cfDNA and single cells"
    },
    ...
]
```

And update the discovery page config of the `studyPageFields` component with the following new changes:
```
 "downloadLinks": {
        "field": "data_download_links",
        "name": "Links"
   },
```

The list of downloadable files will be displayed in a collapisble list in the detail modal, see screenshot below
<img width="1547" alt="Screen Shot 2021-05-21 at 11 19 29 AM" src="https://user-images.githubusercontent.com/2475897/119168406-776ba900-ba26-11eb-8f2e-8f4b9fc21ef4.png">

Deployed and tested in: https://qa-bloodpac.planx-pla.net/discovery

### New Features
- Add download object files feature to discovery page

