### PR TITLE
PXP-7997 and PXP-7991

### DIFF
--- a/dev.html
+++ b/dev.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
     <!-- Content-Security-Policy connect-src:

--- a/docs/portal_config.md
+++ b/docs/portal_config.md
@@ -144,6 +144,7 @@ Below is an example, with inline comments describing what each JSON block config
         "src": "/src/img/gen3.png", // required; src path for the image
         "href": "https://ctds.uchicago.edu/gen3", // required; link for image
         // The alt text for certain cross-commons logos, such as the Gen3 and CTDS logos, are non-configurable so as to avoid redundancy.
+        // Note that this alt text is applied on the basis of link destination, not logo filename.
       },
       {
         "src": "/src/img/createdby.png",

--- a/docs/portal_config.md
+++ b/docs/portal_config.md
@@ -45,7 +45,6 @@ Below is an example, with inline comments describing what each JSON block config
   "components": {
     "appName": "Gen3 Generic Data Commons", // required; title of commons that appears on the homepage
     "homepageHref": "https://example.gen3.org/", // optional; link that the logo in header will pointing to
-    "portalLogoAltText": "Gen3 Data Commons home", // required; descriptive alt text that states what text is in the logo and describes the function of the image. Do not use the phrase "links to". The form "[Logo Text] home" is appropriate.
     "index": { // required; relates to the homepage
       "introduction": { // optional; text on homepage
         "heading": "", // optional; title of introduction

--- a/docs/portal_config.md
+++ b/docs/portal_config.md
@@ -45,7 +45,7 @@ Below is an example, with inline comments describing what each JSON block config
   "components": {
     "appName": "Gen3 Generic Data Commons", // required; title of commons that appears on the homepage
     "homepageHref": "https://example.gen3.org/", // optional; link that the logo in header will pointing to
-    "homepageAltText": "A customized logo", // optional; alt text for logo images in header and footer
+    "portalLogoAltText": "A logo for the Gen3 Data Commons.", // required; descriptive alt text that states what text is in the logo. See here for specific guidelines https://www.sc.edu/about/offices_and_divisions/digital-accessibility/guides_tutorials/alternative_text/linked-images/index.php
     "index": { // required; relates to the homepage
       "introduction": { // optional; text on homepage
         "heading": "", // optional; title of introduction

--- a/docs/portal_config.md
+++ b/docs/portal_config.md
@@ -45,7 +45,7 @@ Below is an example, with inline comments describing what each JSON block config
   "components": {
     "appName": "Gen3 Generic Data Commons", // required; title of commons that appears on the homepage
     "homepageHref": "https://example.gen3.org/", // optional; link that the logo in header will pointing to
-    "portalLogoAltText": "A logo for the Gen3 Data Commons.", // required; descriptive alt text that states what text is in the logo. See here for specific guidelines https://www.sc.edu/about/offices_and_divisions/digital-accessibility/guides_tutorials/alternative_text/linked-images/index.php
+    "portalLogoAltText": "Gen3 Data Commons home", // required; descriptive alt text that states what text is in the logo and describes the function of the image. Do not use the phrase "links to". The form "[Logo Text] home" is appropriate.
     "index": { // required; relates to the homepage
       "introduction": { // optional; text on homepage
         "heading": "", // optional; title of introduction

--- a/docs/portal_config.md
+++ b/docs/portal_config.md
@@ -144,7 +144,7 @@ Below is an example, with inline comments describing what each JSON block config
       {
         "src": "/src/img/gen3.png", // required; src path for the image
         "href": "https://ctds.uchicago.edu/gen3", // required; link for image
-        "alt": "Gen3 Data Commons" // required; alternate text if image won’t load
+        // The alt text for certain cross-commons logos, such as the Gen3 and CTDS logos, are non-configurable so as to avoid redundancy.
       },
       {
         "src": "/src/img/createdby.png",

--- a/src/components/layout/NavBar.jsx
+++ b/src/components/layout/NavBar.jsx
@@ -95,7 +95,7 @@ class NavBar extends Component {
                   <img
                     className='nav-bar__logo-img'
                     src='/src/img/logo.png'
-                    alt={components.portalLogoAltText || 'Gen3 portal logo'}
+                    alt={components.portalLogoAltText || 'Data Portal home'}
                   />
                 </a>)
                 :
@@ -103,7 +103,7 @@ class NavBar extends Component {
                   <img
                     className='nav-bar__logo-img'
                     src='/src/img/logo.png'
-                    alt={components.portalLogoAltText || 'Gen3 portal logo'}
+                    alt={components.portalLogoAltText || 'Data Portal home'}
                   />
                 </NavLink>)
               }

--- a/src/components/layout/NavBar.jsx
+++ b/src/components/layout/NavBar.jsx
@@ -95,7 +95,7 @@ class NavBar extends Component {
                   <img
                     className='nav-bar__logo-img'
                     src='/src/img/logo.png'
-                    alt={commonsWideAltText.portalLogo || 'Data Portal home'}
+                    alt={commonsWideAltText.portalLogo || 'Gen3 Data Commons - home'}
                   />
                 </a>)
                 :
@@ -103,7 +103,7 @@ class NavBar extends Component {
                   <img
                     className='nav-bar__logo-img'
                     src='/src/img/logo.png'
-                    alt={commonsWideAltText.portalLogo || 'Data Portal home'}
+                    alt={commonsWideAltText.portalLogo || 'Gen3 Data Commons - home'}
                   />
                 </NavLink>)
               }

--- a/src/components/layout/NavBar.jsx
+++ b/src/components/layout/NavBar.jsx
@@ -6,7 +6,7 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
 import NavButton from './NavButton';
 import NavBarTooltip from './NavBarTooltip';
-import { breakpoints } from '../../localconf';
+import { breakpoints, commonsWideAltText } from '../../localconf';
 import { config, components } from '../../params';
 import './NavBar.less';
 
@@ -95,7 +95,7 @@ class NavBar extends Component {
                   <img
                     className='nav-bar__logo-img'
                     src='/src/img/logo.png'
-                    alt={components.portalLogoAltText || 'Data Portal home'}
+                    alt={commonsWideAltText.portalLogo || 'Data Portal home'}
                   />
                 </a>)
                 :
@@ -103,7 +103,7 @@ class NavBar extends Component {
                   <img
                     className='nav-bar__logo-img'
                     src='/src/img/logo.png'
-                    alt={components.portalLogoAltText || 'Data Portal home'}
+                    alt={commonsWideAltText.portalLogo || 'Data Portal home'}
                   />
                 </NavLink>)
               }

--- a/src/components/layout/NavBar.jsx
+++ b/src/components/layout/NavBar.jsx
@@ -95,7 +95,7 @@ class NavBar extends Component {
                   <img
                     className='nav-bar__logo-img'
                     src='/src/img/logo.png'
-                    alt={components.homepageAltText || 'Gen3 portal logo'}
+                    alt={components.portalLogoAltText || 'Gen3 portal logo'}
                   />
                 </a>)
                 :
@@ -103,7 +103,7 @@ class NavBar extends Component {
                   <img
                     className='nav-bar__logo-img'
                     src='/src/img/logo.png'
-                    alt={components.homepageAltText || 'Gen3 portal logo'}
+                    alt={components.portalLogoAltText || 'Gen3 portal logo'}
                   />
                 </NavLink>)
               }

--- a/src/index.ejs
+++ b/src/index.ejs
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
     <!-- Content-Security-Policy connect-src:

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -34,7 +34,7 @@ import { ReduxNavBar, ReduxTopBar, ReduxFooter } from './Layout/reduxer';
 import ReduxQueryNode, { submitSearchForm } from './QueryNode/ReduxQueryNode';
 import { basename, dev, gaDebug, workspaceUrl, workspaceErrorUrl,
   indexPublic, explorerPublic, enableResourceBrowser, resourceBrowserPublic, enableDAPTracker,
-  discoveryConfig, commonsWideAltText
+  discoveryConfig, commonsWideAltText,
 } from './localconf';
 import Analysis from './Analysis/Analysis';
 import ReduxAnalysisApp from './Analysis/ReduxAnalysisApp';
@@ -78,8 +78,8 @@ async function init() {
   library.add(faAngleUp, faAngleDown);
 
   for (let i = 0; i < components.footerLogos.length; i += 1) {
-    if(commonsWideAltText.hasOwnProperty(components.footerLogos[i].href)) {
-      components.footerLogos[i].alt = commonsWideAltText[components.footerLogos[i].href]
+    if (Object.prototype.hasOwnProperty.call(commonsWideAltText, components.footerLogos[i].href)) {
+      components.footerLogos[i].alt = commonsWideAltText[components.footerLogos[i].href];
     }
   }
 

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -77,6 +77,9 @@ async function init() {
   // FontAwesome icons
   library.add(faAngleUp, faAngleDown);
 
+  // For any platform-wide branded logos (Gen3, CTDS logos), apply standardized
+  // alt text. For the commons-specific logo, use the appName attribute to apply
+  // accessible alt text.
   for (let i = 0; i < components.footerLogos.length; i += 1) {
     if (Object.prototype.hasOwnProperty.call(commonsWideAltText, components.footerLogos[i].href)) {
       components.footerLogos[i].alt = commonsWideAltText[components.footerLogos[i].href];

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -34,7 +34,7 @@ import { ReduxNavBar, ReduxTopBar, ReduxFooter } from './Layout/reduxer';
 import ReduxQueryNode, { submitSearchForm } from './QueryNode/ReduxQueryNode';
 import { basename, dev, gaDebug, workspaceUrl, workspaceErrorUrl,
   indexPublic, explorerPublic, enableResourceBrowser, resourceBrowserPublic, enableDAPTracker,
-  discoveryConfig,
+  discoveryConfig, commonsWideAltText
 } from './localconf';
 import Analysis from './Analysis/Analysis';
 import ReduxAnalysisApp from './Analysis/ReduxAnalysisApp';
@@ -76,6 +76,12 @@ async function init() {
   );
   // FontAwesome icons
   library.add(faAngleUp, faAngleDown);
+
+  for (let i = 0; i < components.footerLogos.length; i += 1) {
+    if(commonsWideAltText.hasOwnProperty(components.footerLogos[i].href)) {
+      components.footerLogos[i].alt = commonsWideAltText[components.footerLogos[i].href]
+    }
+  }
 
   render(
     <div>

--- a/src/localconf.js
+++ b/src/localconf.js
@@ -376,11 +376,11 @@ function buildConfig(opts) {
   // This allows for one point-of-change in the case of future rebranding.
   // Map href or explicit descriptor to alt text.
   const commonsWideAltText = {
-    'portalLogo': components.appName + ' - home', // Standardized, accessible logo alt text for all commons
+    portalLogo: `${components.appName} - home`, // Standardized, accessible logo alt text for all commons
     'https://ctds.uchicago.edu/gen3': 'Gen3 Data Commons - information and resources',
-    'https://ctds.uchicago.edu/': 'Center for Translational Data Science at the University of Chicago - information and resources'
+    'https://ctds.uchicago.edu/': 'Center for Translational Data Science at the University of Chicago - information and resources',
 
-  }
+  };
 
   return {
     app,

--- a/src/localconf.js
+++ b/src/localconf.js
@@ -372,6 +372,15 @@ function buildConfig(opts) {
   const aggMDSURL = `${hostname}mds/aggregate`;
   const aggMDSDataURL = `${aggMDSURL}/metadata`;
 
+  // Disallow gitops.json configurability of Gen3 Data Commons and CTDS logo alt text.
+  // This allows for one point-of-change in the case of future rebranding.
+  // Map href to alt text.
+  const commonsWideAltText = {
+    'https://ctds.uchicago.edu/gen3': 'Gen3 Data Commons - information and resources',
+    'https://ctds.uchicago.edu/': 'Center for Translational Data Science at the University of Chicago - information and resources'
+
+  }
+
   return {
     app,
     basename,
@@ -454,6 +463,7 @@ function buildConfig(opts) {
     workspaceStorageDownloadUrl,
     marinerUrl,
     aggMDSDataURL,
+    commonsWideAltText,
   };
 }
 

--- a/src/localconf.js
+++ b/src/localconf.js
@@ -374,8 +374,9 @@ function buildConfig(opts) {
 
   // Disallow gitops.json configurability of Gen3 Data Commons and CTDS logo alt text.
   // This allows for one point-of-change in the case of future rebranding.
-  // Map href to alt text.
+  // Map href or explicit descriptor to alt text.
   const commonsWideAltText = {
+    'portalLogo': components.appName + ' - home', // Standardized, accessible logo alt text for all commons
     'https://ctds.uchicago.edu/gen3': 'Gen3 Data Commons - information and resources',
     'https://ctds.uchicago.edu/': 'Center for Translational Data Science at the University of Chicago - information and resources'
 


### PR DESCRIPTION
Jira Tickets: 
[PXP-7991](https://ctds-planx.atlassian.net/browse/PXP-7991)
[PXP-7997](https://ctds-planx.atlassian.net/browse/PXP-7997)

### Improvements
- The data-portal html wrapper's default language is now set to "en". This meets the guideline for default page language in the 508 accessibility specification.

### Dependency updates
- The alt attribute on the primary homepage logo is now  "[appName] - home" across commons. The Gen3, CTDS logo alt texts are now identical across commons. This meets the guideline for linked image alt text in the 508 accessibility specification.