### PR TITLE
feat/occ_modifications

### DIFF
--- a/src/Covid19Dashboard/ControlPanel/index.jsx
+++ b/src/Covid19Dashboard/ControlPanel/index.jsx
@@ -17,7 +17,7 @@ class ControlPanel extends PureComponent {
       <div className='control-panel'>
         <h3>{this.props.legendTitle}</h3>
         <p>
-          Data source:
+          Data source:&nbsp;
           <a href={this.props.legendDataSource.link}>
             {this.props.legendDataSource.title}
           </a>

--- a/src/Covid19Dashboard/ControlPanel/index.jsx
+++ b/src/Covid19Dashboard/ControlPanel/index.jsx
@@ -31,7 +31,7 @@ class ControlPanel extends PureComponent {
                 trigger={['hover', 'focus']}
               >
                 <div id='g3-accessibility-links-tooltip-data_source' className='g3-helper-tooltip g3-ring-on-focus' role='tooltip' tabIndex='0'>
-                  <i className='g3-icon g3-icon--sm g3-icon--info-circle-bootstrap help-tooltip-icon' />                  
+                  <i className='g3-icon g3-icon--sm g3-icon--question-mark-bootstrap help-tooltip-icon' />                  
                 </div>
             </Tooltip>
           )}

--- a/src/Covid19Dashboard/ControlPanel/index.jsx
+++ b/src/Covid19Dashboard/ControlPanel/index.jsx
@@ -10,7 +10,8 @@ import './ControlPanel.less';
 
 class ControlPanel extends PureComponent {
   render() {
-    const tooltipText = 'Additional data of interest to display in map tool-tip pop-up.  These data will not influence color gradients on the map.';
+    const tooltipText1 = 'Google Mobility Data shows movement trends as a percentage variance from an established baseline for a given day and place.'
+    const tooltipText2 = 'Additional data of interest to display in map tool-tip pop-up.  These data will not influence color gradients on the map.';
 
     return (
       <div className='control-panel'>
@@ -20,6 +21,20 @@ class ControlPanel extends PureComponent {
           <a href={this.props.legendDataSource.link}>
             {this.props.legendDataSource.title}
           </a>
+          {this.props.legendTitle === 'Mobility Data' 
+            && (<Tooltip
+                placement='right'
+                overlay={tooltipText1}
+                overlayClassName='g3-filter-section__and-or-toggle-helper-tooltip'
+                arrowContent={<div className='rc-tooltip-arrow-inner' />}
+                width='300px'
+                trigger={['hover', 'focus']}
+              >
+                <div id='g3-accessibility-links-tooltip-data_source' className='g3-helper-tooltip g3-ring-on-focus' role='tooltip' tabIndex='0'>
+                  <i className='g3-icon g3-icon--sm g3-icon--info-circle-bootstrap help-tooltip-icon' />                  
+                </div>
+            </Tooltip>
+          )}
         </p>
         {this.props.lastUpdated
           && (
@@ -55,13 +70,13 @@ class ControlPanel extends PureComponent {
             Additional Data 
             <Tooltip
                 placement='right'
-                overlay={tooltipText}
+                overlay={tooltipText2}
                 overlayClassName='g3-filter-section__and-or-toggle-helper-tooltip'
                 arrowContent={<div className='rc-tooltip-arrow-inner' />}
                 width='300px'
                 trigger={['hover', 'focus']}
               >
-                <div id='g3-accessibility-links-tooltip-explorer' className='g3-helper-tooltip g3-ring-on-focus' role='tooltip' tabIndex='0'>
+                <div id='g3-accessibility-links-tooltip-additional_data' className='g3-helper-tooltip g3-ring-on-focus' role='tooltip' tabIndex='0'>
                   <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="g3-icon g3-icon--sm" viewBox="0 0 16 16"><path d="M8 15A7 7 0 1 1 8 1a7 7 0 0 1 0 14zm0 1A8 8 0 1 0 8 0a8 8 0 0 0 0 16z"></path><path d="m8.93 6.588-2.29.287-.082.38.45.083c.294.07.352.176.288.469l-.738 3.468c-.194.897.105 1.319.808 1.319.545 0 1.178-.252 1.465-.598l.088-.416c-.2.176-.492.246-.686.246-.275 0-.375-.193-.304-.533L8.93 6.588zM9 4.5a1 1 0 1 1-2 0 1 1 0 0 1 2 0z"></path></svg>
                 </div>
             </Tooltip>

--- a/src/Covid19Dashboard/ControlPanel/index.jsx
+++ b/src/Covid19Dashboard/ControlPanel/index.jsx
@@ -77,7 +77,7 @@ class ControlPanel extends PureComponent {
                 trigger={['hover', 'focus']}
               >
                 <div id='g3-accessibility-links-tooltip-additional_data' className='g3-helper-tooltip g3-ring-on-focus' role='tooltip' tabIndex='0'>
-                  <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="g3-icon g3-icon--sm" viewBox="0 0 16 16"><path d="M8 15A7 7 0 1 1 8 1a7 7 0 0 1 0 14zm0 1A8 8 0 1 0 8 0a8 8 0 0 0 0 16z"></path><path d="m8.93 6.588-2.29.287-.082.38.45.083c.294.07.352.176.288.469l-.738 3.468c-.194.897.105 1.319.808 1.319.545 0 1.178-.252 1.465-.598l.088-.416c-.2.176-.492.246-.686.246-.275 0-.375-.193-.304-.533L8.93 6.588zM9 4.5a1 1 0 1 1-2 0 1 1 0 0 1 2 0z"></path></svg>
+                  <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" className="g3-icon g3-icon--sm" viewBox="0 0 16 16"><path d="M8 15A7 7 0 1 1 8 1a7 7 0 0 1 0 14zm0 1A8 8 0 1 0 8 0a8 8 0 0 0 0 16z"></path><path d="m8.93 6.588-2.29.287-.082.38.45.083c.294.07.352.176.288.469l-.738 3.468c-.194.897.105 1.319.808 1.319.545 0 1.178-.252 1.465-.598l.088-.416c-.2.176-.492.246-.686.246-.275 0-.375-.193-.304-.533L8.93 6.588zM9 4.5a1 1 0 1 1-2 0 1 1 0 0 1 2 0z"></path></svg>
                 </div>
             </Tooltip>
               </h4>

--- a/src/Covid19Dashboard/ControlPanel/index.jsx
+++ b/src/Covid19Dashboard/ControlPanel/index.jsx
@@ -4,11 +4,14 @@ import LegendPanel from './LegendPanel';
 import MapStylePanel from './MapStylePanel';
 import LayerSelector from './LayerSelector';
 import DataSelector from './DataSelector';
+import Tooltip from 'rc-tooltip';
 
 import './ControlPanel.less';
 
 class ControlPanel extends PureComponent {
   render() {
+    const tooltipText = 'Additional data of interest to display in map tool-tip pop-up.  These data will not influence color gradients on the map.';
+
     return (
       <div className='control-panel'>
         <h3>{this.props.legendTitle}</h3>
@@ -49,7 +52,19 @@ class ControlPanel extends PureComponent {
                 activeLayer={this.props.activeLayer}
               />
               <h4>
-            Additional Data Points
+            Additional Data 
+            <Tooltip
+                placement='right'
+                overlay={tooltipText}
+                overlayClassName='g3-filter-section__and-or-toggle-helper-tooltip'
+                arrowContent={<div className='rc-tooltip-arrow-inner' />}
+                width='300px'
+                trigger={['hover', 'focus']}
+              >
+                <div id='g3-accessibility-links-tooltip-explorer' className='g3-helper-tooltip g3-ring-on-focus' role='tooltip' tabIndex='0'>
+                  <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="g3-icon g3-icon--sm" viewBox="0 0 16 16"><path d="M8 15A7 7 0 1 1 8 1a7 7 0 0 1 0 14zm0 1A8 8 0 1 0 8 0a8 8 0 0 0 0 16z"></path><path d="m8.93 6.588-2.29.287-.082.38.45.083c.294.07.352.176.288.469l-.738 3.468c-.194.897.105 1.319.808 1.319.545 0 1.178-.252 1.465-.598l.088-.416c-.2.176-.492.246-.686.246-.275 0-.375-.193-.304-.533L8.93 6.588zM9 4.5a1 1 0 1 1-2 0 1 1 0 0 1 2 0z"></path></svg>
+                </div>
+            </Tooltip>
               </h4>
               <DataSelector
                 layers={this.props.dataPoints}

--- a/src/Covid19Dashboard/IllinoisMapChart/index.jsx
+++ b/src/Covid19Dashboard/IllinoisMapChart/index.jsx
@@ -217,20 +217,50 @@ class IllinoisMapChart extends React.Component {
         };
       }
 
-      if (feature.layer.id.includes('mobility_data')) {
+      if (feature.layer.id === 'rnr_mobility_data') {
         const rnr = formatNumberToDisplay(feature.properties[`rnr_${this.state.sliderDate}`]);
-        const gnp = formatNumberToDisplay(feature.properties[`gnp_${this.state.sliderDate}`]);
-        const prk = formatNumberToDisplay(feature.properties[`prk_${this.state.sliderDate}`]);
-        const trn = formatNumberToDisplay(feature.properties[`trn_${this.state.sliderDate}`]);
-        const wrk = formatNumberToDisplay(feature.properties[`wrk_${this.state.sliderDate}`]);
-        const res = formatNumberToDisplay(feature.properties[`res_${this.state.sliderDate}`]);
 
         hoverInfo.mobility_values = {
           'Retail & Recreation': rnr,
+        };
+      }
+
+      if (feature.layer.id === 'gnp_mobility_data') {
+        const gnp = formatNumberToDisplay(feature.properties[`gnp_${this.state.sliderDate}`]);
+
+        hoverInfo.mobility_values = {
           'Grocery & Pharmacy': gnp,
+        };
+      }
+
+      if (feature.layer.id === 'prk_mobility_data') {
+        const prk = formatNumberToDisplay(feature.properties[`prk_${this.state.sliderDate}`]);
+
+        hoverInfo.mobility_values = {
           Parks: prk,
-          Transit: trn,
+        };
+      }
+
+      if (feature.layer.id === 'trn_mobility_data') {
+        const trn = formatNumberToDisplay(feature.properties[`trn_${this.state.sliderDate}`]);
+
+        hoverInfo.mobility_values = {
+          'Transit Stations': trn,
+        };
+      }
+
+      if (feature.layer.id === 'wrk_mobility_data') {
+        const wrk = formatNumberToDisplay(feature.properties[`wrk_${this.state.sliderDate}`]);
+        
+        hoverInfo.mobility_values = {
           Workplaces: wrk,
+        };
+      }
+
+      if (feature.layer.id === 'res_mobility_data') {
+        const res = formatNumberToDisplay(feature.properties[`res_${this.state.sliderDate}`]);
+
+        hoverInfo.mobility_values = {
           Residential: res,
         };
       }
@@ -487,8 +517,8 @@ class IllinoisMapChart extends React.Component {
           {this.state.mobility_data.fetchStatus === 'done' && <MobilityLayer visibility={this.state.activeLayer === 'rnr_mobility_data' ? 'visible' : 'none'} data={this.state.mobility_data.data} date={this.state.sliderDate} />}
           {this.state.mobility_data.fetchStatus === 'done' && <MobilityLayerGnp visibility={this.state.activeLayer === 'gnp_mobility_data' ? 'visible' : 'none'} data={this.state.mobility_data.data} date={this.state.sliderDate} />}
           {this.state.mobility_data.fetchStatus === 'done' && <MobilityLayerPrk visibility={this.state.activeLayer === 'prk_mobility_data' ? 'visible' : 'none'} data={this.state.mobility_data.data} date={this.state.sliderDate} />}
-          {this.state.mobility_data.fetchStatus === 'done' && <MobilityLayerWrk visibility={this.state.activeLayer === 'wrk_mobility_data' ? 'visible' : 'none'} data={this.state.mobility_data.data} date={this.state.sliderDate} />}
           {this.state.mobility_data.fetchStatus === 'done' && <MobilityLayerTrn visibility={this.state.activeLayer === 'trn_mobility_data' ? 'visible' : 'none'} data={this.state.mobility_data.data} date={this.state.sliderDate} />}
+          {this.state.mobility_data.fetchStatus === 'done' && <MobilityLayerWrk visibility={this.state.activeLayer === 'wrk_mobility_data' ? 'visible' : 'none'} data={this.state.mobility_data.data} date={this.state.sliderDate} />}
           {this.state.mobility_data.fetchStatus === 'done' && <MobilityLayerRes visibility={this.state.activeLayer === 'res_mobility_data' ? 'visible' : 'none'} data={this.state.mobility_data.data} date={this.state.sliderDate} />}
           {/*
           // Additional layers used as examples enable here

--- a/src/Covid19Dashboard/IllinoisMapChart/index.jsx
+++ b/src/Covid19Dashboard/IllinoisMapChart/index.jsx
@@ -282,6 +282,7 @@ class IllinoisMapChart extends React.Component {
         ['40% to 60%', '#A25626'],
         ['60% to 80%', '#8B4225'],
         ['80% to 100% +', '#850001'],
+        ['No Data Available', '#5f5d59'],
       ];
       this.setState({ mapColors: colors, legendTitle: 'Mobility Data', legendDataSource: { title: 'Google Mobility Data', link: 'https://www.google.com/covid19/mobility/' } });
     }

--- a/src/Covid19Dashboard/IllinoisMapChart/index.jsx
+++ b/src/Covid19Dashboard/IllinoisMapChart/index.jsx
@@ -88,7 +88,7 @@ class IllinoisMapChart extends React.Component {
       popup_data: {
         /*
         This data is used just for the popup on hover */
-        strain_data: { title: 'Strain Data', visible: 'none' },
+        strain_data: { title: 'SARS-CoV-2 Strain Data', visible: 'none' },
         // mobility_data : {title: 'Mobility Data', visible: 'none'},
       },
       sliderValue: dateDiff,
@@ -407,7 +407,7 @@ class IllinoisMapChart extends React.Component {
               hoverInfo.strain_values
               && (
                 <table>
-                  <caption>Strain Data</caption>
+                  <caption>SARS-CoV-2 Strain Data</caption>
                   <tbody>
                     {Object.entries(hoverInfo.strain_values).map((val, i) => {
                       const secondCol = Object.entries(hoverInfo.strain_values)[i + 1] || ['', ''];


### PR DESCRIPTION
Jira Ticket: [COV-953](https://occ-data.atlassian.net/browse/COV-953) 
Map Layers - Adjust percentage ranges displayed in legend for mobility data:
- The percentage ranges should have "to" instead of "-"

Jira Ticket: [COV-957](https://occ-data.atlassian.net/browse/COV-957) 
Map Layers - Update Legend w/ no data information:
- Update the legend that displays when selecting a mobility layer (Retail & Recreation, Grocery & Pharmacy, etc)  to not that the color gray [#5f5d59] = "No Data Available"

Jira Ticket: [COV-956](https://occ-data.atlassian.net/browse/COV-956)
Map Layers - Modify name of Strain Data selection option + add context:
- In the map menu are, there is a selection under “Additional Data Points” called “Strain Data” 
- Change “Additional Data Points” to be “Additional Data” 
- Add an information icon (small letter i) with a hover/pop-up message that reads “Additional data of interest to display in map tool-tip pop-up.  These data will not influence color gradients on the map.” 
Change “Strain Data” to be “SARS-CoV-2 Strain Data”

Jira Ticket: [COV-954](https://occ-data.atlassian.net/browse/COV-954)
Map Layers - Add informational pop-up in legend for mobility data:
- After / behind the link to "Google Mobility Data" at the top of the legend, include an information icon (small letter i icon, similar to example attached).  When a user mouses over or clicks on the icon, the following text should display as a contextual pop-up:  "Google Mobility Data shows movement trends as a percentage variance from an established baseline for a given day and place."

Jira Ticket: [COV-958](https://occ-data.atlassian.net/browse/COV-958)
Map Layers - Limit map pop-up display to only those Mobility layer(s) selected:
- Modify map pop-up display to include only the mobility layer or layers selected.
