### PR TITLE
Add commons_url to manifest if both exists

### DIFF
--- a/src/Discovery/DiscoveryListView.tsx
+++ b/src/Discovery/DiscoveryListView.tsx
@@ -62,9 +62,13 @@ export const DiscoveryListView: React.FunctionComponent<DiscoveryListViewProps> 
     }
     // combine manifests from all selected studies
     const manifest = [];
-    props.selectedResources.forEach((study) => {
+    props.selectedResources.forEach((study: any) => {
       if (study[manifestFieldName]) {
-        manifest.push(...study[manifestFieldName]);
+        if ('commons_url' in study) { // HEAL addition to allow hostname based DRS in file access clients
+          manifest.push(...study[manifestFieldName].map((x) => ({ ...x, commons_url: study.commons_url })));
+        } else {
+          manifest.push(...study[manifestFieldName]);
+        }
       }
     });
     // post selected resources to manifestservice
@@ -88,9 +92,13 @@ export const DiscoveryListView: React.FunctionComponent<DiscoveryListViewProps> 
     }
     // combine manifests from all selected studies
     const manifest = [];
-    props.selectedResources.forEach((study) => {
+    props.selectedResources.forEach((study: any) => {
       if (study[manifestFieldName]) {
-        manifest.push(...study[manifestFieldName]);
+        if ('commons_url' in study) { // HEAL addition to allow hostname based DRS in file access clients
+          manifest.push(...study[manifestFieldName].map((x) => ({ ...x, commons_url: study.commons_url })));
+        } else {
+          manifest.push(...study[manifestFieldName]);
+        }
       }
     });
     // download the manifest


### PR DESCRIPTION
Jira Ticket: [PXP-8418](https://ctds-planx.atlassian.net/browse/PXP-8418)

<!--
Make sure to follow the DEV guidelines (https://gen3.org/resources/developer/dev-introduction/) before asking for review.

- Describe what this pull request does.
- Add short descriptive bullet points for each section if relevant. Keep in mind that they will be parsed automatically to generate official release notes.
- Test manually.
- Maintain or increase the test coverage (if relevant).
- Update the documentation, or justify if not needed.

-->

### New Features
If Discovery is in Ecosystem mode and the study item contains a commons_url field, add "common_url" to the download and export manifest.

### Breaking Changes


### Bug Fixes


### Improvements


### Dependency updates


### Deployment changes
<!-- This section should only contain important things devops should know when updating service versions. -->
