### PR TITLE
Use the RStudio logo for both 'RStudio' and 'R Studio'

### DIFF
--- a/src/Workspace/index.jsx
+++ b/src/Workspace/index.jsx
@@ -118,7 +118,7 @@ class Workspace extends React.Component {
   ).catch(() => 'Error');
 
   getIcon = (workspace) => {
-    if (this.regIcon(workspace, 'R Studio')) {
+    if (this.regIcon(workspace, 'R Studio') || this.regIcon(workspace, 'RStudio')) {
       return rStudioIcon;
     } if (this.regIcon(workspace, 'Jupyter')) {
       return jupyterIcon;


### PR DESCRIPTION
### Improvements
- Use the RStudio logo for both 'RStudio' and 'R Studio' workspaces
