### PR TITLE
PXP-8431 Feat/ws spin network

### DIFF
--- a/src/Workspace/index.jsx
+++ b/src/Workspace/index.jsx
@@ -288,7 +288,6 @@ class Workspace extends React.Component {
     try {
       const interval = setInterval(async () => {
         const data = await this.getWorkspaceStatus();
-        console.log(data);
         if (this.workspaceStates.includes(data.status)) {
           const workspaceLaunchStepsConfig = this.getWorkspaceLaunchSteps(data);
           this.setState({

--- a/src/Workspace/index.jsx
+++ b/src/Workspace/index.jsx
@@ -117,7 +117,7 @@ class Workspace extends React.Component {
     }).then(
       ({ data }) => data,
     ).catch(() => 'Error');
-    if (workspaceStatus.status === 'Running') {
+    if (workspaceStatus.status === 'Running' && (!this.state.workspaceStatus || this.state.workspaceStatus === 'Not Found' || this.state.workspaceStatus === 'Launching')) {
       await fetchWithCreds({
         path: `${workspaceUrl}proxy/`,
         method: 'GET',
@@ -288,6 +288,7 @@ class Workspace extends React.Component {
     try {
       const interval = setInterval(async () => {
         const data = await this.getWorkspaceStatus();
+        console.log(data);
         if (this.workspaceStates.includes(data.status)) {
           const workspaceLaunchStepsConfig = this.getWorkspaceLaunchSteps(data);
           this.setState({

--- a/src/Workspace/index.jsx
+++ b/src/Workspace/index.jsx
@@ -110,12 +110,31 @@ class Workspace extends React.Component {
     );
   }
 
-  getWorkspaceStatus = async () => fetchWithCreds({
-    path: `${workspaceStatusUrl}`,
-    method: 'GET',
-  }).then(
-    ({ data }) => data,
-  ).catch(() => 'Error');
+  getWorkspaceStatus = async () => {
+    const workspaceStatus = await fetchWithCreds({
+      path: `${workspaceStatusUrl}`,
+      method: 'GET',
+    }).then(
+      ({ data }) => data,
+    ).catch(() => 'Error');
+    if (workspaceStatus.status === 'Running') {
+      await fetchWithCreds({
+        path: `${workspaceUrl}proxy/`,
+        method: 'GET',
+      }).then(
+        ({ status }) => {
+          if (status !== 200) {
+            workspaceStatus.status = 'Launching';
+            workspaceStatus.conditions = [{
+              type: 'ProxyConnected',
+              status: 'False',
+            }];
+          }
+        },
+      ).catch(() => 'Error');
+    }
+    return workspaceStatus;
+  }
 
   getIcon = (workspace) => {
     if (this.regIcon(workspace, 'R Studio')) {
@@ -151,6 +170,10 @@ class Workspace extends React.Component {
         },
         {
           title: 'Getting Containers Ready',
+          description: '',
+        },
+        {
+          title: 'Waiting for Proxy',
           description: '',
         },
       ],
@@ -193,12 +216,21 @@ class Workspace extends React.Component {
       return workspaceLaunchStepsConfig;
     }
 
-    if (workspaceStatusData.conditions.some((element) => (
-      (element.type === 'ContainersReady' && element.status === 'True')
-    ))) {
-      workspaceLaunchStepsConfig.currentIndex = 2;
-      workspaceLaunchStepsConfig.currentStepsStatus = 'finish';
-      workspaceLaunchStepsConfig.steps[2].description = 'All containers are ready';
+    // here we are at step 3, step 3 have no k8s pod/container conditions
+    workspaceLaunchStepsConfig.steps[0].description = 'Pod scheduled';
+    workspaceLaunchStepsConfig.steps[1].description = 'Pod initialized';
+    workspaceLaunchStepsConfig.steps[2].description = 'All containers are ready';
+
+    // condition type: ProxyConnected + status: false => at step 3
+    if (workspaceStatusData.conditions.some((element) => (element.type === 'ProxyConnected' && element.status === 'False'))) {
+      workspaceLaunchStepsConfig.currentIndex = 3;
+      workspaceLaunchStepsConfig.steps[3].description = 'In progress';
+      return workspaceLaunchStepsConfig;
+    }
+    if (workspaceStatusData.conditions.some((element) => (element.type === 'ProxyConnected' && element.status === 'True'))) {
+      workspaceLaunchStepsConfig.currentIndex = 3;
+      workspaceLaunchStepsConfig.currentStepsStatus = 'success';
+      workspaceLaunchStepsConfig.steps[3].description = 'Proxy is ready';
     }
     return workspaceLaunchStepsConfig;
   }


### PR DESCRIPTION
Jira Ticket: [PXP-8431](https://ctds-planx.atlassian.net/browse/PXP-8431)

Workspace launch spinner now supports for waiting for network proxy (Ambassador) becomes ready

When spinning up workspace pods in external cluster, it cannot be accessed via Ambassador until the DNS has been updated

Deployed in https://qureshi.planx-pla.net

<img width="1859" alt="Screen Shot 2021-07-13 at 9 45 43 AM" src="https://user-images.githubusercontent.com/2475897/125472967-e8c566d9-c891-4ab6-ab32-d0fdf2fe6af7.png">


### Improvements
- Workspace: add support for waiting for network proxy becomes ready in launch spinner

