### PR TITLE
(PXP-8564) Fix for indexing download button not working

### DIFF
--- a/src/Indexing/Indexing.jsx
+++ b/src/Indexing/Indexing.jsx
@@ -311,8 +311,8 @@ class Indexing extends React.Component {
   downloadJobOutput = (linkToFile) => {
     const link = document.createElement('a');
     link.href = linkToFile;
-    document.body.appendChild(link);
     link.click();
+    document.body.appendChild(link);
   }
 
   download = async () => {


### PR DESCRIPTION
https://ctds-planx.atlassian.net/browse/PXP-8564

The download buttons on the Indexing page have stopped working in Chrome. I'm not sure why, but it seems to have something to do with triggering a click on an `<a>` element AFTER it's been attached to the <body> of the page. Triggering the click BEFORE the <a> element is attached to the body of the page prevents this.

I considered removing the code that attaches the <a> element to the <body> of the page, BUT it's useful as a workaround right now. Because breaking changes in browsers could affect the way that the download buttons work, I think we should keep appending the link to the HTML so that we have an escape hatch if we hit a similar bug in the future.

To replicate:
* Index any file in https://qa-dcp.planx-pla.net/indexing. Expect that the Download Logs and Download Manifest buttons do not work.
* Run local portal in this branch and index the same file in https://qa-dcp.planx-pla.net/dev.html/indexing. Expect that the buttons download the files.

### New Features


### Breaking Changes


### Bug Fixes
- Fixed a bug in the Indexing page in which the download buttons would not function in Chrome.


### Improvements


### Dependency updates


### Deployment changes
<!-- This section should only contain important things devops should know when updating service versions. -->
