### PR TITLE
HP-305 Feat/ws kernel shutdown

### DIFF
--- a/src/Popup/ReduxWorkspaceShutdownBanner.jsx
+++ b/src/Popup/ReduxWorkspaceShutdownBanner.jsx
@@ -17,7 +17,11 @@ const ReduxWorkspaceShutdownPopup = connect(timeoutPopupMapState, timeoutPopupMa
     const remainingTimeInMinutes = (Math.ceil(remainingWorkspaceKernelLife / 60 / 1000));
     return (
       <Alert
-        message={`Your workspace will be terminated in ${remainingTimeInMinutes} ${(remainingTimeInMinutes === 1) ? 'minute' : 'minutes'} due to inactivity. Navigate to the workspace soon if you have unsaved data.`}
+        message={(
+          <React.Fragment>
+            Your workspace will be terminated in <b>{remainingTimeInMinutes}</b> {` ${(remainingTimeInMinutes === 1) ? 'minute' : 'minutes'}`} due to inactivity. Navigate to the workspace soon if you have unsaved data.
+          </React.Fragment>
+        )}
         banner
       />
     );

--- a/src/Popup/ReduxWorkspaceShutdownBanner.jsx
+++ b/src/Popup/ReduxWorkspaceShutdownBanner.jsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { connect } from 'react-redux';
+import { Alert } from 'antd';
+
+const timeoutPopupMapState = (state) => ({
+  showShutdownBanner: state.popups.showShutdownBanner,
+  remainingWorkspaceKernelLife: state.popups.remainingWorkspaceKernelLife,
+});
+
+const timeoutPopupMapDispatch = () => ({});
+
+const ReduxWorkspaceShutdownPopup = connect(timeoutPopupMapState, timeoutPopupMapDispatch)(
+  ({ showShutdownBanner, remainingWorkspaceKernelLife }) => {
+    if (!showShutdownBanner) {
+      return null;
+    }
+    const remainingTimeInMinutes = (Math.ceil(remainingWorkspaceKernelLife / 60 / 1000));
+    return (
+      <Alert
+        message={`Your workspace will be terminated in ${remainingTimeInMinutes} ${(remainingTimeInMinutes === 1) ? 'minute' : 'minutes'} due to inactivity. Navigate to the workspace soon if you have unsaved data.`}
+        banner
+      />
+    );
+  },
+);
+
+export default ReduxWorkspaceShutdownPopup;

--- a/src/Popup/ReduxWorkspaceShutdownPopup.jsx
+++ b/src/Popup/ReduxWorkspaceShutdownPopup.jsx
@@ -27,7 +27,6 @@ const ReduxWorkspaceShutdownPopup = connect(workspaceShutdownPopupMapState, work
       });
       closeWorkspaceShutdownPopup();
       if (SessionMonitor.isUserOnPage('workspace')) {
-        console.log('on ws page');
         window.location.reload(); // if user is on workspace page, refresh to update
       }
     };

--- a/src/Popup/ReduxWorkspaceShutdownPopup.jsx
+++ b/src/Popup/ReduxWorkspaceShutdownPopup.jsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import { connect } from 'react-redux';
+import Popup from '../components/Popup';
+import { SessionMonitor } from '../SessionMonitor';
+
+import { workspaceTerminateUrl } from '../localconf';
+import { fetchWithCreds } from '../actions';
+
+const workspaceShutdownPopupMapState = (state) => ({
+  showShutdownPopup: state.popups.showShutdownPopup,
+  idleTimeLimit: state.popups.idleTimeLimit,
+});
+
+const workspaceShutdownPopupMapDispatch = (dispatch) => ({
+  closeWorkspaceShutdownPopup: () => dispatch({ type: 'UPDATE_WORKSPACE_ALERT', data: { showShutdownPopup: false, showShutdownBanner: false } }),
+});
+
+const ReduxWorkspaceShutdownPopup = connect(workspaceShutdownPopupMapState, workspaceShutdownPopupMapDispatch)(
+  ({ showShutdownPopup, idleTimeLimit, closeWorkspaceShutdownPopup }) => {
+    if (!showShutdownPopup) {
+      return null;
+    }
+    const handleClose = () => {
+      fetchWithCreds({
+        path: `${workspaceTerminateUrl}`,
+        method: 'POST',
+      });
+      closeWorkspaceShutdownPopup();
+      if (SessionMonitor.isUserOnPage('workspace')) {
+        console.log('on ws page');
+        window.location.reload(); // if user is on workspace page, refresh to update
+      }
+    };
+
+    return (
+      <Popup
+        message={`Your workspace has been terminated because it has been inactive for longer than ${idleTimeLimit / 60 / 1000} minutes.`}
+        rightButtons={[
+          {
+            caption: 'Close',
+            fn: handleClose,
+          },
+        ]}
+      />
+    );
+  },
+);
+
+export default ReduxWorkspaceShutdownPopup;

--- a/src/Popup/reducers.js
+++ b/src/Popup/reducers.js
@@ -2,6 +2,8 @@ const popups = (state = {}, action) => {
   switch (action.type) {
   case 'UPDATE_POPUP':
     return { ...state, ...action.data };
+  case 'UPDATE_WORKSPACE_ALERT':
+    return { ...state, ...action.data };
   default:
     return state;
   }

--- a/src/Workspace/WorkspaceSessionMonitor.js
+++ b/src/Workspace/WorkspaceSessionMonitor.js
@@ -53,6 +53,8 @@ export class WorkspaceSessionMonitor {
               } else if (remainingWorkspaceKernelLife <= this.workspaceShutdownAlertLimit) {
                 console.log('ws sm dispatch banner', remainingWorkspaceKernelLife);
                 store.dispatch({ type: 'UPDATE_WORKSPACE_ALERT', data: { showShutdownBanner: true, showShutdownPopup: false, remainingWorkspaceKernelLife } });
+              } else {
+                store.dispatch({ type: 'UPDATE_WORKSPACE_ALERT', data: { showShutdownBanner: false, showShutdownPopup: false } });
               }
             },
           );

--- a/src/Workspace/WorkspaceSessionMonitor.js
+++ b/src/Workspace/WorkspaceSessionMonitor.js
@@ -1,0 +1,66 @@
+import getReduxStore from '../reduxStore';
+import { fetchWithCreds } from '../actions';
+import { workspaceStatusUrl } from '../localconf';
+
+export class WorkspaceSessionMonitor {
+  constructor() {
+    this.checkStatusInterval = 15 * 1000;
+    this.workspaceShutdownAlertLimit = 5 * 60 * 1000; // Time limit for banner/popup begins to show
+    this.interval = null;
+  }
+
+  start() {
+    console.log('ws sm start');
+    if (this.interval) { // interval already started
+      console.log('ws sm start found interval');
+      return;
+    }
+    console.log('ws sm start set interval');
+    this.checkWorkspaceStatus();
+    this.interval = setInterval(
+      () => this.checkWorkspaceStatus(),
+      this.checkStatusInterval,
+    );
+  }
+
+  stop() {
+    console.log('ws sm stop');
+    if (this.interval) {
+      clearInterval(this.interval);
+      this.interval = null; // make sure the interval got cleared
+    }
+  }
+
+  checkWorkspaceStatus() {
+    console.log('ws sm check status');
+    fetchWithCreds({
+      path: `${workspaceStatusUrl}`,
+      method: 'GET',
+    }).then(
+      ({ data }) => {
+        if (!data.idleTimeLimit) {
+          this.stop();
+          return;
+        }
+        if (data.idleTimeLimit && data.lastActivityTime) {
+          getReduxStore().then(
+            (store) => {
+              const remainingWorkspaceKernelLife = data.idleTimeLimit - (Date.now() - data.lastActivityTime);
+              if (remainingWorkspaceKernelLife <= 0) { // kernel has died due to inactivity
+                console.log('ws sm dispatch popup');
+                store.dispatch({ type: 'UPDATE_WORKSPACE_ALERT', data: { showShutdownBanner: false, showShutdownPopup: true, idleTimeLimit: data.idleTimeLimit } });
+                this.stop();
+              } else if (remainingWorkspaceKernelLife <= this.workspaceShutdownAlertLimit) {
+                console.log('ws sm dispatch banner', remainingWorkspaceKernelLife);
+                store.dispatch({ type: 'UPDATE_WORKSPACE_ALERT', data: { showShutdownBanner: true, showShutdownPopup: false, remainingWorkspaceKernelLife } });
+              }
+            },
+          );
+        }
+      },
+    );
+  }
+}
+
+const singleton = new WorkspaceSessionMonitor();
+export default singleton;

--- a/src/Workspace/WorkspaceSessionMonitor.js
+++ b/src/Workspace/WorkspaceSessionMonitor.js
@@ -38,11 +38,11 @@ export class WorkspaceSessionMonitor {
       method: 'GET',
     }).then(
       ({ data }) => {
-        if (!data.idleTimeLimit) {
+        if (!data.idleTimeLimit || data.idleTimeLimit < 0) {
           this.stop();
           return;
         }
-        if (data.idleTimeLimit && data.lastActivityTime) {
+        if (data.idleTimeLimit && data.idleTimeLimit > 0 && data.lastActivityTime) {
           getReduxStore().then(
             (store) => {
               const remainingWorkspaceKernelLife = data.idleTimeLimit - (Date.now() - data.lastActivityTime);

--- a/src/Workspace/WorkspaceSessionMonitor.js
+++ b/src/Workspace/WorkspaceSessionMonitor.js
@@ -53,8 +53,8 @@ export class WorkspaceSessionMonitor {
               } else if (remainingWorkspaceKernelLife <= this.workspaceShutdownAlertLimit) {
                 console.log('ws sm dispatch banner', remainingWorkspaceKernelLife);
                 store.dispatch({ type: 'UPDATE_WORKSPACE_ALERT', data: { showShutdownBanner: true, showShutdownPopup: false, remainingWorkspaceKernelLife } });
-              } else {
-                store.dispatch({ type: 'UPDATE_WORKSPACE_ALERT', data: { showShutdownBanner: false, showShutdownPopup: false } });
+              } else if (store.getState().popups.showShutdownBanner) {
+                store.dispatch({ type: 'UPDATE_WORKSPACE_ALERT', data: { showShutdownBanner: false } });
               }
             },
           );

--- a/src/Workspace/WorkspaceSessionMonitor.js
+++ b/src/Workspace/WorkspaceSessionMonitor.js
@@ -42,7 +42,7 @@ export class WorkspaceSessionMonitor {
           this.stop();
           return;
         }
-        if (data.idleTimeLimit && data.idleTimeLimit > 0 && data.lastActivityTime) {
+        if (data.idleTimeLimit > 0 && data.lastActivityTime > 0) {
           getReduxStore().then(
             (store) => {
               const remainingWorkspaceKernelLife = data.idleTimeLimit - (Date.now() - data.lastActivityTime);

--- a/src/Workspace/WorkspaceSessionMonitor.js
+++ b/src/Workspace/WorkspaceSessionMonitor.js
@@ -10,12 +10,9 @@ export class WorkspaceSessionMonitor {
   }
 
   start() {
-    console.log('ws sm start');
     if (this.interval) { // interval already started
-      console.log('ws sm start found interval');
       return;
     }
-    console.log('ws sm start set interval');
     this.checkWorkspaceStatus();
     this.interval = setInterval(
       () => this.checkWorkspaceStatus(),
@@ -24,7 +21,6 @@ export class WorkspaceSessionMonitor {
   }
 
   stop() {
-    console.log('ws sm stop');
     if (this.interval) {
       clearInterval(this.interval);
       this.interval = null; // make sure the interval got cleared
@@ -32,7 +28,6 @@ export class WorkspaceSessionMonitor {
   }
 
   checkWorkspaceStatus() {
-    console.log('ws sm check status');
     fetchWithCreds({
       path: `${workspaceStatusUrl}`,
       method: 'GET',
@@ -47,11 +42,9 @@ export class WorkspaceSessionMonitor {
             (store) => {
               const remainingWorkspaceKernelLife = data.idleTimeLimit - (Date.now() - data.lastActivityTime);
               if (remainingWorkspaceKernelLife <= 0) { // kernel has died due to inactivity
-                console.log('ws sm dispatch popup');
                 store.dispatch({ type: 'UPDATE_WORKSPACE_ALERT', data: { showShutdownBanner: false, showShutdownPopup: true, idleTimeLimit: data.idleTimeLimit } });
                 this.stop();
               } else if (remainingWorkspaceKernelLife <= this.workspaceShutdownAlertLimit) {
-                console.log('ws sm dispatch banner', remainingWorkspaceKernelLife);
                 store.dispatch({ type: 'UPDATE_WORKSPACE_ALERT', data: { showShutdownBanner: true, showShutdownPopup: false, remainingWorkspaceKernelLife } });
               } else if (store.getState().popups.showShutdownBanner) {
                 store.dispatch({ type: 'UPDATE_WORKSPACE_ALERT', data: { showShutdownBanner: false } });

--- a/src/Workspace/index.jsx
+++ b/src/Workspace/index.jsx
@@ -330,7 +330,7 @@ class Workspace extends React.Component {
           }, () => {
             if (this.state.workspaceStatus !== 'Launching'
               && this.state.workspaceStatus !== 'Terminating') {
-              if (data.idleTimeLimit && data.idleTimeLimit > 0) {
+              if (data.idleTimeLimit > 0) {
                 // start ws session monitor only if idleTimeLimit exists
                 workspaceSessionMonitor.start();
               }

--- a/src/Workspace/index.jsx
+++ b/src/Workspace/index.jsx
@@ -1,7 +1,9 @@
 import React from 'react';
 import parse from 'html-react-parser';
 import Button from '@gen3/ui-component/dist/components/Button';
-import { Alert, Popconfirm, Steps } from 'antd';
+import {
+  Alert, Popconfirm, Steps, message,
+} from 'antd';
 
 import {
   workspaceUrl,
@@ -254,8 +256,18 @@ class Workspace extends React.Component {
       fetchWithCreds({
         path: `${workspaceLaunchUrl}?id=${workspace.id}`,
         method: 'POST',
-      }).then(() => {
-        this.checkWorkspaceStatus();
+      }).then(({ status }) => {
+        switch (status) {
+        case 200:
+          this.checkWorkspaceStatus();
+          break;
+        default:
+          message.error('There is an error when trying to launch your workspace');
+          this.setState({
+            workspaceID: null,
+            workspaceLaunchStepsConfig: null,
+          });
+        }
       });
     });
   }
@@ -318,7 +330,7 @@ class Workspace extends React.Component {
           }, () => {
             if (this.state.workspaceStatus !== 'Launching'
               && this.state.workspaceStatus !== 'Terminating') {
-              if (data.idleTimeLimit) {
+              if (data.idleTimeLimit && data.idleTimeLimit > 0) {
                 // start ws session monitor only if idleTimeLimit exists
                 workspaceSessionMonitor.start();
               }

--- a/src/covid19Index.jsx
+++ b/src/covid19Index.jsx
@@ -51,20 +51,23 @@ import { DAPRouteTracker } from './components/DAPAnalytics';
 import GuppyDataExplorer from './GuppyDataExplorer';
 import isEnabled from './helpers/featureFlags';
 import sessionMonitor from './SessionMonitor';
+import workspaceSessionMonitor from './Workspace/WorkspaceSessionMonitor';
 import Workspace from './Workspace';
 import ResourceBrowser from './ResourceBrowser';
 import Discovery from './Discovery';
+import ReduxWorkspaceShutdownPopup from './Popup/ReduxWorkspaceShutdownPopup';
+import ReduxWorkspaceShutdownBanner from './Popup/ReduxWorkspaceShutdownBanner';
 import ErrorWorkspacePlaceholder from './Workspace/ErrorWorkspacePlaceholder';
 import NotFound from './components/NotFound';
 
 // monitor user's session
 sessionMonitor.start();
+workspaceSessionMonitor.start();
 
 // render the app after the store is configured
 async function init() {
   const store = await getReduxStore();
 
-  // asyncSetInterval(() => store.dispatch(fetchUser), 60000);
   ReactGA.initialize(gaTracking);
   ReactGA.pageview(window.location.pathname + window.location.search);
 
@@ -119,6 +122,8 @@ async function init() {
               <ReduxTopBar />
               <ReduxNavBar />
               <div className='main-content'>
+                <ReduxWorkspaceShutdownBanner />
+                <ReduxWorkspaceShutdownPopup />
                 <Switch>
                   {/* process with trailing and duplicate slashes first */}
                   {/* see https://github.com/ReactTraining/react-router/issues/4841#issuecomment-523625186 */}

--- a/src/ecosystemIndex.jsx
+++ b/src/ecosystemIndex.jsx
@@ -51,21 +51,24 @@ import { DAPRouteTracker } from './components/DAPAnalytics';
 import GuppyDataExplorer from './GuppyDataExplorer';
 import isEnabled from './helpers/featureFlags';
 import sessionMonitor from './SessionMonitor';
+import workspaceSessionMonitor from './Workspace/WorkspaceSessionMonitor';
 import Workspace from './Workspace';
 import ResourceBrowser from './ResourceBrowser';
 import Discovery from './Discovery';
+import ReduxWorkspaceShutdownPopup from './Popup/ReduxWorkspaceShutdownPopup';
+import ReduxWorkspaceShutdownBanner from './Popup/ReduxWorkspaceShutdownBanner';
 import ErrorWorkspacePlaceholder from './Workspace/ErrorWorkspacePlaceholder';
 import { ReduxStudyViewer, ReduxSingleStudyViewer } from './StudyViewer/reduxer';
 import NotFound from './components/NotFound';
 
 // monitor user's session
 sessionMonitor.start();
+workspaceSessionMonitor.start();
 
 // render the app after the store is configured
 async function init() {
   const store = await getReduxStore();
 
-  // asyncSetInterval(() => store.dispatch(fetchUser), 60000);
   ReactGA.initialize(gaTracking);
   ReactGA.pageview(window.location.pathname + window.location.search);
 
@@ -120,6 +123,8 @@ async function init() {
               <ReduxTopBar />
               <ReduxNavBar />
               <div className='main-content'>
+                <ReduxWorkspaceShutdownBanner />
+                <ReduxWorkspaceShutdownPopup />
                 <Switch>
                   {/* process with trailing and duplicate slashes first */}
                   {/* see https://github.com/ReactTraining/react-router/issues/4841#issuecomment-523625186 */}

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -51,21 +51,24 @@ import { DAPRouteTracker } from './components/DAPAnalytics';
 import GuppyDataExplorer from './GuppyDataExplorer';
 import isEnabled from './helpers/featureFlags';
 import sessionMonitor from './SessionMonitor';
+import workspaceSessionMonitor from './Workspace/WorkspaceSessionMonitor';
 import Workspace from './Workspace';
 import ResourceBrowser from './ResourceBrowser';
 import Discovery from './Discovery';
+import ReduxWorkspaceShutdownPopup from './Popup/ReduxWorkspaceShutdownPopup';
+import ReduxWorkspaceShutdownBanner from './Popup/ReduxWorkspaceShutdownBanner';
 import ErrorWorkspacePlaceholder from './Workspace/ErrorWorkspacePlaceholder';
 import { ReduxStudyViewer, ReduxSingleStudyViewer } from './StudyViewer/reduxer';
 import NotFound from './components/NotFound';
 
 // monitor user's session
 sessionMonitor.start();
+workspaceSessionMonitor.start();
 
 // render the app after the store is configured
 async function init() {
   const store = await getReduxStore();
 
-  // asyncSetInterval(() => store.dispatch(fetchUser), 60000);
   ReactGA.initialize(gaTracking);
   ReactGA.pageview(window.location.pathname + window.location.search);
 
@@ -129,6 +132,8 @@ async function init() {
               <ReduxTopBar />
               <ReduxNavBar />
               <div className='main-content'>
+                <ReduxWorkspaceShutdownBanner />
+                <ReduxWorkspaceShutdownPopup />
                 <Switch>
                   {/* process with trailing and duplicate slashes first */}
                   {/* see https://github.com/ReactTraining/react-router/issues/4841#issuecomment-523625186 */}

--- a/src/nctIndex.jsx
+++ b/src/nctIndex.jsx
@@ -64,9 +64,12 @@ import { DAPRouteTracker } from './components/DAPAnalytics';
 import GuppyDataExplorer from './GuppyDataExplorer';
 import isEnabled from './helpers/featureFlags';
 import sessionMonitor from './SessionMonitor';
+import workspaceSessionMonitor from './Workspace/WorkspaceSessionMonitor';
 import Workspace from './Workspace';
 import ResourceBrowser from './ResourceBrowser';
 import Discovery from './Discovery';
+import ReduxWorkspaceShutdownPopup from './Popup/ReduxWorkspaceShutdownPopup';
+import ReduxWorkspaceShutdownBanner from './Popup/ReduxWorkspaceShutdownBanner';
 import ErrorWorkspacePlaceholder from './Workspace/ErrorWorkspacePlaceholder';
 import './nctIndex.css';
 import { ReduxStudyViewer, ReduxSingleStudyViewer } from './StudyViewer/reduxer';
@@ -75,12 +78,12 @@ import FooterNIAID from './components/layout/FooterNIAID';
 
 // monitor user's session
 sessionMonitor.start();
+workspaceSessionMonitor.start();
 
 // render the app after the store is configured
 async function init() {
   const store = await getReduxStore();
 
-  // asyncSetInterval(() => store.dispatch(fetchUser), 60000);
   ReactGA.initialize(gaTracking);
   ReactGA.pageview(window.location.pathname + window.location.search);
 
@@ -145,6 +148,8 @@ async function init() {
               <ReduxTopBar />
               <ReduxNavBar />
               <div className='main-content'>
+                <ReduxWorkspaceShutdownBanner />
+                <ReduxWorkspaceShutdownPopup />
                 <Switch>
                   {/* process with trailing and duplicate slashes first */}
                   {/* see https://github.com/ReactTraining/react-router/issues/4841#issuecomment-523625186 */}

--- a/src/workspaceIndex.jsx
+++ b/src/workspaceIndex.jsx
@@ -37,17 +37,20 @@ import GA, { RouteTracker } from './components/GoogleAnalytics';
 import { DAPRouteTracker } from './components/DAPAnalytics';
 import isEnabled from './helpers/featureFlags';
 import sessionMonitor from './SessionMonitor';
+import workspaceSessionMonitor from './Workspace/WorkspaceSessionMonitor';
 import Workspace from './Workspace';
+import ReduxWorkspaceShutdownPopup from './Popup/ReduxWorkspaceShutdownPopup';
+import ReduxWorkspaceShutdownBanner from './Popup/ReduxWorkspaceShutdownBanner';
 import ErrorWorkspacePlaceholder from './Workspace/ErrorWorkspacePlaceholder';
 
 // monitor user's session
 sessionMonitor.start();
+workspaceSessionMonitor.start();
 
 // render the app after the store is configured
 async function init() {
   const store = await getReduxStore();
 
-  // asyncSetInterval(() => store.dispatch(fetchUser), 60000);
   ReactGA.initialize(gaTracking);
   ReactGA.pageview(window.location.pathname + window.location.search);
 
@@ -100,6 +103,8 @@ async function init() {
               <ReduxTopBar />
               <ReduxNavBar />
               <div className='main-content'>
+                <ReduxWorkspaceShutdownBanner />
+                <ReduxWorkspaceShutdownPopup />
                 <Switch>
                   {/* process with trailing and duplicate slashes first */}
                   {/* see https://github.com/ReactTraining/react-router/issues/4841#issuecomment-523625186 */}


### PR DESCRIPTION
Jira Ticket: [HP-305](https://ctds-planx.atlassian.net/browse/HP-305)

Add `workspaceShutdownBanner` and `workspaceShutdownPopup` to alert user that their Jupyter notebook's kernel will be or has been shutdown due to inactivity.

The banner will show up when the notebook kernel's remaining life is less than 5 minutes and stays visible until the user take actions to use the workspace, or after the kernel has been killed and the popup will show to inform use that the workspace has been terminated.

The `Close` button on the popup will trigger a call to terminate workspace to Hatchery, in order to clean up any messes remaining.

ℹ️ _Note: some jupyter notebooks (mostly those without using superslim base image) has a feature to automatically refresh the session every 1 minute if the window is visible, so if you left your browser tab open on the workspace page you will never see the banner/popup. To trigger them, you have to go to another page, or switch to another broser tab_

These banner and button will only show up if Jupyter notebook has `--NotebookApp.shutdown_no_activity_timeout` arg setup and using appropriate Hatchery version

Design doc attached in JIRA ticket. One noteable deviation is that the `workspaceShutdownBanner` is now unclosable. I was hope to be able to wrap the banner close button with a `popconfirm` component so that user can use it to "mute" this banner but the antd `Alert` component currenly doesn't support this. So if we make the banner closable then it will show up after 15 seconds again, which I think is disturbing.

Deployed in https://mingfei.planx-pla.net/workspace (the `Jupyter Notebook with pd` option has been configured to have `--NotebookApp.shutdown_no_activity_timeout=420` for testing)

Screenshots:
<img width="1289" alt="Screen Shot 2021-09-16 at 11 39 27 PM" src="https://user-images.githubusercontent.com/2475897/133725505-ac37c3b9-8446-4bb0-aac1-58c6791815a4.png">
<img width="1294" alt="Screen Shot 2021-09-16 at 11 35 55 PM" src="https://user-images.githubusercontent.com/2475897/133725510-012b7982-a454-461a-bb78-5161f537a121.png">

### New Features
- Add `workspaceShutdownBanner` and `workspaceShutdownPopup` to alert user that their Jupyter notebook's kernel will be or has been shutdown due to inactivity.


### Dependency updates
- This feature depends on Hathcery PR: https://github.com/uc-cdis/hatchery/pull/26