### PR TITLE
Document chart fields in filters

### DIFF
--- a/docs/portal_config.md
+++ b/docs/portal_config.md
@@ -171,6 +171,7 @@ Below is an example, with inline comments describing what each JSON block config
   },
   "dataExplorerConfig": { // required only if featureFlags.explorer is true; configuration for the Data Explorer (/explorer); can be replaced by explorerConfig, see Multi Tab Explorer doc
     "charts": { // optional; indicates which charts to display in the Data Explorer
+      // Note that the fields configured in `charts` must be present in the `filters` section as well
       "project_id": { // required; GraphQL field to query for a chart (ex: this one will display the number of projects, based on the project_id)
         "chartType": "count", // required; indicates this chart will display a “count”
         "title": "Projects" // required; title to display on the chart
@@ -333,6 +334,7 @@ Below is an example, with inline comments describing what each JSON block config
   },
   "fileExplorerConfig": { // optional; configuration for the File Explorer; can be replaced by explorerConfig, see Multi Tab Explorer doc
     "charts": { // optional; indicates which charts to display in the File Explorer
+      // Note that the fields configured in `charts` must be present in the `filters` section as well
       "data_type": { // required; GraphQL field to query for a chart (ex: this one will display a bar chart for data types of the files in the cohort)
         "chartType": "stackedBar", // required; chart type of stack bar
         "title": "File Type" // required; title of chart


### PR DESCRIPTION
Reported by user:
> When configuring charts that appear above the table, `explorerConfig->charts->[my_data_field]`. The field must be listed in the `explorerConfig->filters->[fields]`. Apparently, it is the latter that drives the generation of the histogram query that in turn populates the chart. If the field is missing from `explorerConfig->filters` the chart will not render or log an exception in the browser window.

@mfshao:
> the aggs data was generated by filter fields from the beginning. so it is by the design (or it was)

Document that explorer chart fields must be in filters