### PR TITLE
HP-555 Feat/disco tag dropdown viewer

### DIFF
--- a/docs/portal_config.md
+++ b/docs/portal_config.md
@@ -420,7 +420,16 @@ Below is an example, with inline comments describing what each JSON block config
       },
       "search": {
         "searchBar": {
-          "enabled": true
+          "enabled": true,
+          "inputSubtitle": "Search Bar", // optional, subtitle of search bar
+          "placeholder": "Search studies by keyword", // optional, placeholder text of search input
+          "searchableTextFields": ["study", "age", "publication"] // optional, list of properties in data to make searchable
+                                                                  // if not present, only fields visible in the table will be searchable
+        },
+        "tagSearchDropdown": { // optional, config section for searchable tags
+          "enabled": true,
+          "collapseOnDefault": false, // optional, whether the searchable tag panel is collapsed when loading, default value is "true"
+          "collapsibleButtonText": "Study Characteristics" // optional, display text for the searchable tag panel collapse control button, default value is "Tag Panel"
         }
       },
       "advSearchFilters": {

--- a/src/Discovery/Discovery.css
+++ b/src/Discovery/Discovery.css
@@ -147,7 +147,7 @@
 .discovery-tag {
   cursor: pointer;
   line-height: 18px;
-  font-size: 10px;
+  font-size: 12px;
   box-sizing: border-box;
   border-radius: 5px;
   border-width: 2px;
@@ -196,7 +196,7 @@
   border-color: var(--g3-color__base-blue);
   border-width: 1px;
   border-radius: 7px;
-  max-width: 500px;
+  max-width: 800px;
 }
 
 .discovery-input-subtitle {
@@ -349,6 +349,9 @@
   border-color: var(--g3-color__base-blue);
   min-width: 150px;
   margin-left: 8px;
+  height: 40px;
+  border-width: 1px;
+  border-radius: 7px;
 }
 
 .discovery-header__dropdown-tags-control-panel {

--- a/src/Discovery/Discovery.css
+++ b/src/Discovery/Discovery.css
@@ -371,6 +371,11 @@
   width: 50%;
 }
 
+.discovery-header__dropdown-tags .ant-select-show-search.ant-select:not(.ant-select-customize-input) .ant-select-selector {
+  border-width: 1px;
+  border-radius: 7px;
+}
+
 .discovery-modal {
   box-sizing: border-box;
 }

--- a/src/Discovery/Discovery.css
+++ b/src/Discovery/Discovery.css
@@ -188,7 +188,7 @@
   overflow-y: auto;
 }
 
-.discovery-search-container {
+.discovery-search-container__standalone {
   margin-bottom: 10px;
 }
 

--- a/src/Discovery/Discovery.css
+++ b/src/Discovery/Discovery.css
@@ -97,6 +97,11 @@
   height: 90%;
 }
 
+.discovery-header__dropdown-tags-container {
+  flex: 3 1 60%;
+  height: 90%;
+}
+
 .discovery-header__tags-header {
   padding-left: 50px;
   cursor: default;
@@ -337,6 +342,30 @@
 .discovery-action-bar-button--disabled {
   color: unset;
   border-color: unset;
+}
+
+.discovery-header__dropdown-tags-control-button {
+  color: var(--g3-color__base-blue);
+  border-color: var(--g3-color__base-blue);
+  min-width: 150px;
+  margin-left: 8px;
+}
+
+.discovery-header__dropdown-tags-control-panel {
+  width: 100%;
+  padding-right: 16px;
+  padding-left: 16px;
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+}
+
+.discovery-header__dropdown-tags-display-panel .ant-collapse-header {
+  display: none;
+}
+
+.discovery-header__dropdown-tags-search {
+  width: 50%;
 }
 
 .discovery-modal {

--- a/src/Discovery/Discovery.tsx
+++ b/src/Discovery/Discovery.tsx
@@ -1,12 +1,15 @@
 import React, { useState, useEffect } from 'react';
 import * as JsSearch from 'js-search';
-import { Tag, Popover } from 'antd';
+import {
+  Tag, Popover, Space, Collapse, Button,
+} from 'antd';
 import {
   UnlockOutlined, ClockCircleOutlined, DashOutlined,
 } from '@ant-design/icons';
 import { DiscoveryConfig } from './DiscoveryConfig';
 import './Discovery.css';
 import DiscoverySummary from './DiscoverySummary';
+import DiscoveryTagViewer from './DiscoveryTagViewer';
 import DiscoveryDropdownTagViewer from './DiscoveryDropdownTagViewer';
 import DiscoveryListView from './DiscoveryListView';
 import DiscoveryDetails from './DiscoveryDetails';
@@ -23,6 +26,8 @@ export enum AccessLevel {
   PENDING = 3,
   NOT_AVAILABLE = 4,
 }
+
+const { Panel } = Collapse;
 
 const ARBORIST_READ_PRIV = 'read';
 
@@ -199,6 +204,12 @@ const Discovery: React.FunctionComponent<Props> = (props: Props) => {
   const [discoveryActionStatusMessage, setDiscoveryActionStatusMessage] = useState({
     url: '', message: '', title: '', active: false,
   });
+  const [searchableTagCollapsed, setSearchableTagCollapsed] = useState(
+    config.features.search.tagSearchDropdown
+    && config.features.search.tagSearchDropdown.enabled
+    && (config.features.search.tagSearchDropdown.collapseOnDefault
+      || config.features.search.tagSearchDropdown.collapseOnDefault === undefined),
+  );
 
   const handleSearchChange = (ev) => {
     const { value } = ev.currentTarget;
@@ -476,6 +487,14 @@ const Discovery: React.FunctionComponent<Props> = (props: Props) => {
     config,
   );
 
+  const enableSearchBar = props.config.features.search
+  && props.config.features.search.searchBar
+  && props.config.features.search.searchBar.enabled;
+
+  const enableSearchableTags = props.config.features.search
+  && props.config.features.search.tagSearchDropdown
+  && props.config.features.search.tagSearchDropdown.enabled;
+
   // Disabling noninteractive-tabindex rule because the span tooltip must be focusable as per https://www.w3.org/TR/2017/REC-wai-aria-1.1-20171214/#tooltip
   /* eslint-disable jsx-a11y/no-noninteractive-tabindex */
   return (
@@ -491,22 +510,57 @@ const Discovery: React.FunctionComponent<Props> = (props: Props) => {
           visibleResources={visibleResources}
           config={config}
         />
-        <DiscoveryDropdownTagViewer
-          config={config}
-          studies={props.studies}
-          selectedTags={selectedTags}
-          setSelectedTags={setSelectedTags}
-          searchTerm={searchTerm}
-          setSearchTerm={setSearchTerm}
-        />
+        {(enableSearchableTags) ? (
+          <div className='discovery-header__dropdown-tags-container' id='discovery-tag-filters'>
+            <Space direction='vertical' style={{ width: '100%' }}>
+              <div className='discovery-header__dropdown-tags-control-panel'>
+                {(enableSearchBar)
+                && (
+                  <div className='discovery-header__dropdown-tags-search'>
+                    <DiscoveryMDSSearch
+                      searchTerm={searchTerm}
+                      handleSearchChange={handleSearchChange}
+                      inputSubtitle={config.features.search.searchBar.inputSubtitle}
+                    />
+                  </div>
+                )}
+                <Button
+                  type='default'
+                  className={'discovery-header__dropdown-tags-control-button'}
+                  onClick={() => { setSearchableTagCollapsed(!searchableTagCollapsed); }}
+                >
+                  {`${searchableTagCollapsed ? 'Show' : 'Hide'} ${props.config.features.search.tagSearchDropdown.collapsibleButtonText || 'Tag Panel'}`}
+                </Button>
+              </div>
+              <div className='discovery-header__dropdown-tags-display-panel'>
+                <Collapse activeKey={(searchableTagCollapsed) ? '' : '1'} ghost>
+                  <Panel header='This is panel header 1' key='1'>
+                    <div className='discovery-header__tags-dropdown'>
+                      <DiscoveryDropdownTagViewer
+                        config={config}
+                        studies={props.studies}
+                        selectedTags={selectedTags}
+                        setSelectedTags={setSelectedTags}
+                      />
+                    </div>
+                  </Panel>
+                </Collapse>
+              </div>
+            </Space>
+          </div>
+        ) : (
+          <DiscoveryTagViewer
+            config={config}
+            studies={props.studies}
+            selectedTags={selectedTags}
+            setSelectedTags={setSelectedTags}
+          />
+        )}
       </div>
 
       <div className='discovery-studies-container'>
         {/* Free-form text search box */}
-        { (props.config.features.search
-        && props.config.features.search.searchBar
-        && props.config.features.search.searchBar.enabled
-        && props.config.features.dropdownTagViewer.enabled
+        { (enableSearchBar && !enableSearchableTags
         )
             && (
               <div className='discovery-search-container'>

--- a/src/Discovery/Discovery.tsx
+++ b/src/Discovery/Discovery.tsx
@@ -516,7 +516,7 @@ const Discovery: React.FunctionComponent<Props> = (props: Props) => {
               <div className='discovery-header__dropdown-tags-control-panel'>
                 {(enableSearchBar)
                 && (
-                  <div className='discovery-header__dropdown-tags-search'>
+                  <div className='discovery-search-container discovery-header__dropdown-tags-search'>
                     <DiscoveryMDSSearch
                       searchTerm={searchTerm}
                       handleSearchChange={handleSearchChange}
@@ -575,7 +575,7 @@ const Discovery: React.FunctionComponent<Props> = (props: Props) => {
         { (enableSearchBar && !enableSearchableTags
         )
             && (
-              <div className='discovery-search-container'>
+              <div className='discovery-search-container discovery-search-container__standalone'>
                 <DiscoveryMDSSearch
                   searchTerm={searchTerm}
                   handleSearchChange={handleSearchChange}

--- a/src/Discovery/Discovery.tsx
+++ b/src/Discovery/Discovery.tsx
@@ -547,7 +547,7 @@ const Discovery: React.FunctionComponent<Props> = (props: Props) => {
               <div className='discovery-header__dropdown-tags-display-panel'>
                 <Collapse activeKey={(searchableTagCollapsed) ? '' : '1'} ghost>
                   <Panel header='This is panel header 1' key='1'>
-                    <div className='discovery-header__tags-dropdown'>
+                    <div className='discovery-header__dropdown-tags'>
                       <DiscoveryDropdownTagViewer
                         config={config}
                         studies={props.studies}

--- a/src/Discovery/Discovery.tsx
+++ b/src/Discovery/Discovery.tsx
@@ -7,7 +7,7 @@ import {
 import { DiscoveryConfig } from './DiscoveryConfig';
 import './Discovery.css';
 import DiscoverySummary from './DiscoverySummary';
-import DiscoveryTagViewer from './DiscoveryTagViewer';
+import DiscoveryDropdownTagViewer from './DiscoveryDropdownTagViewer';
 import DiscoveryListView from './DiscoveryListView';
 import DiscoveryDetails from './DiscoveryDetails';
 import DiscoveryAdvancedSearchPanel from './DiscoveryAdvancedSearchPanel';
@@ -491,7 +491,7 @@ const Discovery: React.FunctionComponent<Props> = (props: Props) => {
           visibleResources={visibleResources}
           config={config}
         />
-        <DiscoveryTagViewer
+        <DiscoveryDropdownTagViewer
           config={config}
           studies={props.studies}
           selectedTags={selectedTags}

--- a/src/Discovery/Discovery.tsx
+++ b/src/Discovery/Discovery.tsx
@@ -496,6 +496,8 @@ const Discovery: React.FunctionComponent<Props> = (props: Props) => {
           studies={props.studies}
           selectedTags={selectedTags}
           setSelectedTags={setSelectedTags}
+          searchTerm={searchTerm}
+          setSearchTerm={setSearchTerm}
         />
       </div>
 
@@ -503,7 +505,9 @@ const Discovery: React.FunctionComponent<Props> = (props: Props) => {
         {/* Free-form text search box */}
         { (props.config.features.search
         && props.config.features.search.searchBar
-        && props.config.features.search.searchBar.enabled)
+        && props.config.features.search.searchBar.enabled
+        && props.config.features.dropdownTagViewer.enabled
+        )
             && (
               <div className='discovery-search-container'>
                 <DiscoveryMDSSearch

--- a/src/Discovery/Discovery.tsx
+++ b/src/Discovery/Discovery.tsx
@@ -4,7 +4,7 @@ import {
   Tag, Popover, Space, Collapse, Button,
 } from 'antd';
 import {
-  UnlockOutlined, ClockCircleOutlined, DashOutlined,
+  UnlockOutlined, ClockCircleOutlined, DashOutlined, UpOutlined, DownOutlined, UndoOutlined,
 } from '@ant-design/icons';
 import { DiscoveryConfig } from './DiscoveryConfig';
 import './Discovery.css';
@@ -524,13 +524,25 @@ const Discovery: React.FunctionComponent<Props> = (props: Props) => {
                     />
                   </div>
                 )}
-                <Button
-                  type='default'
-                  className={'discovery-header__dropdown-tags-control-button'}
-                  onClick={() => { setSearchableTagCollapsed(!searchableTagCollapsed); }}
-                >
-                  {`${searchableTagCollapsed ? 'Show' : 'Hide'} ${props.config.features.search.tagSearchDropdown.collapsibleButtonText || 'Tag Panel'}`}
-                </Button>
+                <div className='discovery-header__dropdown-tags-buttons'>
+                  <Button
+                    type='default'
+                    className={'discovery-header__dropdown-tags-control-button'}
+                    disabled={Object.keys(selectedTags).length === 0}
+                    onClick={() => { setSelectedTags({}); }}
+                    icon={<UndoOutlined />}
+                  >
+                    {'Reset Selection'}
+                  </Button>
+                  <Button
+                    type='default'
+                    className={'discovery-header__dropdown-tags-control-button'}
+                    onClick={() => { setSearchableTagCollapsed(!searchableTagCollapsed); }}
+                    icon={(searchableTagCollapsed) ? <DownOutlined /> : <UpOutlined />}
+                  >
+                    {`${props.config.features.search.tagSearchDropdown.collapsibleButtonText || 'Tag Panel'}`}
+                  </Button>
+                </div>
               </div>
               <div className='discovery-header__dropdown-tags-display-panel'>
                 <Collapse activeKey={(searchableTagCollapsed) ? '' : '1'} ghost>

--- a/src/Discovery/DiscoveryConfig.d.ts
+++ b/src/Discovery/DiscoveryConfig.d.ts
@@ -27,10 +27,14 @@ export interface DiscoveryConfig {
                 enabled: boolean,
                 inputSubtitle?: string,
                 placeholder?: string
-                // searchTags: boolean, // not supported, consider removing
                 searchableTextFields?: string[] // list of properties in data to make searchable.
                                                 // if not present, only fields visible in the table
                                                 // will be searchable.
+            },
+            tagSearchDropdown?: {
+                enabled: boolean,
+                collapsibleButtonText?: string
+                collapseOnDefault?: boolean
             }
         },
         authorization: {

--- a/src/Discovery/DiscoveryDropdownTagViewer.tsx
+++ b/src/Discovery/DiscoveryDropdownTagViewer.tsx
@@ -11,6 +11,8 @@ interface DiscoveryTagViewerProps {
   studies?: {__accessible: boolean, [any: string]: any}[]
   selectedTags: any
   setSelectedTags: any
+  searchTerm: any
+  setSearchTerm: any
 }
 
 const DiscoveryDropdownTagViewer: React.FunctionComponent<DiscoveryTagViewerProps> = (props: DiscoveryTagViewerProps) => {

--- a/src/Discovery/DiscoveryDropdownTagViewer.tsx
+++ b/src/Discovery/DiscoveryDropdownTagViewer.tsx
@@ -1,6 +1,6 @@
-import React, { useState } from 'react';
+import React from 'react';
 import {
-  Select, Button, Row, Col,
+  Select, Row, Col, Tag,
 } from 'antd';
 import { DiscoveryConfig } from './DiscoveryConfig';
 
@@ -11,14 +11,12 @@ interface DiscoveryTagViewerProps {
   studies?: {__accessible: boolean, [any: string]: any}[]
   selectedTags: any
   setSelectedTags: any
-  searchTerm: any
-  setSearchTerm: any
 }
 
 const DiscoveryDropdownTagViewer: React.FunctionComponent<DiscoveryTagViewerProps> = (props: DiscoveryTagViewerProps) => {
   // getTagsInCategory returns a list of the unique tags in studies which belong
   // to the specified category.
-  const getTagsInCategory = (category: any, studies: any[] | null):React.ReactNode => {
+  const getTagsInCategory = (category: any, displayName: string, studies: any[] | null):React.ReactNode => {
     if (!studies) {
       return <React.Fragment />;
     }
@@ -38,19 +36,46 @@ const DiscoveryDropdownTagViewer: React.FunctionComponent<DiscoveryTagViewerProp
 
     return (
       <Select
-        mode='tags'
+        mode='multiple'
+        showSearch
         showArrow
         allowClear
         maxTagCount={3}
         style={{ width: '100%' }}
         id={`discovery-tag-column--${category.name}`}
+        placeholder={displayName}
+        onSelect={(tag: string) => {
+          props.setSelectedTags({
+            ...props.selectedTags,
+            [tag]: props.selectedTags[tag] ? undefined : true,
+          });
+        }}
+        onDeselect={(tag: string) => {
+          props.setSelectedTags({
+            ...props.selectedTags,
+            [tag]: props.selectedTags[tag] ? undefined : true,
+          });
+        }}
       >
         { tagArray.map((tag) => (
           <Option
             key={category.name + tag}
             value={tag}
           >
-            {tag}
+            <Tag
+              key={category.name + tag}
+              role='button'
+              tabIndex={0}
+              aria-pressed={props.selectedTags[tag] ? 'true' : 'false'}
+              className={`discovery-header__tag-btn discovery-tag ${(props.selectedTags[tag]) ? 'discovery-tag--selected' : ''}`}
+              aria-label={tag}
+              style={{
+                backgroundColor: props.selectedTags[tag] ? category.color : 'initial',
+                borderColor: category.color,
+              }}
+            >
+              {tag}
+            </Tag>
           </Option>
         ),
         )}
@@ -59,50 +84,44 @@ const DiscoveryDropdownTagViewer: React.FunctionComponent<DiscoveryTagViewerProp
   };
 
   return (
-    <div className='discovery-header__tags-container' id='discovery-tag-filters'>
-      {props.config.tagSelector.title
-      && <h3 className='discovery-header__tags-header'>{props.config.tagSelector.title}</h3>}
-      <Row
-        gutter={{
-          xs: 8, sm: 16, md: 24, lg: 32,
-        }}
-        justify='space-between'
-      >
-        {
-          props.config.tagCategories.map((category) => {
-            if (category.display === false) {
-              return null;
-            }
-            const tags = getTagsInCategory(category, props.studies);
+    <Row
+      gutter={[16, 8]}
+      justify='space-between'
+    >
+      {
+        props.config.tagCategories.map((category) => {
+          if (category.display === false) {
+            return null;
+          }
 
-            let categoryDisplayName = category.displayName;
-            if (!categoryDisplayName) {
+          let categoryDisplayName = category.displayName;
+          if (!categoryDisplayName) {
             // Capitalize category name
-              const categoryWords = category.name.split('_').map((x) => x.toLowerCase());
-              categoryWords[0] = categoryWords[0].charAt(0).toUpperCase()
+            const categoryWords = category.name.split('_').map((x) => x.toLowerCase());
+            categoryWords[0] = categoryWords[0].charAt(0).toUpperCase()
                 + categoryWords[0].slice(1);
-              categoryDisplayName = categoryWords.join(' ');
-            }
+            categoryDisplayName = categoryWords.join(' ');
+          }
 
-            return (
-              <Col
-                className='discovery-header__tag-group'
-                key={category.name}
-                xs={24}
-                sm={24}
-                md={12}
-                lg={6}
-                xl={6}
-                xxl={4}
-              >
-                <h5 className='discovery-header__tag-group-header'>{categoryDisplayName}</h5>
-                { tags }
-              </Col>
-            );
-          })
-        }
-      </Row>
-    </div>
+          const tags = getTagsInCategory(category, categoryDisplayName, props.studies);
+
+          return (
+            <Col
+              className='discovery-header__tag-group'
+              key={category.name}
+              xs={24}
+              sm={24}
+              md={12}
+              lg={12}
+              xl={12}
+              xxl={12}
+            >
+              { tags }
+            </Col>
+          );
+        })
+      }
+    </Row>
   );
 };
 

--- a/src/Discovery/DiscoveryDropdownTagViewer.tsx
+++ b/src/Discovery/DiscoveryDropdownTagViewer.tsx
@@ -31,7 +31,12 @@ const DiscoveryDropdownTagViewer: React.FunctionComponent<DiscoveryTagViewerProp
       });
     });
     const tagArray = Object.keys(tagMap).sort((a, b) => a.localeCompare(b));
-    const valueArray = _.intersection(tagArray, Object.keys(props.selectedTags));
+    // get selected tags which value is not 'undefined'
+    const trulySelectedTags = Object.keys(props.selectedTags).reduce((acc, el) => {
+      if (props.selectedTags[el] !== undefined) acc.push(el);
+      return acc;
+    }, []);
+    const valueArray = _.intersection(tagArray, trulySelectedTags);
 
     return (
       <Select

--- a/src/Discovery/DiscoveryDropdownTagViewer.tsx
+++ b/src/Discovery/DiscoveryDropdownTagViewer.tsx
@@ -1,0 +1,108 @@
+import React, { useState } from 'react';
+import {
+  Select, Button, Row, Col,
+} from 'antd';
+import { DiscoveryConfig } from './DiscoveryConfig';
+
+const { Option } = Select;
+
+interface DiscoveryTagViewerProps {
+  config: DiscoveryConfig
+  studies?: {__accessible: boolean, [any: string]: any}[]
+  selectedTags: any
+  setSelectedTags: any
+}
+
+const DiscoveryDropdownTagViewer: React.FunctionComponent<DiscoveryTagViewerProps> = (props: DiscoveryTagViewerProps) => {
+  // getTagsInCategory returns a list of the unique tags in studies which belong
+  // to the specified category.
+  const getTagsInCategory = (category: any, studies: any[] | null):React.ReactNode => {
+    if (!studies) {
+      return <React.Fragment />;
+    }
+    const tagMap = {};
+    studies.forEach((study) => {
+      const tagField = props.config.minimalFieldMapping.tagsListFieldName;
+      study[tagField].forEach((tag) => {
+        if (tag.category === category.name) {
+          if (tagMap[tag.name] === undefined) {
+            tagMap[tag.name] = 1;
+          }
+          tagMap[tag.name] += 1;
+        }
+      });
+    });
+    const tagArray = Object.keys(tagMap).sort((a, b) => tagMap[b] - tagMap[a]);
+
+    return (
+      <Select
+        mode='tags'
+        id={`discovery-tag-column--${category.name}`}
+        className='discovery-header__tag-column discovery-tag-column'
+      >
+        { tagArray.map((tag) => (
+          <Option
+            key={category.name + tag}
+            value={tag}
+          >
+            {tag}
+          </Option>
+        ),
+        )}
+      </Select>
+    );
+  };
+
+  return (
+    <div className='discovery-header__tags-container' id='discovery-tag-filters'>
+      {props.config.tagSelector.title
+      && <h3 className='discovery-header__tags-header'>{props.config.tagSelector.title}</h3>}
+      <Row
+        gutter={{
+          xs: 8, sm: 16, md: 24, lg: 32,
+        }}
+        justify='space-between'
+      >
+        {
+          props.config.tagCategories.map((category) => {
+            if (category.display === false) {
+              return null;
+            }
+            const tags = getTagsInCategory(category, props.studies);
+
+            let categoryDisplayName = category.displayName;
+            if (!categoryDisplayName) {
+            // Capitalize category name
+              const categoryWords = category.name.split('_').map((x) => x.toLowerCase());
+              categoryWords[0] = categoryWords[0].charAt(0).toUpperCase()
+                + categoryWords[0].slice(1);
+              categoryDisplayName = categoryWords.join(' ');
+            }
+
+            return (
+              <Col
+                className='discovery-header__tag-group'
+                key={category.name}
+                xs={24}
+                sm={24}
+                md={12}
+                lg={6}
+                xl={6}
+                xxl={4}
+              >
+                <h5 className='discovery-header__tag-group-header'>{categoryDisplayName}</h5>
+                { tags }
+              </Col>
+            );
+          })
+        }
+      </Row>
+    </div>
+  );
+};
+
+DiscoveryDropdownTagViewer.defaultProps = {
+  studies: null,
+};
+
+export default DiscoveryDropdownTagViewer;

--- a/src/Discovery/DiscoveryDropdownTagViewer.tsx
+++ b/src/Discovery/DiscoveryDropdownTagViewer.tsx
@@ -37,8 +37,11 @@ const DiscoveryDropdownTagViewer: React.FunctionComponent<DiscoveryTagViewerProp
     return (
       <Select
         mode='tags'
+        showArrow
+        allowClear
+        maxTagCount={3}
+        style={{ width: '100%' }}
         id={`discovery-tag-column--${category.name}`}
-        className='discovery-header__tag-column discovery-tag-column'
       >
         { tagArray.map((tag) => (
           <Option

--- a/src/Discovery/DiscoveryDropdownTagViewer.tsx
+++ b/src/Discovery/DiscoveryDropdownTagViewer.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import _ from 'lodash';
 import {
   Select, Row, Col, Tag,
 } from 'antd';
@@ -25,14 +26,12 @@ const DiscoveryDropdownTagViewer: React.FunctionComponent<DiscoveryTagViewerProp
       const tagField = props.config.minimalFieldMapping.tagsListFieldName;
       study[tagField].forEach((tag) => {
         if (tag.category === category.name) {
-          if (tagMap[tag.name] === undefined) {
-            tagMap[tag.name] = 1;
-          }
-          tagMap[tag.name] += 1;
+          tagMap[tag.name] = 1;
         }
       });
     });
-    const tagArray = Object.keys(tagMap).sort((a, b) => tagMap[b] - tagMap[a]);
+    const tagArray = Object.keys(tagMap).sort((a, b) => a.localeCompare(b));
+    const valueArray = _.intersection(tagArray, Object.keys(props.selectedTags));
 
     return (
       <Select
@@ -44,6 +43,7 @@ const DiscoveryDropdownTagViewer: React.FunctionComponent<DiscoveryTagViewerProp
         style={{ width: '100%' }}
         id={`discovery-tag-column--${category.name}`}
         placeholder={displayName}
+        value={valueArray}
         onSelect={(tag: string) => {
           props.setSelectedTags({
             ...props.selectedTags,

--- a/src/Discovery/DiscoveryTagViewer.tsx
+++ b/src/Discovery/DiscoveryTagViewer.tsx
@@ -26,14 +26,11 @@ const DiscoveryTagViewer: React.FunctionComponent<DiscoveryTagViewerProps> = (pr
       const tagField = props.config.minimalFieldMapping.tagsListFieldName;
       study[tagField].forEach((tag) => {
         if (tag.category === category.name) {
-          if (tagMap[tag.name] === undefined) {
-            tagMap[tag.name] = 1;
-          }
-          tagMap[tag.name] += 1;
+          tagMap[tag.name] = 1;
         }
       });
     });
-    const tagArray = Object.keys(tagMap).sort((a, b) => tagMap[b] - tagMap[a]);
+    const tagArray = Object.keys(tagMap).sort((a, b) => a.localeCompare(b));
 
     return (
       <div>


### PR DESCRIPTION
Jira Ticket: [HP-555](https://ctds-planx.atlassian.net/browse/HP-555)

Add new "searchable tags panel" to discovery page, replacing the old tags area.

This is an optional UI change and can be turned on by putting the following into portal config `discoveryConfig.features.search` section, see `portal-config.md` for more info

> "tagSearchDropdown": {
>           "enabled": true
>    }

Deployed in: https://qa-heal.planx-pla.net/

<img width="1811" alt="Screen Shot 2021-09-28 at 2 50 26 PM" src="https://user-images.githubusercontent.com/2475897/135156078-c675804d-2e7f-4eb6-ba41-6763efa61aa2.png">


### New Features
- Discovery: new "searchable tags panel" can be enabled via config

### Improvements
- Discovery: tags now are sorted by alphabetic orders

### Deployment changes
- Discovery: introduced a new config section `discoveryConfig.features.search.tagSearchDropdown`, see `portal-config.md` for more info
