### PR TITLE
(PXP-8570) Export PFB to arbitrary URL

### DIFF
--- a/docs/export_pfb_to_url.md
+++ b/docs/export_pfb_to_url.md
@@ -1,0 +1,33 @@
+# Export PFB to URL
+
+A new button in the Explorer which allows us to send a PFB of data exported from the explorer to an arbitrary URL.
+Used to transfer data to external analysis platforms, such as Seven Bridges, Terra, and Cavatica.
+
+## Background
+The Explorer already supported exporting selected subjects to Seven Bridges and Terra in PFB format.
+Originally we implemented this feature for just seven bridges and terra in a hardcoded way, e.g. the
+`terraExportURL` portal config. Now, BDCat needs to support sending PFBs to other analysis platforms,
+so we added a more generic way to send a PFB of data to an external URL.
+
+## Implementation
+Adds a new ExplorerButtonGroup button type, `"export-pfb-to-url"`, which has an additional config field `targetURLTemplate`.
+`targetURLTemplate` is the full URL that the PFB should be exported to, including any query params required by the third party
+analysis platform we're sending the PFB to. `targetURLTemplate` MUST include the string `{{PRESIGNED_URL}}` -- this string will
+be replaced by the actual presigned URL of the exported PFB.
+> Example: `"targetURLTemplate": "https://cgc-interop-vayu.sbgenomics.com/import/pfb?URL={{PRESIGNED_URL}}&source=anvil"`
+
+## Config
+```
+"{data,file}ExplorerConfig": {
+    ...
+    "buttons": [
+      {
+        "enabled": true,
+        "type": "export-pfb-to-url",
+        "targetURLTemplate": "https://terra.biodatacatalyst.nhlbi.nih.gov/#import-data?url={{PRESIGNED_URL}}",
+        "title": "Export All to Terra",
+        "rightIcon": "external-link"
+      },
+    ]
+}
+```

--- a/docs/portal_config.md
+++ b/docs/portal_config.md
@@ -297,6 +297,13 @@ Below is an example, with inline comments describing what each JSON block config
       },
       {
         "enabled": true,
+        "type": "export-pfb-to-url", // export PFB to arbitrary URL; see docs/export_pfb_to_url.md
+        "targetURLTemplate": "https://terra.biodatacatalyst.nhlbi.nih.gov/#import-data?url={{PRESIGNED_URL}}", // required if type is `export-pfb-to-url`; `{{PRESIGNED_URL}}` is a required template variable which is replaced by the presigned URL of the exported PFB
+        "title": "Export All to Terra",
+        "rightIcon": "external-link"
+      },
+      {
+        "enabled": true,
         "type": "export-to-workspace", // required; export-to-workspace = export to workspace type
         "title": "Export to Workspace",
         "leftIcon": "datafile",

--- a/src/GuppyDataExplorer/ExplorerButtonGroup/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerButtonGroup/index.jsx
@@ -813,12 +813,6 @@ Currently, in order to export a File PFB, \`enableLimitedFilePFBExport\` must be
       return this.isPFBRunning()
         && this.state.exportingToSevenBridges;
     }
-    if (buttonConfig.type === 'export-pfb-to-url') {
-      // export to seven bridges button is pending if a pfb export job is running
-      // and it's an export to seven bridges job.
-      return this.isPFBRunning()
-        && this.state.exportingPFBToURL;
-    }
     return false;
   };
 

--- a/src/GuppyDataExplorer/ExplorerButtonGroup/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerButtonGroup/index.jsx
@@ -436,7 +436,7 @@ class ExplorerButtonGroup extends React.Component {
   // in the component state, create the pfb with exportToPFB(), and send the
   // pfb to the target url with `sendPFBToURL()`.
   // `sendPFBToURL()` is called from componentWillUpdate.
-  exportPFBToURL = (pfbExportTargetURL) => {
+  exportPFBToURL = (pfbExportTargetURL) => () => {
     this.setState({
       exportingPFBToURL: true,
       pfbExportTargetURL,

--- a/src/GuppyDataExplorer/ExplorerButtonGroup/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerButtonGroup/index.jsx
@@ -954,8 +954,8 @@ Currently, in order to export a File PFB, \`enableLimitedFilePFBExport\` must be
                         return (
                           <Dropdown.Item
                             key={`${btnCfg.type}-${btnCfg.title}`}
-                            leftIcon='datafile'
-                            rightIcon='download'
+                            leftIcon={btnCfg.leftIcon}
+                            rightIcon={btnCfg.rightIcon}
                             onClick={() => ((!this.props.user.username && this.isLoginForDownloadEnabled()
                               && this.isDownloadButton(btnCfg)) ? this.goToLogin() : onClick())}
                           >

--- a/src/GuppyDataExplorer/ExplorerButtonGroup/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerButtonGroup/index.jsx
@@ -716,6 +716,7 @@ Currently, in order to export a File PFB, \`enableLimitedFilePFBExport\` must be
     }
     const pfbJobIsRunning = this.state.exportingToTerra
     || this.state.exportingToSevenBridges
+    || this.state.exportingPFBToURL
     || this.isPFBRunning();
     if (buttonConfig.type === 'export-to-pfb') {
       // disable the pfb export button if any other pfb export jobs are running
@@ -742,6 +743,9 @@ Currently, in order to export a File PFB, \`enableLimitedFilePFBExport\` must be
       if (this.props.buttonConfig.enableLimitedFilePFBExport) {
         return this.state.sourceNodesInCohort.length === 1;
       }
+    }
+    if (buttonConfig.type === 'export-pfb-to-url') {
+      return !pfbJobIsRunning;
     }
     if (buttonConfig.type === 'export') {
       // disable the terra export button if any of the

--- a/src/GuppyDataExplorer/ExplorerButtonGroup/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerButtonGroup/index.jsx
@@ -813,6 +813,12 @@ Currently, in order to export a File PFB, \`enableLimitedFilePFBExport\` must be
       return this.isPFBRunning()
         && this.state.exportingToSevenBridges;
     }
+    if (buttonConfig.type === 'export-pfb-to-url') {
+      // export to seven bridges button is pending if a pfb export job is running
+      // and it's an export to seven bridges job.
+      return this.isPFBRunning()
+        && this.state.exportingPFBToURL;
+    }
     return false;
   };
 

--- a/src/GuppyDataExplorer/ExplorerButtonGroup/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerButtonGroup/index.jsx
@@ -799,7 +799,7 @@ Currently, in order to export a File PFB, \`enableLimitedFilePFBExport\` must be
       // export to pfb button is pending if a pfb export job is running and it's
       // neither an export to terra job or an export to seven bridges job.
       return this.isPFBRunning()
-        && !(this.state.exportingToTerra || this.state.exportingToSevenBridges);
+        && !(this.state.exportingToTerra || this.state.exportingToSevenBridges || this.state.exportingPFBToURL);
     }
     if (buttonConfig.type === 'export' || buttonConfig.type === 'export-files') {
       // export to terra button is pending if a pfb export job is running and
@@ -812,6 +812,10 @@ Currently, in order to export a File PFB, \`enableLimitedFilePFBExport\` must be
       // and it's an export to seven bridges job.
       return this.isPFBRunning()
         && this.state.exportingToSevenBridges;
+    }
+    if (buttonConfig.type === 'export-pfb-to-url') {
+      return this.isPFBRunning()
+        && this.state.exportingPFBToURL;
     }
     return false;
   };


### PR DESCRIPTION
Jira Ticket: [PXP-8570](https://ctds-planx.atlassian.net/browse/PXP-8570)

A new button in the Explorer which allows us to send a PFB of data exported from the explorer to an arbitrary URL.
Used to transfer data to external analysis platforms, such as Seven Bridges, Terra, and Cavatica.


### New Features
- Add `"export-pfb-to-url"` button to Explorer, which allows exporting PFBs to arbitrary URLs.

### Breaking Changes


### Bug Fixes


### Improvements


### Dependency updates


### Deployment changes
<!-- This section should only contain important things devops should know when updating service versions. -->
