### PR TITLE
Revert #950

### DIFF
--- a/docs/study_viewer.md
+++ b/docs/study_viewer.md
@@ -13,14 +13,12 @@ Example configuration:
             "blockFields": ["short_description"],
             // displayed in table:
             "tableFields": ["condition", ...],
-            "hideEmptyFields": false //optional false by default; hides empty fields
         },
         "singleItemConfig": { // optional, if omitted, "listItemConfig" block will be used for both pages
             // displayed outside of table:
             "blockFields": ["long_description"],
             // displayed in table:
             "tableFields": ["condition", ...],
-            "hideEmptyFields": false, //optional false by default; hides empty fields
             // optional configs for side boxes, only for single study viewer
             "sideBoxes": [
                 {

--- a/src/StudyViewer/reduxer.js
+++ b/src/StudyViewer/reduxer.js
@@ -109,13 +109,6 @@ const fetchRequestedAccess = (receivedData) => {
   );
 };
 
-const removeEmptyFields = (inputObj, flag) => {
-  if (flag) {
-    return _.omitBy(inputObj, _.isNil);
-  }
-  return inputObj;
-};
-
 const processDataset = (nameOfIndex, receivedData, itemConfig, displayButtonsFields) => {
   const targetStudyViewerConfig = fetchStudyViewerConfig(nameOfIndex);
   const processedDataset = [];
@@ -127,7 +120,7 @@ const processDataset = (nameOfIndex, receivedData, itemConfig, displayButtonsFie
           processedItem.title = dataElement[targetStudyViewerConfig.titleField];
           processedItem.rowAccessorValue = dataElement[targetStudyViewerConfig.rowAccessor];
           processedItem.blockData = _.pick(dataElement, itemConfig.blockFields);
-          processedItem.tableData = removeEmptyFields(_.pick(dataElement, itemConfig.tableFields), itemConfig.hideEmptyFields);
+          processedItem.tableData = _.pick(dataElement, itemConfig.tableFields);
           processedItem.displayButtonsData = _.pick(dataElement, displayButtonsFields);
           processedItem.accessibleValidationValue = dataElement.auth_resource_path;
           processedItem.accessRequested = !!(requestedAccess


### PR DESCRIPTION
This reverts commit eb3fb03ee73425bc6ad672f21b551851ba9ba5ce.

revert #950 - guppy is getting queried over and over again instead of only once when the component mounts, and guppy eventually crashes

### New Features


### Breaking Changes


### Bug Fixes


### Improvements


### Dependency updates


### Deployment changes
<!-- This section should only contain important things devops should know when updating service versions. -->
