### PR TITLE
fix redux ref

### DIFF
--- a/src/DataDictionary/DataDictionary.jsx
+++ b/src/DataDictionary/DataDictionary.jsx
@@ -18,11 +18,11 @@ class DataDictionary extends React.Component {
   };
 
   handleClickSearchHistoryItem = (keyword) => {
-    this.dictionarySearcherRef.current.getWrappedInstance().launchSearchFromOutside(keyword);
+    this.dictionarySearcherRef.current.launchSearchFromOutside(keyword);
   };
 
   handleClearSearchResult = () => {
-    this.dictionarySearcherRef.current.getWrappedInstance().launchClearSearchFromOutside();
+    this.dictionarySearcherRef.current.launchClearSearchFromOutside();
   };
 
   render() {


### PR DESCRIPTION
It should be no longer needed to call `.getWrappedInstance()` after updating to Redux 6

### Bug Fixes
- Dictionary: fixed a bug causing `clear history` and `clear result` buttons are malfunctioning 
