### PR TITLE
fix(StudyExplorer): Study Details does not display numbers

### DIFF
--- a/src/StudyViewer/StudyDetails.jsx
+++ b/src/StudyViewer/StudyDetails.jsx
@@ -387,6 +387,8 @@ class StudyDetails extends React.Component {
                              );
                            }
                            return item;
+                         } else if (_.isNumeric(item)) {
+                           return item;
                          }
                          if (!item) {
                            return null;


### PR DESCRIPTION
Make sure to follow the DEV guidelines (https://gen3.org/resources/developer/dev-introduction/) before asking for review.

- Describe what this pull request does.

When StudyViewer is configured to show numeric details, they are not displayed.

gitops extract:
`  "studyViewerConfig": [{
    "dataType": "project",
    "title": "projects",
    "titleField": "name",
    "listItemConfig": {
        "blockFields": ["project_description", "full_name", "code"],
        "tableFields": ["_sequencing_files_count", "_subjects_count", "consent_codes"],
        "customFields": [],
        "applicationFields": []
    },
    "fieldMapping": [],
    "rowAccessor": "dbgap_accession_number",
    "openMode": "open-first",
    "openFirstRowAccessor": "",
    "buttons": []
}]`

before the fix:
![before](https://user-images.githubusercontent.com/25582125/149715509-30561272-e6d9-417d-8c48-a1173202aecb.png)

after the fix:
![after](https://user-images.githubusercontent.com/25582125/149715501-a6f37c0e-338c-4459-911c-f0a50f05d029.png)


### Bug Fixes
Display Numeric Values on Study Details



