### PR TITLE
Fix PRC chart tooltips and Study viewer API call

### DIFF
--- a/src/Covid19Dashboard/index.jsx
+++ b/src/Covid19Dashboard/index.jsx
@@ -198,7 +198,7 @@ class Covid19Dashboard extends React.Component {
         <p>{monthNames[date.getUTCMonth()]} {date.getUTCDate()}, {date.getUTCFullYear()}</p>
         {
           props.payload.map((data, i) => {
-            const val = typeof (rawData[data.name]) === 'number' ? rawData[data.name].toLocaleString() : rawData[data.name];
+            const val = typeof (rawData[data.dataKey]) === 'number' ? rawData[data.dataKey].toLocaleString() : rawData[data.dataKey];
             return (
               <p
                 style={{ color: data.stroke }}

--- a/src/StudyViewer/reduxer.js
+++ b/src/StudyViewer/reduxer.js
@@ -109,7 +109,15 @@ const fetchRequestedAccess = (receivedData) => {
     method: 'POST',
     body: JSON.stringify(body),
   }).then(
-    ({ data }) => data,
+    ({ status, data }) => {
+      switch (status) {
+        case 200:
+          return data;
+        default:
+          console.error('Unable to get requested access:', status, data);
+          return {};
+        }
+    },
   );
 };
 


### PR DESCRIPTION
Jira Ticket: COV-1111

Since https://github.com/uc-cdis/data-portal/pull/967, in the data source the "confirmed" data is in field "C" and the "deaths" data in field "D". The recharts `Line` names were updated so the legend would display "confirmed" and "deaths" instead of "C" and "D". We need to update `renderLocationPopupTooltip` as well to use `dataKey` ("C" and "D") instead of `name` ("confirmed" and "deaths") when fetching values from the data source, or the tooltip only reads undefined data.

### Bug Fixes
- PRC homepage: fix chart tooltips

### Improvements
- Study viewer: log an error when getting a non-200 status code from Requestor and do not process error data
