### PR TITLE
PXP-9341 Allow customizing the intro button text

### DIFF
--- a/docs/portal_config.md
+++ b/docs/portal_config.md
@@ -96,25 +96,21 @@ Below is an example, with inline comments describing what each JSON block config
         {
           "icon": "dictionary", // required; icon from /img/icons for the button
           "link": "/DD", // required; the link for the button
-          "color": "#a2a2a2", // optional; hex color of the icon
           "name": "Dictionary" // required; text for the button
         },
         {
           "icon": "exploration",
           "link": "/explorer",
-          "color": "#a2a2a2",
           "name": "Exploration"
         },
         {
           "icon": "workspace",
           "link": "/workspace",
-          "color": "#a2a2a2",
           "name": "Workspace"
         },
         {
           "icon": "profile",
           "link": "/identity",
-          "color": "#a2a2a2",
           "name": "Profile"
         }
       ]

--- a/docs/resource_browser.md
+++ b/docs/resource_browser.md
@@ -10,8 +10,7 @@ Example configuration:
                 {
                     "name": "Resource Browser",
                     "link": "/resource-browser",
-                    "icon": "query",
-                    "color": "#a2a2a2"
+                    "icon": "query"
                 }
             ]
         }

--- a/src/components/Introduction.jsx
+++ b/src/components/Introduction.jsx
@@ -9,7 +9,10 @@ import { userHasCreateOrUpdateOnAnyProject } from '../authMappingUtils';
 class Introduction extends Component {
   render() {
     let buttonText = 'Submit Data';
-    if (useArboristUI) {
+    if (this.props.data.buttonText) {
+      buttonText = this.props.data.buttonText;
+    }
+    else if (useArboristUI) {
       if (userHasCreateOrUpdateOnAnyProject(this.props.userAuthMapping)) {
         buttonText = 'Submit/Browse Data';
       } else {

--- a/src/components/Introduction.jsx
+++ b/src/components/Introduction.jsx
@@ -10,9 +10,8 @@ class Introduction extends Component {
   render() {
     let buttonText = 'Submit Data';
     if (this.props.data.buttonText) {
-      buttonText = this.props.data.buttonText;
-    }
-    else if (useArboristUI) {
+      ({ buttonText } = this.props.data);
+    } else if (useArboristUI) {
       if (userHasCreateOrUpdateOnAnyProject(this.props.userAuthMapping)) {
         buttonText = 'Submit/Browse Data';
       } else {

--- a/src/components/layout/Footer.jsx
+++ b/src/components/layout/Footer.jsx
@@ -93,7 +93,7 @@ const LogoObject = PropTypes.shape({
 });
 
 const FooterLink = PropTypes.shape({
-  text: PropTypes.string.isRequired,
+  text: PropTypes.string,
   href: PropTypes.string.isRequired,
 });
 


### PR DESCRIPTION
Jira Ticket: [PXP-9341](https://ctds-planx.atlassian.net/browse/PXP-9341)

- I removed the `navigation.items.color` config from the docs because I tried using it and looked for it in the code, and it doesn't seem to do anything.
- `footer.links.text` is optional ([link](https://github.com/uc-cdis/data-portal/blob/4d888b06dc68c3059f17cf4ce445b9098edce385/src/components/layout/Footer.jsx#L73)), so remove the warning when it's not provided

### Improvements
- The homepage introduction button link could already be customized, now also allow customizing the button text
