### PR TITLE
PRC homepage: date slider style improvements

### DIFF
--- a/src/Covid19Dashboard/IllinoisMapChart/index.jsx
+++ b/src/Covid19Dashboard/IllinoisMapChart/index.jsx
@@ -610,6 +610,8 @@ class IllinoisMapChart extends React.Component {
   render() {
     return (
       <div className='map-chart map-chart-il'>
+        {this.state.sliderDate
+        && <MapSlider title={`View Data by Date: ${this.state.sliderDate}`} value={this.state.sliderValue} maxValue={this.state.sliderDataLastUpdated} onChange={this.sliderOnChange} />}
         {this.state.mapColors
         && (
           <ControlPanel
@@ -684,8 +686,7 @@ class IllinoisMapChart extends React.Component {
             />
           </ReactMapGL.Source>
         </ReactMapGL.InteractiveMap>
-        {this.state.sliderDate
-        && <MapSlider title={`View data by date: ${this.state.sliderDate}`} value={this.state.sliderValue} maxValue={this.state.sliderDataLastUpdated} onChange={this.sliderOnChange} />}
+
       </div>
     );
   }

--- a/src/Covid19Dashboard/MapSlider/index.jsx
+++ b/src/Covid19Dashboard/MapSlider/index.jsx
@@ -12,7 +12,7 @@ function MapSlider({
     <div id='map-slider' className='map-slider top'>
       <div className='map-overlay-inner' id='map-overlay-inner'>
         <label>
-          <span>{title}</span>
+          <h3>{title}</h3>
           <input id='slider' type='range' min='0' max={(maxValue)} step='1' value={value} onChange={(e) => { onChange(Number(e.target.value)); }} />
         </label>
       </div>

--- a/src/Covid19Dashboard/MapSlider/mapSlider.less
+++ b/src/Covid19Dashboard/MapSlider/mapSlider.less
@@ -14,7 +14,7 @@
     color: #000;
     background: rgba(255,255,255,0.85);
     box-shadow: 0 2px 4px rgba(0,0,0,0.3);
-    margin: 10px;
+    padding: 10px;
     visibility: visible;
 }
 .map-slider input {

--- a/src/Covid19Dashboard/MapSlider/mapSlider.less
+++ b/src/Covid19Dashboard/MapSlider/mapSlider.less
@@ -5,7 +5,7 @@
     width: 50%;
     min-width: 15rem;
     max-width: 20rem;
-    padding: 1rem;
+    margin: 10px;
     float: right;
     z-index: 3;
 }
@@ -14,7 +14,7 @@
     color: #000;
     background: rgba(255,255,255,0.85);
     box-shadow: 0 2px 4px rgba(0,0,0,0.3);
-    padding: 0.5rem;
+    margin: 10px;
     visibility: visible;
 }
 .map-slider input {

--- a/src/Covid19Dashboard/MapSlider/mapSlider.less
+++ b/src/Covid19Dashboard/MapSlider/mapSlider.less
@@ -14,7 +14,6 @@
     color: #000;
     background: rgba(255,255,255,0.85);
     box-shadow: 0 2px 4px rgba(0,0,0,0.3);
-    border-radius: 3px;
     padding: 0.5rem;
     visibility: visible;
 }

--- a/src/Covid19Dashboard/MapSlider/mapSlider.less
+++ b/src/Covid19Dashboard/MapSlider/mapSlider.less
@@ -3,20 +3,19 @@
     font: 12px/20px 'Helvetica Neue', Arial, Helvetica, sans-serif;
     position: relative;
     width: 50%;
-    min-width: 150px;
-    max-width: 500px;
-    bottom: 120px;
-    padding: 10px;
+    min-width: 15rem;
+    max-width: 20rem;
+    padding: 1rem;
     float: right;
     z-index: 3;
 }
 .map-slider .map-overlay-inner {
     /* background-color: rgba(77, 0, 102, 0.7); */
-    background-color: black;
-    box-shadow: 0 1px 2px rgba(0, 0, 0, 0.2);
+    color: #000;
+    background: rgba(255,255,255,0.85);
+    box-shadow: 0 2px 4px rgba(0,0,0,0.3);
     border-radius: 3px;
-    padding: 10px;
-    margin-bottom: 10px;
+    padding: 0.5rem;
     visibility: visible;
 }
 .map-slider input {
@@ -26,11 +25,4 @@
     position: relative;
     margin: 0;
     cursor: ew-resize;
-}
-.map-slider span {
-    font-size: 24px;
-    line-height: 24px;
-    display: block;
-    margin: 0 0 10px;
-    color: white;
 }

--- a/src/Covid19Dashboard/index.jsx
+++ b/src/Covid19Dashboard/index.jsx
@@ -43,6 +43,41 @@ class Covid19Dashboard extends React.Component {
     Object.entries(dashboardDataLocations).forEach(
       (e) => this.props.fetchDashboardData(e[0], e[1]),
     );
+
+    // scrolling effect added to show homepage starting from covid counts
+    const targetNode = document.getElementsByClassName('covid19-dashboard_panel')[0];
+
+    //defined a scroll flag to only scroll for one time
+    var scrollFlag = false;
+
+    // Options for the observer (which mutations to observe)
+    const config = { attributes: true, childList: true, subtree: true };
+
+    // Callback function to execute when mutations are observed
+    const callback = function(mutationsList, observer) {
+        for(const mutation of mutationsList) {
+            if (mutation.type === 'childList' && mutation.addedNodes[0] == document.getElementById('map-slider') && scrollFlag == false) {
+              var covid19DashboardDiv = document.getElementsByClassName("covid19-dashboard_counts")[0].getBoundingClientRect();
+              window.scrollTo({
+                  top: covid19DashboardDiv.y,
+                  left: 0,
+                  behavior: 'smooth'
+              });
+              scrollFlag = true;
+            }
+        }
+    };
+
+    /**
+     * An observer instance linked to the callback function
+     * reference for MutationObserver: https://developer.mozilla.org/en-US/docs/Web/API/MutationObserver
+     */
+
+    const observer = new MutationObserver(callback);
+
+    // Start observing the target node for configured mutations
+    observer.observe(targetNode, config);
+
   }
 
   getTotalCounts() {

--- a/src/Covid19Dashboard/index.jsx
+++ b/src/Covid19Dashboard/index.jsx
@@ -51,7 +51,7 @@ class Covid19Dashboard extends React.Component {
     let scrollFlag = false;
 
     // Options for the observer (which mutations to observe)
-    const config = { attributes: true, childList: true, subtree: true };
+    const config = { attributes: false, childList: true, subtree: true };
 
     // Callback function to execute when mutations are observed
     const callback = function (mutationsList, observer) {
@@ -62,7 +62,7 @@ class Covid19Dashboard extends React.Component {
           window.scrollTo({
             top: covid19DashboardDiv.y,
             left: 0,
-            behavior: 'smooth',
+            behavior: 'smooth'
           });
           scrollFlag = true;
           observer.disconnect();

--- a/src/Covid19Dashboard/index.jsx
+++ b/src/Covid19Dashboard/index.jsx
@@ -47,25 +47,27 @@ class Covid19Dashboard extends React.Component {
     // scrolling effect added to show homepage starting from covid counts
     const targetNode = document.getElementsByClassName('covid19-dashboard_panel')[0];
 
-    //defined a scroll flag to only scroll for one time
-    var scrollFlag = false;
+    // defined a scroll flag to only scroll for one time
+    let scrollFlag = false;
 
     // Options for the observer (which mutations to observe)
     const config = { attributes: true, childList: true, subtree: true };
 
     // Callback function to execute when mutations are observed
-    const callback = function(mutationsList, observer) {
-        for(const mutation of mutationsList) {
-            if (mutation.type === 'childList' && mutation.addedNodes[0] == document.getElementById('map-slider') && scrollFlag == false) {
-              var covid19DashboardDiv = document.getElementsByClassName("covid19-dashboard_counts")[0].getBoundingClientRect();
-              window.scrollTo({
-                  top: covid19DashboardDiv.y,
-                  left: 0,
-                  behavior: 'smooth'
-              });
-              scrollFlag = true;
-            }
+    const callback = function (mutationsList, observer) {
+      Object.values(mutationsList).forEach((mutation) => {
+        // condiiton to scroll when "map-chart-il" div adds "map-slider" in the childList
+        if (mutation.type === 'childList' && mutation.addedNodes[0] === document.getElementById('map-slider') && scrollFlag === false) {
+          const covid19DashboardDiv = document.getElementsByClassName('covid19-dashboard_counts')[0].getBoundingClientRect();
+          window.scrollTo({
+            top: covid19DashboardDiv.y,
+            left: 0,
+            behavior: 'smooth',
+          });
+          scrollFlag = true;
+          observer.disconnect();
         }
+      });
     };
 
     /**
@@ -77,7 +79,6 @@ class Covid19Dashboard extends React.Component {
 
     // Start observing the target node for configured mutations
     observer.observe(targetNode, config);
-
   }
 
   getTotalCounts() {

--- a/src/Covid19Dashboard/index.jsx
+++ b/src/Covid19Dashboard/index.jsx
@@ -43,42 +43,6 @@ class Covid19Dashboard extends React.Component {
     Object.entries(dashboardDataLocations).forEach(
       (e) => this.props.fetchDashboardData(e[0], e[1]),
     );
-
-    // scrolling effect added to show homepage starting from covid counts
-    const targetNode = document.getElementsByClassName('covid19-dashboard_panel')[0];
-
-    // defined a scroll flag to only scroll for one time
-    let scrollFlag = false;
-
-    // Options for the observer (which mutations to observe)
-    const config = { attributes: false, childList: true, subtree: true };
-
-    // Callback function to execute when mutations are observed
-    const callback = function (mutationsList, observer) {
-      Object.values(mutationsList).forEach((mutation) => {
-        // condiiton to scroll when "map-chart-il" div adds "map-slider" in the childList
-        if (mutation.type === 'childList' && mutation.addedNodes[0] === document.getElementById('map-slider') && scrollFlag === false) {
-          const covid19DashboardDiv = document.getElementsByClassName('covid19-dashboard_counts')[0].getBoundingClientRect();
-          window.scrollTo({
-            top: covid19DashboardDiv.y,
-            left: 0,
-            behavior: 'smooth'
-          });
-          scrollFlag = true;
-          observer.disconnect();
-        }
-      });
-    };
-
-    /**
-     * An observer instance linked to the callback function
-     * reference for MutationObserver: https://developer.mozilla.org/en-US/docs/Web/API/MutationObserver
-     */
-
-    const observer = new MutationObserver(callback);
-
-    // Start observing the target node for configured mutations
-    observer.observe(targetNode, config);
   }
 
   getTotalCounts() {


### PR DESCRIPTION
~Code is added to add a scroll-down effect to map div when the PRC homepage is loaded. 
MutationObserver is added to the `covid19-dashboard_panel` and it will observe attributes and nodes added to it. Once  `map-slider` has been added as a child to this div, scroll method will be applied~

~Reference for MutationObserver : https://developer.mozilla.org/en-US/docs/Web/API/MutationObserver~

### Improvements
- PRC homepage: date slider style improvements