### PR TITLE
pin npm to 8.5.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ services:
     - docker
 
 before_install:
-    - npm install -g npm@8
+    - npm install -g npm@8.5.5
 
 install:
     - npm ci

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ services:
     - docker
 
 before_install:
-    - npm install -g npm@8.5.5
+    - npm install -g npm@8.5
 
 install:
     - npm ci

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/* \
     && ln -sf /dev/stdout /var/log/nginx/access.log \
     && ln -sf /dev/stderr /var/log/nginx/error.log \
-    && npm install -g npm@8
+    && npm install -g npm@8.5.5
 
 ARG APP=dev
 ARG BASENAME

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/* \
     && ln -sf /dev/stdout /var/log/nginx/access.log \
     && ln -sf /dev/stderr /var/log/nginx/error.log \
-    && npm install -g npm@8.5.5
+    && npm install -g npm@8.5
 
 ARG APP=dev
 ARG BASENAME


### PR DESCRIPTION
Pin npm to 8.5 versions since the new dep resolution logic introduced in npm 8.6 breaks the overrides, need time to investigate




### Improvements
- Pin npm to 8.5 versions 

