### PR TITLE
feat(PXP-9641): Atlas Timeout Banner and Popup

### DIFF
--- a/src/Analysis/AnalysisApp.jsx
+++ b/src/Analysis/AnalysisApp.jsx
@@ -82,7 +82,7 @@ class AnalysisApp extends React.Component {
       );
     default:
       return (
-        <AtlasWrapper handleIframeApp={this.handleIframeApp}></AtlasWrapper>
+        <AtlasWrapper handleIframeApp={this.handleIframeApp} url={`${this.state.app.applicationUrl}`}></AtlasWrapper>
       );
     }
   }

--- a/src/Analysis/AnalysisApp.jsx
+++ b/src/Analysis/AnalysisApp.jsx
@@ -9,6 +9,7 @@ import ReduxGWASApp from './GWASApp/ReduxGWASApp';
 import ReduxGWASUIApp from './GWASUIApp/ReduxGWASUIApp';
 import { analysisApps } from '../localconf';
 import './AnalysisApp.css';
+import AtlasWrapper from './AtlasWrapper/AtlasWrapper';
 
 class AnalysisApp extends React.Component {
   constructor(props) {
@@ -81,17 +82,7 @@ class AnalysisApp extends React.Component {
       );
     default:
       return (
-        <React.Fragment>
-          <div className='analysis-app__iframe-wrapper'>
-            <iframe
-              className='analysis-app__iframe'
-              title='Analysis App'
-              frameBorder='0'
-              src={`${this.state.app.applicationUrl}`}
-              onLoad={this.handleIframeApp}
-            />
-          </div>
-        </React.Fragment>
+        <AtlasWrapper handleIframeApp={this.handleIframeApp}></AtlasWrapper>
       );
     }
   }

--- a/src/Analysis/AtlasWrapper/AtlasSessionMonitor.js
+++ b/src/Analysis/AtlasWrapper/AtlasSessionMonitor.js
@@ -1,6 +1,9 @@
 import getReduxStore from '../reduxStore';
 
+const EVENT_TYPE = "message"; // from event types https://developer.mozilla.org/en-US/docs/Web/API/EventSource/message_event
+
 export class AtlasSessionMonitor {
+
   constructor() {
     this.checkStatusInterval = 15 * 1000;
     this.atlasShutdownAlertLimit = 5 * 60 * 1000; // Time limit for banner/popup begins to show
@@ -11,6 +14,7 @@ export class AtlasSessionMonitor {
     if (this.interval) { // interval already started
       return;
     }
+    window.addEventListener(EVENT_TYPE, () => this.updateUserActivity(), false); // receives mouseovers from atlas
     this.checkAtlasStatus();
     this.interval = setInterval(
       () => this.checkCheckStatus(),
@@ -21,30 +25,47 @@ export class AtlasSessionMonitor {
   stop() {
     if (this.interval) {
       clearInterval(this.interval);
+      window.removeEventListener(EVENT_TYPE, () => this.updateUserActivity(), false);
       this.interval = null; // make sure the interval got cleared
     }
   }
 
-  checkAtlasStatus() {
-    if (idleLimit < 0) {
-        this.stop()
-    }
-    if (idleLimit > 0 && lastActivityTime > 0) {
-        getReduxStore().then(
-            (store) => {
-                const remainingSessionTime = idleLimit  - (Date.now() - lastActivityTime);
-              if (remainingSessionTime <= 0) { // kernel has died due to inactivity
-                store.dispatch({ type: 'UPDATE_ATLAS_ALERT', data: { showShutdownBanner: false, showShutdownPopup: true, idleTimeLimit: idleTimeLimit } });
-                this.stop();
-              } else if (remainingSessionTime <= this.workspaceShutdownAlertLimit) {
-                store.dispatch({ type: 'UPDATE_ATLAS_ALERT', data: { showShutdownBanner: true, showShutdownPopup: false, remainingWorkspaceKernelLife } });
-              } else if (store.getState().popups.showShutdownBanner) {
-                store.dispatch({ type: 'UPDATE_ATLAS_ALERT', data: { showShutdownBanner: false } });
-              }
-            },
-          );
-        }
-    }
+  // logoutUser() {
+  //   // don't hit the logout endpoint over and over if the popup is already shown
+  //   if (this.popupShown) {
+  //     return;
+  //   }
+
+  //   getReduxStore().then((store) => {
+  //     store.dispatch(logoutAPI(true));
+  //     this.popupShown = true;
+  //   });
+  // }
+
+  updateUserActivity() {
+    this.mostRecentActivityTimestamp = Date.now();
+  }
+
+  // checkAtlasStatus() {
+  //   if (idleLimit < 0) {
+  //       this.stop()
+  //   }
+  //   if (idleLimit > 0 && lastActivityTime > 0) {
+  //       getReduxStore().then(
+  //           (store) => {
+  //               const remainingSessionTime = idleLimit  - (Date.now() - lastActivityTime);
+  //             if (remainingSessionTime <= 0) { // kernel has died due to inactivity
+  //               store.dispatch({ type: 'UPDATE_ATLAS_ALERT', data: { showShutdownBanner: false, showShutdownPopup: true, idleTimeLimit: idleTimeLimit } });
+  //               this.stop();
+  //             } else if (remainingSessionTime <= this.workspaceShutdownAlertLimit) {
+  //               store.dispatch({ type: 'UPDATE_ATLAS_ALERT', data: { showShutdownBanner: true, showShutdownPopup: false, remainingWorkspaceKernelLife } });
+  //             } else if (store.getState().popups.showShutdownBanner) {
+  //               store.dispatch({ type: 'UPDATE_ATLAS_ALERT', data: { showShutdownBanner: false } });
+  //             }
+  //           },
+  //         );
+  //       }
+  //   }
 }
 
 const singleton = new AtlasSessionMonitor();

--- a/src/Analysis/AtlasWrapper/AtlasSessionMonitor.js
+++ b/src/Analysis/AtlasWrapper/AtlasSessionMonitor.js
@@ -46,26 +46,28 @@ export class AtlasSessionMonitor {
     this.mostRecentActivityTimestamp = Date.now();
   }
 
-  // checkAtlasStatus() {
-  //   if (idleLimit < 0) {
-  //       this.stop()
-  //   }
-  //   if (idleLimit > 0 && lastActivityTime > 0) {
-  //       getReduxStore().then(
-  //           (store) => {
-  //               const remainingSessionTime = idleLimit  - (Date.now() - lastActivityTime);
-  //             if (remainingSessionTime <= 0) { // kernel has died due to inactivity
-  //               store.dispatch({ type: 'UPDATE_ATLAS_ALERT', data: { showShutdownBanner: false, showShutdownPopup: true, idleTimeLimit: idleTimeLimit } });
-  //               this.stop();
-  //             } else if (remainingSessionTime <= this.workspaceShutdownAlertLimit) {
-  //               store.dispatch({ type: 'UPDATE_ATLAS_ALERT', data: { showShutdownBanner: true, showShutdownPopup: false, remainingWorkspaceKernelLife } });
-  //             } else if (store.getState().popups.showShutdownBanner) {
-  //               store.dispatch({ type: 'UPDATE_ATLAS_ALERT', data: { showShutdownBanner: false } });
-  //             }
-  //           },
-  //         );
-  //       }
-  //   }
+  checkAtlasStatus() {
+    if (idleLimit < 0) {
+      this.stop()
+    }
+    if (idleLimit > 0 && lastActivityTime > 0) {
+      getReduxStore().then(
+          (store) => {
+              const remainingSessionTime = idleLimit  - (Date.now() - lastActivityTime);
+            if (remainingSessionTime <= 0) {
+              store.dispatch({ type: 'UPDATE_ATLAS_ALERT', data: { showShutdownBanner: false, showShutdownPopup: true, idleTimeLimit: idleTimeLimit } });
+              this.stop();
+            } else if (remainingSessionTime <= this.workspaceShutdownAlertLimit) {
+              store.dispatch({ type: 'UPDATE_ATLAS_ALERT', data: { showShutdownBanner: true, showShutdownPopup: false, remainingSessionTime } });
+            } else if (store.getState().popups.showShutdownBanner) {
+              store.dispatch({ type: 'UPDATE_ATLAS_ALERT', data: { showShutdownBanner: false } });
+            }
+          },
+        );
+      }
+
+  }
+
 }
 
 const singleton = new AtlasSessionMonitor();

--- a/src/Analysis/AtlasWrapper/AtlasSessionMonitor.js
+++ b/src/Analysis/AtlasWrapper/AtlasSessionMonitor.js
@@ -1,0 +1,51 @@
+import getReduxStore from '../reduxStore';
+
+export class AtlasSessionMonitor {
+  constructor() {
+    this.checkStatusInterval = 15 * 1000;
+    this.atlasShutdownAlertLimit = 5 * 60 * 1000; // Time limit for banner/popup begins to show
+    this.interval = null;
+  }
+
+  start() {
+    if (this.interval) { // interval already started
+      return;
+    }
+    this.checkAtlasStatus();
+    this.interval = setInterval(
+      () => this.checkCheckStatus(),
+      this.checkStatusInterval,
+    );
+  }
+
+  stop() {
+    if (this.interval) {
+      clearInterval(this.interval);
+      this.interval = null; // make sure the interval got cleared
+    }
+  }
+
+  checkAtlasStatus() {
+    if (idleLimit < 0) {
+        this.stop()
+    }
+    if (idleLimit > 0 && lastActivityTime > 0) {
+        getReduxStore().then(
+            (store) => {
+                const remainingSessionTime = idleLimit  - (Date.now() - lastActivityTime);
+              if (remainingSessionTime <= 0) { // kernel has died due to inactivity
+                store.dispatch({ type: 'UPDATE_ATLAS_ALERT', data: { showShutdownBanner: false, showShutdownPopup: true, idleTimeLimit: idleTimeLimit } });
+                this.stop();
+              } else if (remainingSessionTime <= this.workspaceShutdownAlertLimit) {
+                store.dispatch({ type: 'UPDATE_ATLAS_ALERT', data: { showShutdownBanner: true, showShutdownPopup: false, remainingWorkspaceKernelLife } });
+              } else if (store.getState().popups.showShutdownBanner) {
+                store.dispatch({ type: 'UPDATE_ATLAS_ALERT', data: { showShutdownBanner: false } });
+              }
+            },
+          );
+        }
+    }
+}
+
+const singleton = new AtlasSessionMonitor();
+export default singleton;

--- a/src/Analysis/AtlasWrapper/AtlasWrapper.jsx
+++ b/src/Analysis/AtlasWrapper/AtlasWrapper.jsx
@@ -1,0 +1,28 @@
+import React, { useState, useEffect } from 'react';
+
+const AtlasWrapper = ({ handleIframeApp }) => {
+    const EVENT_TYPE = "message"; // from event types https://developer.mozilla.org/en-US/docs/Web/API/EventSource/message_event
+
+    useEffect(() => {
+        window.addEventListener(EVENT_TYPE, (event) => {
+            console.log("got message (event.origin): " + event.origin);
+            console.log("got message (event.data): " + event.data);
+            // TODO: update user session when "message" posted from child iframe
+        });
+    }, [])
+    return (
+        <React.Fragment>
+          <div className='analysis-app__iframe-wrapper'>
+            <iframe
+              className='analysis-app__iframe'
+              title='Analysis App'
+              frameBorder='0'
+              src={`${this.state.app.applicationUrl}`}
+              onLoad={handleIframeApp}
+            />
+          </div>
+        </React.Fragment>
+    )
+}
+
+export default AtlasWrapper

--- a/src/Analysis/AtlasWrapper/AtlasWrapper.jsx
+++ b/src/Analysis/AtlasWrapper/AtlasWrapper.jsx
@@ -1,28 +1,38 @@
 import React, { useState, useEffect } from 'react';
+import ReduxAtlasShutdownPopup from '../../Popup/ReduxAtlasShutdownBanner';
+import { AtlasSessionMonitor } from './AtlasSessionMonitor';
+
 
 const AtlasWrapper = ({ handleIframeApp, url }) => {
-    const EVENT_TYPE = "message"; // from event types https://developer.mozilla.org/en-US/docs/Web/API/EventSource/message_event
+  const EVENT_TYPE = "message"; // from event types https://developer.mozilla.org/en-US/docs/Web/API/EventSource/message_event
 
-    useEffect(() => {
-        window.addEventListener(EVENT_TYPE, (event) => {
-            console.log("got message (event.origin): " + event.origin);
-            console.log("got message (event.data): " + event.data);
-            // TODO: update user session when "message" posted from child iframe
-        });
-    }, [])
-    return (
-        <React.Fragment>
-          <div className='analysis-app__iframe-wrapper'>
-            <iframe
-              className='analysis-app__iframe'
-              title='Analysis App'
-              frameBorder='0'
-              src={url}
-              onLoad={handleIframeApp}
-            />
-          </div>
-        </React.Fragment>
-    )
+  useEffect(() => {
+    AtlasSessionMonitor.start();
+  });
+
+  useEffect(() => {
+    window.addEventListener(EVENT_TYPE, (event) => {
+      console.log("got message (event.origin): " + event.origin);
+      console.log("got message (event.data): " + event.data);
+      // TODO: update user session when "message" posted from child iframe
+    });
+  }, []);
+
+  return (
+    <React.Fragment>
+      <ReduxAtlasShutdownBanner></ReduxAtlasShutdownBanner>
+      <ReduxAtlasShutdownPopup></ReduxAtlasShutdownPopup>
+      <div className='analysis-app__iframe-wrapper'>
+        <iframe
+          className='analysis-app__iframe'
+          title='Analysis App'
+          frameBorder='0'
+          src={url}
+          onLoad={handleIframeApp}
+        />
+      </div>
+    </React.Fragment>
+  )
 }
 
 export default AtlasWrapper

--- a/src/Analysis/AtlasWrapper/AtlasWrapper.jsx
+++ b/src/Analysis/AtlasWrapper/AtlasWrapper.jsx
@@ -4,18 +4,10 @@ import { AtlasSessionMonitor } from './AtlasSessionMonitor';
 
 
 const AtlasWrapper = ({ handleIframeApp, url }) => {
-  const EVENT_TYPE = "message"; // from event types https://developer.mozilla.org/en-US/docs/Web/API/EventSource/message_event
+
 
   useEffect(() => {
     AtlasSessionMonitor.start();
-  });
-
-  useEffect(() => {
-    window.addEventListener(EVENT_TYPE, (event) => {
-      console.log("got message (event.origin): " + event.origin);
-      console.log("got message (event.data): " + event.data);
-      // TODO: update user session when "message" posted from child iframe
-    });
   }, []);
 
   return (

--- a/src/Analysis/AtlasWrapper/AtlasWrapper.jsx
+++ b/src/Analysis/AtlasWrapper/AtlasWrapper.jsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react';
 
-const AtlasWrapper = ({ handleIframeApp }) => {
+const AtlasWrapper = ({ handleIframeApp, url }) => {
     const EVENT_TYPE = "message"; // from event types https://developer.mozilla.org/en-US/docs/Web/API/EventSource/message_event
 
     useEffect(() => {
@@ -17,7 +17,7 @@ const AtlasWrapper = ({ handleIframeApp }) => {
               className='analysis-app__iframe'
               title='Analysis App'
               frameBorder='0'
-              src={`${this.state.app.applicationUrl}`}
+              src={url}
               onLoad={handleIframeApp}
             />
           </div>

--- a/src/Popup/ReduxAtlasShutdownBanner.jsx
+++ b/src/Popup/ReduxAtlasShutdownBanner.jsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import { connect } from 'react-redux';
+import { Alert } from 'antd';
+
+const shutdownBannerMapState = (state) => ({
+    showShutdownBanner: state.popups.showShutdownBanner,
+    remainingSessionTime: state.popups.remainingSessionTime,
+  });
+
+const shutdownBannerMapDispatch = () => ({});
+
+const ReduxAtlasShutdownPopup = connect(shutdownBannerMapState, shutdownBannerMapDispatch)(
+    ({ showShutdownBanner, remainingSessionTime }) => {
+      if (!showShutdownBanner) {
+        return null;
+      }
+      const remainingTimeInMinutes = (Math.ceil(remainingSessionTime / 60 / 1000));
+      return (
+        <Alert
+          message={(
+            <React.Fragment>
+              Your session will be terminated in <b>{remainingTimeInMinutes}</b> {` ${(remainingTimeInMinutes === 1) ? 'minute' : 'minutes'}`} due to inactivity. Close this to refresh session.
+            </React.Fragment>
+          )}
+          banner
+        />
+      );
+    },
+  );
+
+export default ReduxAtlasShutdownPopup;

--- a/src/Popup/ReduxAtlasShutdownPopup.jsx
+++ b/src/Popup/ReduxAtlasShutdownPopup.jsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import { connect } from 'react-redux';
+import Popup from '../components/Popup';
+// import { SessionMonitor } from '../SessionMonitor';
+
+const atlasShutdownPopupMapState = (state) => ({
+    showShutdownPopup: state.popups.showShutdownPopup,
+    idleTimeLimit: state.popups.idleTimeLimit,
+});
+
+const atlasShutdownPopupMapDispatch = (dispatch) => ({
+    closeAtlasShutdownPopup: () => dispatch({ type: 'UPDATE_ATLAS_ALERT', data: { showShutdownPopup: false, showShutdownBanner: false } }),
+  });
+
+  const ReduxAtlasShutdownPopup = connect(atlasShutdownPopupMapState, atlasShutdownPopupMapDispatch)(
+    ({ showShutdownPopup, idleTimeLimit, closeAtlasShutdownPopup }) => {
+      if (!showShutdownPopup) {
+        return null;
+      }
+      const handleClose = () => {
+        closeAtlasShutdownPopup();
+
+        // TODO: check somehow if user is on atlas page instead (url contains `OHDSI%20Atlas`)
+        // if (SessionMonitor.isUserOnPage('atlas')) {
+        //   window.location.reload(); // if user is on workspace page, refresh to update
+        // }
+      };
+
+      return (
+        <Popup
+          message={`Your session has been terminated because it has been inactive for longer than ${idleTimeLimit / 60 / 1000} minutes.`}
+          rightButtons={[
+            {
+              caption: 'Close',
+              fn: handleClose,
+            },
+          ]}
+        />
+      );
+    },
+  );
+
+  export default ReduxAtlasShutdownPopup;


### PR DESCRIPTION
[PXP-9641](https://ctds-planx.atlassian.net/browse/PXP-9641)

- Describe what this pull request does.
Atlas is an inframe so any work done by the user will not count as manipulating the portal. thus causing the portal to timeout.
This work is to add a banner with a counter for timeout at the top of the Atlas page, and a pop up for "Are you still logged in? Y/N" 2 min or so before timeout.
