### PR TITLE
Catch errors while querying total counts

### DIFF
--- a/src/GuppyDataExplorer/ExplorerButtonGroup/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerButtonGroup/index.jsx
@@ -695,6 +695,9 @@ Currently, in order to export a File PFB, \`enableLimitedFilePFBExport\` must be
           let caseIDList = caseIDResult.map((i) => i[caseField]);
           caseIDList = _.uniq(caseIDList);
           const fileType = this.props.guppyConfig.manifestMapping.resourceIndexType;
+          if (!fileType) {
+            throw Error('guppyConfig.manifestMapping.resourceIndexType is not defined');
+          }
           const countResult = await this.props.getTotalCountsByTypeAndFilter(fileType, {
             [caseFieldInFileIndex]: {
               selectedValues: caseIDList,


### PR DESCRIPTION
When `fileType` is `undefined`, a graphql query is still generated and it fails. The field should be explicitly required.
Relates to https://github.com/uc-cdis/guppy/pull/142

### Improvements
- Catch errors while querying total counts
