### PR TITLE
Fix to run qa.planx-pla.net

### DIFF
--- a/runWebpack.sh
+++ b/runWebpack.sh
@@ -61,7 +61,7 @@ gitops_config() {
     echo "ERROR: gitops_config requires hostname arg"
     return 1
   fi
-  if [[ "$hostname" =~ ^qa- ]]; then
+  if [[ "$hostname" =~ ^qa[-.] ]]; then
     gitRepo="gitops-qa"
   elif [[ "$hostname" =~ planx-pla.net$ ]]; then
     gitRepo="gitops-dev"


### PR DESCRIPTION
Fix `runWebpack.sh` to be able to run `HOSTNAME=qa.planx-pla.net NODE_ENV=auto bash ./runWebpack.sh`:
```
ERROR: gitops_config - manifest does not exist ../gitops-dev/qa.planx-pla.net/manifest.json
```