### PR TITLE
Fix/gwas submission params

### DIFF
--- a/src/Analysis/GWASUIApp/CaseControlGWAS.jsx
+++ b/src/Analysis/GWASUIApp/CaseControlGWAS.jsx
@@ -562,7 +562,7 @@ const CaseControlGWAS = (props) => {
             // hare_codes: // TODO
             maf_threshold: Number(mafThreshold),
             imputation_score_cutoff: Number(imputationScore),
-            template_version: "gwas-template-e4b5fa6bf50d7ccd6dcb058d225c1da674d67e5b",
+            template_version: "gwas-template-latest",
             source_id: sourceId,
             case_cohort_definition_id: caseCohortDefinitionId,
             control_cohort_definition_id: controlCohortDefinitionId,

--- a/src/Analysis/GWASUIApp/CaseControlGWAS.jsx
+++ b/src/Analysis/GWASUIApp/CaseControlGWAS.jsx
@@ -559,7 +559,7 @@ const CaseControlGWAS = (props) => {
             covariates,
             out_prefix: Date.now().toString(),
             outcome: "-1",
-            // hare_codes: // TODO
+            hare_population: selectedCaseHare, // TODO: single selection for both case and control
             maf_threshold: Number(mafThreshold),
             imputation_score_cutoff: Number(imputationScore),
             template_version: "gwas-template-latest",

--- a/src/Analysis/GWASUIApp/QuantitativeGWAS.jsx
+++ b/src/Analysis/GWASUIApp/QuantitativeGWAS.jsx
@@ -438,7 +438,7 @@ const QuantitativeGWAS = (props) => {
       covariates,
       out_prefix: Date.now().toString(),
       outcome: selectedOutcome,
-      // hare_code: selectedHare, // TODO - align w/ Zuyi
+      hare_population: selectedHare,
       maf_threshold: Number(mafThreshold),
       imputation_score_cutoff: Number(imputationScore),
       template_version: 'gwas-template-latest',

--- a/src/Analysis/GWASUIApp/QuantitativeGWAS.jsx
+++ b/src/Analysis/GWASUIApp/QuantitativeGWAS.jsx
@@ -441,7 +441,7 @@ const QuantitativeGWAS = (props) => {
       // hare_code: selectedHare, // TODO - align w/ Zuyi
       maf_threshold: Number(mafThreshold),
       imputation_score_cutoff: Number(imputationScore),
-      template_version: 'gwas-template-e4b5fa6bf50d7ccd6dcb058d225c1da674d67e5b',
+      template_version: 'gwas-template-latest',
       source_id: sourceId,
       case_cohort_definition_id: cohortDefinitionId,
       control_cohort_definition_id: '-1',


### PR DESCRIPTION
* Set gwas template name to `gwas-template-latest` to make life easier until we make a PR to read it from configuration
* add the `hare_population` parameter to the request to submit the workflow (for now using Case selection in case/control)