### PR TITLE
fix(hare): pass concept value name

### DIFF
--- a/src/Analysis/GWASUIApp/CaseControlGWAS.jsx
+++ b/src/Analysis/GWASUIApp/CaseControlGWAS.jsx
@@ -75,6 +75,7 @@ const CaseControlGWAS = (props) => {
     const [selectedHare, setSelectedHare] = useState('');
     const [selectedHareDescription, setSelectedHareDescription] = useState('-select one of the ancestry groups below-');
     const [selectedHareValueAsConceptId, setSelectedHareValueAsConceptId] = useState(0);
+    const [selectedHareValueName, setSelectedHareValueName] = useState('');
 
     const [selectedCaseSize, setSelectedCaseSize] = useState(0);
     const [selectedControlSize, setSelectedControlSize] = useState(0);
@@ -496,7 +497,7 @@ const CaseControlGWAS = (props) => {
                                         <Dropdown.Item
                                             key={`${datum.concept_value}`}
                                             value={`${datum.concept_value}`}
-                                            onClick={() => {setSelectedHare(datum.concept_value); setSelectedHareValueAsConceptId(datum.concept_value_as_concept_id);}}
+                                            onClick={() => {setSelectedHare(datum.concept_value); setSelectedHareValueAsConceptId(datum.concept_value_as_concept_id); setSelectedHareValueName(datum.concept_value_name); }}
                                         >
                                             {<div>{getHareAndDescriptionUsingValueAndBreakDownItems(datum.concept_value, dataCase.concept_breakdown, dataControl.concept_breakdown)}</div>}
                                         </Dropdown.Item>
@@ -569,7 +570,7 @@ const CaseControlGWAS = (props) => {
             covariates: selectedCovariates.map((val) => val.prefixed_concept_id),
             out_prefix: Date.now().toString(),
             outcome: "-1",
-            hare_population: selectedHare,
+            hare_population: selectedHareValueName,
             hare_concept_id: hareConceptId,
             maf_threshold: Number(mafThreshold),
             imputation_score_cutoff: Number(imputationScore),
@@ -602,6 +603,7 @@ const CaseControlGWAS = (props) => {
         setSelectedControlCohort(undefined);
         setSelectedCaseCohort(undefined);
         setSelectedHare('');
+        setSelectedHareValueName('');
         setSelectedHareDescription('-select one of the ancestry groups below-');
         setSelectedHareValueAsConceptId(0);
         setGwasJobName('');

--- a/src/Analysis/GWASUIApp/QuantitativeGWAS.jsx
+++ b/src/Analysis/GWASUIApp/QuantitativeGWAS.jsx
@@ -67,6 +67,7 @@ const QuantitativeGWAS = (props) => {
   const [selectedPhenotype, setSelectedPhenotype] = useState(undefined);
   const [selectedCovariates, setSelectedCovariates] = useState([]);
   const [selectedHare, setSelectedHare] = useState('');
+  const [selectedHareValueName, setSelectedHareValueName] = useState('');
   const [selectedHareDescription, setSelectedHareDescription] = useState('-select one of the ancestry groups below-');
   const [gwasJobName, setGwasJobName] = useState('');
 
@@ -484,7 +485,7 @@ const QuantitativeGWAS = (props) => {
                 <Dropdown.Item
                   key={`${datum.concept_value}`}
                   value={`${datum.concept_value}`}
-                  onClick={() => setSelectedHare(datum.concept_value)}
+                  onClick={() => setSelectedHare(datum.concept_value); setSelectedHareValueName(datum.concept_value_name); }
                 >
                   {<div>{getHareAndDescription(datum)}</div>}
                 </Dropdown.Item>
@@ -503,7 +504,7 @@ const QuantitativeGWAS = (props) => {
       covariates,
       out_prefix: Date.now().toString(),
       outcome: selectedOutcome,
-      hare_population: selectedHare,
+      hare_population: selectedHareValueName,
       hare_concept_id: hareConceptId,
       maf_threshold: Number(mafThreshold),
       imputation_score_cutoff: Number(imputationScore),
@@ -534,6 +535,7 @@ const QuantitativeGWAS = (props) => {
     setCohortDefinitionId(undefined);
     setSelectedCohort(undefined);
     setSelectedHare('');
+    setSelectedHareValueName('');
     setSelectedHareDescription('-select one of the ancestry groups below-');
     setGwasJobName('');
     props.refreshWorkflows();

--- a/src/Analysis/GWASUIApp/QuantitativeGWAS.jsx
+++ b/src/Analysis/GWASUIApp/QuantitativeGWAS.jsx
@@ -485,7 +485,7 @@ const QuantitativeGWAS = (props) => {
                 <Dropdown.Item
                   key={`${datum.concept_value}`}
                   value={`${datum.concept_value}`}
-                  onClick={() => setSelectedHare(datum.concept_value); setSelectedHareValueName(datum.concept_value_name); }
+                  onClick={() => { setSelectedHare(datum.concept_value); setSelectedHareValueName(datum.concept_value_name);}}
                 >
                   {<div>{getHareAndDescription(datum)}</div>}
                 </Dropdown.Item>


### PR DESCRIPTION
The short names (e.g., `ASN`) were still being passed to argo wrapper which causes a problem since the CSV will write out the long name. Added even more state vars for the other string. We really should have only 1 state for that whole hare object tbh.