### PR TITLE
fix(cd-delete): dont delete all custom dich covariates

### DIFF
--- a/src/Analysis/GWASWizard/GWASCaseControl.jsx
+++ b/src/Analysis/GWASWizard/GWASCaseControl.jsx
@@ -52,8 +52,8 @@ const GWASCaseControl = ({ resetGWASType, refreshWorkflows }) => {
     setSelectedDichotomousCovariates((prevCD) => [...prevCD, cd]);
   };
 
-  const handleCDRemove = (id) => {
-    setSelectedDichotomousCovariates((prevCD) => [...prevCD.filter((cd) => cd.id !== id)]);
+  const handleCDRemove = (uuid) => {
+    setSelectedDichotomousCovariates((prevCD) => [...prevCD.filter((cd) => cd.uuid !== uuid)]);
   };
 
   const handleHareChange = (hare, allCaseHares, allControlHares) => {

--- a/src/Analysis/GWASWizard/GWASQuantitative.jsx
+++ b/src/Analysis/GWASWizard/GWASQuantitative.jsx
@@ -52,8 +52,8 @@ const GWASQuantitative = ({ resetGWASType, refreshWorkflows }) => {
     setSelectedDichotomousCovariates((prevCDArr) => [...prevCDArr, cd]);
   };
 
-  const handleCDRemove = (id) => {
-    setSelectedDichotomousCovariates((prevCD) => [...prevCD.filter((cd) => cd.id !== id)]);
+  const handleCDRemove = (uuid) => {
+    setSelectedDichotomousCovariates((prevCD) => [...prevCD.filter((cd) => cd.uuid !== uuid)]);
   };
 
   const handleHareChange = (hare) => {

--- a/src/Analysis/GWASWizard/shared/CustomDichotomousSelect.jsx
+++ b/src/Analysis/GWASWizard/shared/CustomDichotomousSelect.jsx
@@ -84,7 +84,7 @@ const CustomDichotomousSelect = ({
                 width: 300,
               }}
               actions={[
-                <DeleteOutlined onClick={(d) => handleCDRemove(d.uuid)} key='delete' />,
+                <DeleteOutlined onClick={() => handleCDRemove(cd.uuid)} key='delete' />,
               ]}
             >
               <Meta


### PR DESCRIPTION
### Bug Fixes
deleting custom dichotomous covariate doesnt delete all of them anymore
*filter was returning empty array each time