### PR TITLE
Fix attrition row update

### DIFF
--- a/src/Analysis/GWASWizard/shared/AttritionTable.stories.jsx
+++ b/src/Analysis/GWASWizard/shared/AttritionTable.stories.jsx
@@ -73,6 +73,14 @@ MockedSuccess.parameters = {
         console.log(cohortmiddlewarepath);
         console.log(cohortdefinition);
         rowCount++;
+        if (rowCount == 12) {
+          // simulate empty response scenario:
+          return res(
+            ctx.delay(200*rowCount),
+            ctx.json({
+              concept_breakdown: null})
+          );
+        }
         return res(
           ctx.delay(200*rowCount),
           ctx.json({

--- a/src/Analysis/GWASWizard/shared/AttritionTableRow.jsx
+++ b/src/Analysis/GWASWizard/shared/AttritionTableRow.jsx
@@ -48,16 +48,18 @@ const AttritionTableRow = ({
       setBreakdownSize(filteredBreakdown
         .reduce((acc, curr) => acc + curr.persons_in_cohort_with_value, 0));
       setBreakdownColumns(filteredBreakdown);
+    } else {
+      setBreakdownSize(0);
+      setBreakdownColumns([]);
     }
   }, [breakdown, cohortDefinitionId, covariateSubset, sourceId]);
 
   useEffect(() => {
-    if (breakdownColumns.length) {
-      setAfr(getSizeByColumn('AFR'));
-      setAsn(getSizeByColumn('ASN'));
-      setEur(getSizeByColumn('EUR'));
-      setHis(getSizeByColumn('HIS'));
-    }
+    setAfr(getSizeByColumn('AFR'));
+    setAsn(getSizeByColumn('ASN'));
+    setEur(getSizeByColumn('EUR'));
+    setHis(getSizeByColumn('HIS'));
+
   }, [breakdownColumns]);
 
   return (


### PR DESCRIPTION
Jira Ticket: [VADC-204](https://ctds-planx.atlassian.net/browse/VADC-204)


### Bug Fixes

- fixes the bug where an attrition row would not always update: when removing a covariate just above another one that is 100% missing, the latter one would get the counts of the previous one (i.e. the counts were not updated)
 

