### PR TITLE
Makes whole cards clickable in GWASUIApp.jsx

### DIFF
--- a/src/Analysis/GWASUIApp/GWASUIApp.css
+++ b/src/Analysis/GWASUIApp/GWASUIApp.css
@@ -333,9 +333,9 @@
 }
 
 .GWASUI-attritionTable {
-    display: flex;
-    width: 100%;
-    flex-direction: row;
+  display: flex;
+  width: 100%;
+  flex-direction: row;
 }
 
 .GWASUI-attritionRow .ant-collapse {

--- a/src/Analysis/GWASUIApp/GWASUIApp.css
+++ b/src/Analysis/GWASUIApp/GWASUIApp.css
@@ -130,6 +130,16 @@
   padding: 10px;
 }
 
+.GWASUI-typeSelector div .ant-card {
+  cursor: pointer;
+  border: 2px solid var(--g3-color__silver);
+  border-radius: 5px;
+}
+
+.GWASUI-typeSelector div .ant-card:hover {
+  border-color: white;
+}
+
 .GWASUI-typeTitle {
   float: relative;
 }

--- a/src/Analysis/GWASUIApp/GWASUIApp.jsx
+++ b/src/Analysis/GWASUIApp/GWASUIApp.jsx
@@ -1,8 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
-import {
-  Checkbox, Card, Space,
-} from 'antd';
+import { Card, Space } from 'antd';
 import { fetchAndSetCsrfToken } from '../../configs';
 import GWASQuantitative from '../GWASWizard/GWASQuantitative';
 import GWASCaseControl from '../GWASWizard/GWASCaseControl';
@@ -26,17 +24,18 @@ const GWASUIApp = (props) => {
   }, [props]);
 
   if (!gwasTypeSelected) {
-    const isEnterOrSpace = (event) => (event.key === 'Enter' || event.key === ' ' || event.key === 'Spacebar' || event.keycode === '32' || event.keycode === '13');
+    const isEnterOrSpace = (event) => (event.key === 'Enter' || event.key === ' ' || event.key === 'Spacebar'
+      || event.keycode === '32' || event.keycode === '13');
 
-    const handleKeyPress = (event, gwasType) => {
-      if (isEnterOrSpace(event)) {
-        triggerNavigation(gwasType);
-      }
+    const triggerNavigation = (gwasTypeInput) => {
+      setGwasType(gwasTypeInput);
+      setGwasTypeSelected(true);
     };
 
-    const triggerNavigation = (gwasType) => {
-      setGwasType(gwasType);
-      setGwasTypeSelected(true);
+    const handleKeyPress = (event, gwasTypeInput) => {
+      if (isEnterOrSpace(event)) {
+        triggerNavigation(gwasTypeInput);
+      }
     };
 
     return (
@@ -48,8 +47,7 @@ const GWASUIApp = (props) => {
                 title='Case Control GWAS'
                 bordered
                 style={cardContent}
-
-                tabIndex='1'
+                tabIndex='0'
                 role='button'
                 aria-label='Case Control GWAS'
                 onKeyPress={(e) => handleKeyPress(e, 'caseControl')}
@@ -68,7 +66,7 @@ const GWASUIApp = (props) => {
                 title='Quantitative Phenotype'
                 bordered
                 style={cardContent}
-                tabIndex='1'
+                tabIndex='0'
                 role='button'
                 aria-label='Quantitative Phenotype'
                 onKeyPress={(e) => handleKeyPress(e, 'quantitative')}

--- a/src/Analysis/GWASUIApp/GWASUIApp.jsx
+++ b/src/Analysis/GWASUIApp/GWASUIApp.jsx
@@ -26,12 +26,35 @@ const GWASUIApp = (props) => {
   }, [props]);
 
   if (!gwasTypeSelected) {
+    const isEnterOrSpace = (event) => (event.key === 'Enter' || event.key === ' ' || event.key === 'Spacebar' || event.keycode === '32' || event.keycode === '13');
+
+    const handleKeyPress = (event, gwasType) => {
+      if (isEnterOrSpace(event)) {
+        triggerNavigation(gwasType);
+      }
+    };
+
+    const triggerNavigation = (gwasType) => {
+      setGwasType(gwasType);
+      setGwasTypeSelected(true);
+    };
+
     return (
       <React.Fragment>
         <Space direction={'vertical'} style={{ width: '100%' }} align={'center'}>
           <div className='GWASUI-typeSelector'>
             <div>
-              <Card title='Case Control GWAS' bordered style={cardContent}>
+              <Card
+                title='Case Control GWAS'
+                bordered
+                style={cardContent}
+
+                tabIndex='1'
+                role='button'
+                aria-label='Case Control GWAS'
+                onKeyPress={(e) => handleKeyPress(e, 'caseControl')}
+                onClick={() => triggerNavigation('caseControl')}
+              >
                 <p>
                   Genome-wide association studies (GWAS) for a case-control study.
                   Here, the genotypes of roughly equal number of diseased (“cases”) and healthy (“controls”)
@@ -39,33 +62,27 @@ const GWASUIApp = (props) => {
                   Cases are encoded as ‘1’ while controls are encoded as ‘0’ and a binary model is used.
                 </p>
               </Card>
-              <div style={cardContent}>
-                <Checkbox onChange={() => {
-                  setGwasType('caseControl');
-                  setGwasTypeSelected(true);
-                }}
-                />
-              </div>
             </div>
             <div>
-              <Card title='Quantitative Phenotype' bordered style={cardContent}>
+              <Card
+                title='Quantitative Phenotype'
+                bordered
+                style={cardContent}
+                tabIndex='1'
+                role='button'
+                aria-label='Quantitative Phenotype'
+                onKeyPress={(e) => handleKeyPress(e, 'quantitative')}
+                onClick={() => triggerNavigation('quantitative')}
+              >
                 <p>
                   Genome-wide association studies (GWAS) for quantitative phenotype.
                   Here, GWAS evaluates statistical association between genetic variation and a continuous phenotype.
                   A phenotype, also called a trait, can be any measured or observed property of an individual.
                 </p>
               </Card>
-              <div style={cardContent}>
-                <Checkbox onChange={() => {
-                  setGwasType('quantitative');
-                  setGwasTypeSelected(true);
-                }}
-                />
-              </div>
             </div>
           </div>
         </Space>
-
       </React.Fragment>
     );
   }


### PR DESCRIPTION
Jira Ticket: [VADC-213](https://ctds-planx.atlassian.net/browse/VADC-213)
<!--
Make sure to follow the DEV guidelines (https://gen3.org/resources/developer/dev-introduction/) before asking for review.

- Describe what this pull request does.
- Add short descriptive bullet points for each section if relevant. Keep in mind that they will be parsed automatically to generate official release notes.
- Test manually.
- Maintain or increase the test coverage (if relevant).
- Update the documentation, or justify if not needed.

-->

### New Features
* This makes the whole of the cards on the Gen3 GWAS clickable. 
* It also allows for the user to navigate to them using their keyboard (by pressing the tab key) and trigger them using either the space bar or enter key. Adds a hover state for the cards modeled after hover state used on cards on previous page (App selection UI)
* Include basic ADA accessibility code (tabIndex and aria-labels)
* Removes checkbox interaction

### Breaking Changes
* None

### Bug Fixes
* None

### Improvements
* Addition of hover state and accessibility code 

### Screenshots

##### BEFORE: Screenshot showing that navigation occurs via check-boxes below the cards.
![image](https://user-images.githubusercontent.com/113449836/193657314-3d59e084-2b27-4992-a3dc-c93b1957fafd.png)

##### AFTER: GIF showing navigation via keyboard using tab and enter or spacebar, following by navigation with mouse. 
![output](https://user-images.githubusercontent.com/113449836/193657012-87949075-af8c-4f00-9a8f-7df56c88e2c9.gif)




