### PR TITLE
fix: auth calc

### DIFF
--- a/src/Discovery/index.tsx
+++ b/src/Discovery/index.tsx
@@ -104,7 +104,7 @@ const DiscoveryWithMDSBackend: React.FC<{
           let accessible: AccessLevel;
           if (supportedValues.pending.enabled && dataAvailabilityField && study[dataAvailabilityField] === 'pending') {
             accessible = AccessLevel.PENDING;
-          } else if (supportedValues.notAvailable.enabled && (study[authzField] === undefined || study[authzField] === '')) {
+          } else if (supportedValues.notAvailable.enabled && !study[authzField]) {
             accessible = AccessLevel.NOT_AVAILABLE;
           } else {
             let authMapping;


### PR DESCRIPTION



### Bug Fixes
- Discovery: fixed a bug which causes study with `authz == null` incorrectly showing as `OTHER` accessibility level

