### PR TITLE
Style/gwas pipeline padding

### DIFF
--- a/src/Analysis/GWASUIApp/GWASUIApp.css
+++ b/src/Analysis/GWASUIApp/GWASUIApp.css
@@ -393,3 +393,7 @@
 .GWASUI-mt-15 {
   margin-top: 15px;
 }
+
+.GWASUI-no-padding {
+  padding: 0;
+}

--- a/src/Analysis/GWASUIApp/GWASUIApp.css
+++ b/src/Analysis/GWASUIApp/GWASUIApp.css
@@ -383,3 +383,9 @@
   align-items: right;
   flex: 7;
 }
+
+label.GWASUI-label.asterisk:before {
+  content: "*";
+  margin: 0 2px 0 -10px;
+  color: red;
+}

--- a/src/Analysis/GWASUIApp/GWASUIApp.css
+++ b/src/Analysis/GWASUIApp/GWASUIApp.css
@@ -397,3 +397,8 @@
 .GWASUI-no-padding {
   padding: 0;
 }
+
+.GWASUI-no-top-spacing {
+  padding-top: 0;
+  margin-top: 0;
+}

--- a/src/Analysis/GWASUIApp/GWASUIApp.css
+++ b/src/Analysis/GWASUIApp/GWASUIApp.css
@@ -332,7 +332,7 @@
   text-overflow: ellipsis;
 }
 
-.GWASUI-label.asterisk:before {
+.GWASUI-asterisk:before {
   content: "*";
   margin: 0 2px 0 -10px;
   color: red;

--- a/src/Analysis/GWASUIApp/GWASUIApp.css
+++ b/src/Analysis/GWASUIApp/GWASUIApp.css
@@ -4,7 +4,7 @@
   border: 1px dashed #e9e9e9;
   border-radius: 2px;
   background-color: #fafafa;
-  padding-top: 40px;
+  padding-top: 25px;
   padding-bottom: 40px;
   display: flex;
   flex-direction: column;

--- a/src/Analysis/GWASUIApp/GWASUIApp.css
+++ b/src/Analysis/GWASUIApp/GWASUIApp.css
@@ -334,7 +334,7 @@
 
 .GWASUI-asterisk:before {
   content: "*";
-  margin: 0 2px 0 -10px;
+  margin: 0 3px 0 -10px;
   color: red;
 }
 

--- a/src/Analysis/GWASUIApp/GWASUIApp.css
+++ b/src/Analysis/GWASUIApp/GWASUIApp.css
@@ -332,6 +332,12 @@
   text-overflow: ellipsis;
 }
 
+.GWASUI-label.asterisk:before {
+  content: "*";
+  margin: 0 2px 0 -10px;
+  color: red;
+}
+
 .GWASUI-attritionTable {
   display: flex;
   width: 100%;
@@ -384,8 +390,6 @@
   flex: 7;
 }
 
-label.GWASUI-label.asterisk:before {
-  content: "*";
-  margin: 0 2px 0 -10px;
-  color: red;
+.GWASUI-mt-15 {
+  margin-top: 15px;
 }

--- a/src/Analysis/GWASWizard/CovariateReview.jsx
+++ b/src/Analysis/GWASWizard/CovariateReview.jsx
@@ -75,7 +75,6 @@ const CovariateReview = ({
     // after map above, allConcepts contains both case and control stats:
     return (
       <Space direction={'vertical'} align={'center'} style={{ width: '100%' }}>
-        <hr />
         <h4 className='GWASUI-selectInstruction' data-tour='step-4-review'>
                     In this step, you can review the covariates selection based on % missing metrics.
                     To adjust covariates please return to Step 3.

--- a/src/Analysis/GWASWizard/GWASCaseControl.jsx
+++ b/src/Analysis/GWASWizard/GWASCaseControl.jsx
@@ -19,6 +19,16 @@ import AttritionTable from './shared/AttritionTable';
 
 const { Step } = Steps;
 
+
+const stepsContentPaddingTop = {
+  0: "30px",
+  1: "30px",
+  2: "30px",
+  3: "30px",
+  4: "30px",
+  5: "30px",
+}
+
 const GWASCaseControl = ({ resetGWASType, refreshWorkflows }) => {
   const [current, setCurrent] = useState(0);
   const [selectedCaseCohort, setSelectedCaseCohort] = useState(undefined);
@@ -142,7 +152,7 @@ const GWASCaseControl = ({ resetGWASType, refreshWorkflows }) => {
             <AddCohortButton />
           </div>
           <React.Fragment>
-            <div className='tour-div'>
+            <div className='tour-div' style={{marginTop: "15px"}}>
               <TourButton stepInfo={stepInfo} />
               <h4>&nbsp;Tutorial</h4>
             </div>
@@ -168,7 +178,7 @@ const GWASCaseControl = ({ resetGWASType, refreshWorkflows }) => {
         <React.Fragment>
           <AddCohortButton />
           <React.Fragment>
-            <div className='tour-div'>
+            <div className='tour-div' style={{marginTop: "15px"}}>
               <TourButton stepInfo={stepInfo} />
               <h4>&nbsp;Tutorial</h4>
             </div>
@@ -194,7 +204,7 @@ const GWASCaseControl = ({ resetGWASType, refreshWorkflows }) => {
       return (
         <React.Fragment>
           <React.Fragment>
-            <div className='tour-div'>
+            <div className='tour-div' style={{padding: "0"}}>
               <TourButton stepInfo={stepInfo} />
               <h4>&nbsp;Tutorial</h4>
             </div>
@@ -218,7 +228,7 @@ const GWASCaseControl = ({ resetGWASType, refreshWorkflows }) => {
           {selectedCovariates.length > 0
               && (
                 <div className='tour-div'>
-                  <TourButton stepInfo={stepInfo} />
+                  <TourButton stepInfo={stepInfo} style={{padding: "0"}}/>
                   <h4>&nbsp;Tutorial</h4>
                 </div>
               )}
@@ -300,7 +310,7 @@ const GWASCaseControl = ({ resetGWASType, refreshWorkflows }) => {
     case 6:
       return (
         <React.Fragment>
-          <div className='tour-div'>
+          <div className='tour-div' style={{padding: 0, marginTop: "-15px" }}>
             <TourButton stepInfo={stepInfo} />
             <h4>&nbsp;Tutorial</h4>
           </div>
@@ -393,7 +403,7 @@ const GWASCaseControl = ({ resetGWASType, refreshWorkflows }) => {
             <Step key={item.title} title={item.title} description={item.description} />
           ))}
         </Steps>
-        <div className='steps-content'>
+        <div className='steps-content' style={{paddingTop: stepsContentPaddingTop[current]}}>
           <Space direction={'vertical'} align={'center'} style={{ width: '100%' }}>
             {generateStep(current)}
           </Space>

--- a/src/Analysis/GWASWizard/GWASCaseControl.jsx
+++ b/src/Analysis/GWASWizard/GWASCaseControl.jsx
@@ -138,11 +138,11 @@ const GWASCaseControl = ({ resetGWASType, refreshWorkflows }) => {
     case 0:
       return (!loading && sourceId ? (
         <React.Fragment>
-          <div data-tour='step-1-new-cohort' style={{marginTop: "15px"}}>
+          <div data-tour='step-1-new-cohort' className='GWASUI-mt-15'>
             <AddCohortButton />
           </div>
           <React.Fragment>
-            <div className='tour-div' style={{marginTop: "15px"}}>
+            <div className='tour-div GWASUI-mt-15'>
               <TourButton stepInfo={stepInfo} />
               <h4>&nbsp;Tutorial</h4>
             </div>
@@ -166,11 +166,11 @@ const GWASCaseControl = ({ resetGWASType, refreshWorkflows }) => {
     case 1:
       return (
         <React.Fragment>
-          <div style={{marginTop: "15px"}}>
+          <div className='GWASUI-mt-15'>
             <AddCohortButton />
           </div>
           <React.Fragment>
-            <div className='tour-div' style={{marginTop: "15px"}}>
+            <div className='tour-div GWASUI-mt-15'>
               <TourButton stepInfo={stepInfo} />
               <h4>&nbsp;Tutorial</h4>
             </div>
@@ -254,7 +254,6 @@ const GWASCaseControl = ({ resetGWASType, refreshWorkflows }) => {
                   sourceId={sourceId}
                 />
               )}
-
         </React.Fragment>
       );
     case 4:
@@ -390,7 +389,7 @@ const GWASCaseControl = ({ resetGWASType, refreshWorkflows }) => {
           />
         </React.Fragment>
       )}
-      <Space direction={'vertical'} style={{ width: '100%', marginTop: '15px' }}>
+      <Space direction={'vertical'} className='GWASUI-mt-15' style={{ width: '100%'}}>
         <Steps current={current}>
           {caseControlSteps.map((item) => (
             <Step key={item.title} title={item.title} description={item.description} />

--- a/src/Analysis/GWASWizard/GWASCaseControl.jsx
+++ b/src/Analysis/GWASWizard/GWASCaseControl.jsx
@@ -197,7 +197,7 @@ const GWASCaseControl = ({ resetGWASType, refreshWorkflows }) => {
       return (
         <React.Fragment>
           <React.Fragment>
-            <div className='tour-div' style={{padding: "0"}}>
+            <div className='tour-div GWASUI-no-padding'>
               <TourButton stepInfo={stepInfo} />
               <h4>&nbsp;Tutorial</h4>
             </div>
@@ -221,7 +221,7 @@ const GWASCaseControl = ({ resetGWASType, refreshWorkflows }) => {
           {selectedCovariates.length > 0
               && (
                 <div className='tour-div'>
-                  <TourButton stepInfo={stepInfo} style={{padding: "0"}}/>
+                  <TourButton stepInfo={stepInfo} className='GWASUI-no-padding'/>
                   <h4>&nbsp;Tutorial</h4>
                 </div>
               )}
@@ -302,7 +302,7 @@ const GWASCaseControl = ({ resetGWASType, refreshWorkflows }) => {
     case 6:
       return (
         <React.Fragment>
-          <div className='tour-div' style={{padding: 0}}>
+          <div className='tour-div GWASUI-no-padding'>
             <TourButton stepInfo={stepInfo} />
             <h4>&nbsp;Tutorial</h4>
           </div>

--- a/src/Analysis/GWASWizard/GWASCaseControl.jsx
+++ b/src/Analysis/GWASWizard/GWASCaseControl.jsx
@@ -178,7 +178,7 @@ const GWASCaseControl = ({ resetGWASType, refreshWorkflows }) => {
               <h4 className='GWASUI-selectInstruction' data-tour='step-2-cohort-selection'>
                   In this step, you will continue to define your study populations.
                   Please select the cohort that you would like to define as your study
-                  <span className='GWASUI-emphText'>control</span> population.
+                <span className='GWASUI-emphText'>control</span> population.
               </h4>
               <div className='GWASUI-mainTable'>
                 <CohortSelect
@@ -221,7 +221,7 @@ const GWASCaseControl = ({ resetGWASType, refreshWorkflows }) => {
           {selectedCovariates.length > 0
               && (
                 <div className='tour-div'>
-                  <TourButton stepInfo={stepInfo} className='GWASUI-no-padding'/>
+                  <TourButton stepInfo={stepInfo} className='GWASUI-no-padding' />
                   <h4>&nbsp;Tutorial</h4>
                 </div>
               )}
@@ -389,7 +389,7 @@ const GWASCaseControl = ({ resetGWASType, refreshWorkflows }) => {
           />
         </React.Fragment>
       )}
-      <Space direction={'vertical'} className='GWASUI-mt-15' style={{ width: '100%'}}>
+      <Space direction={'vertical'} className='GWASUI-mt-15' style={{ width: '100%' }}>
         <Steps current={current}>
           {caseControlSteps.map((item) => (
             <Step key={item.title} title={item.title} description={item.description} />

--- a/src/Analysis/GWASWizard/GWASCaseControl.jsx
+++ b/src/Analysis/GWASWizard/GWASCaseControl.jsx
@@ -397,7 +397,7 @@ const GWASCaseControl = ({ resetGWASType, refreshWorkflows }) => {
           />
         </React.Fragment>
       )}
-      <Space direction={'vertical'} style={{ width: '100%' }}>
+      <Space direction={'vertical'} style={{ width: '100%', marginTop: '15px' }}>
         <Steps current={current}>
           {caseControlSteps.map((item) => (
             <Step key={item.title} title={item.title} description={item.description} />

--- a/src/Analysis/GWASWizard/GWASCaseControl.jsx
+++ b/src/Analysis/GWASWizard/GWASCaseControl.jsx
@@ -19,16 +19,6 @@ import AttritionTable from './shared/AttritionTable';
 
 const { Step } = Steps;
 
-
-const stepsContentPaddingTop = {
-  0: "30px",
-  1: "30px",
-  2: "30px",
-  3: "30px",
-  4: "30px",
-  5: "30px",
-}
-
 const GWASCaseControl = ({ resetGWASType, refreshWorkflows }) => {
   const [current, setCurrent] = useState(0);
   const [selectedCaseCohort, setSelectedCaseCohort] = useState(undefined);
@@ -403,7 +393,7 @@ const GWASCaseControl = ({ resetGWASType, refreshWorkflows }) => {
             <Step key={item.title} title={item.title} description={item.description} />
           ))}
         </Steps>
-        <div className='steps-content' style={{paddingTop: stepsContentPaddingTop[current]}}>
+        <div className='steps-content'>
           <Space direction={'vertical'} align={'center'} style={{ width: '100%' }}>
             {generateStep(current)}
           </Space>

--- a/src/Analysis/GWASWizard/GWASCaseControl.jsx
+++ b/src/Analysis/GWASWizard/GWASCaseControl.jsx
@@ -138,7 +138,7 @@ const GWASCaseControl = ({ resetGWASType, refreshWorkflows }) => {
     case 0:
       return (!loading && sourceId ? (
         <React.Fragment>
-          <div data-tour='step-1-new-cohort'>
+          <div data-tour='step-1-new-cohort' style={{marginTop: "15px"}}>
             <AddCohortButton />
           </div>
           <React.Fragment>
@@ -166,7 +166,9 @@ const GWASCaseControl = ({ resetGWASType, refreshWorkflows }) => {
     case 1:
       return (
         <React.Fragment>
-          <AddCohortButton />
+          <div style={{marginTop: "15px"}}>
+            <AddCohortButton />
+          </div>
           <React.Fragment>
             <div className='tour-div' style={{marginTop: "15px"}}>
               <TourButton stepInfo={stepInfo} />
@@ -175,7 +177,8 @@ const GWASCaseControl = ({ resetGWASType, refreshWorkflows }) => {
             <Space direction={'vertical'} align={'center'} style={{ width: '100%' }}>
               <h4 className='GWASUI-selectInstruction' data-tour='step-2-cohort-selection'>
                   In this step, you will continue to define your study populations.
-                  Please select the cohort that you would like to define as your study <span className='GWASUI-emphText'>control</span> population.
+                  Please select the cohort that you would like to define as your study
+                  <span className='GWASUI-emphText'>control</span> population.
               </h4>
               <div className='GWASUI-mainTable'>
                 <CohortSelect
@@ -300,7 +303,7 @@ const GWASCaseControl = ({ resetGWASType, refreshWorkflows }) => {
     case 6:
       return (
         <React.Fragment>
-          <div className='tour-div' style={{padding: 0, marginTop: "-15px" }}>
+          <div className='tour-div' style={{padding: 0}}>
             <TourButton stepInfo={stepInfo} />
             <h4>&nbsp;Tutorial</h4>
           </div>

--- a/src/Analysis/GWASWizard/GWASQuantitative.jsx
+++ b/src/Analysis/GWASWizard/GWASQuantitative.jsx
@@ -314,7 +314,7 @@ const GWASQuantitative = ({ resetGWASType, refreshWorkflows }) => {
         </div>
       )}
       <React.Fragment>
-        <Space direction={'vertical'} style={{ width: '100%' }}>
+        <Space direction={'vertical'} style={{ width: '100%', marginTop: '15px' }}>
           <Steps current={current}>
             {quantitativeSteps.map((item) => (
               <Step key={item.title} title={item.title} description={item.description} />

--- a/src/Analysis/GWASWizard/GWASQuantitative.jsx
+++ b/src/Analysis/GWASWizard/GWASQuantitative.jsx
@@ -314,7 +314,7 @@ const GWASQuantitative = ({ resetGWASType, refreshWorkflows }) => {
         </div>
       )}
       <React.Fragment>
-        <Space direction={'vertical'} className='GWASUI-mt-15' style={{ width: '100%'}}>
+        <Space direction={'vertical'} className='GWASUI-mt-15' style={{ width: '100%' }}>
           <Steps current={current}>
             {quantitativeSteps.map((item) => (
               <Step key={item.title} title={item.title} description={item.description} />

--- a/src/Analysis/GWASWizard/GWASQuantitative.jsx
+++ b/src/Analysis/GWASWizard/GWASQuantitative.jsx
@@ -135,7 +135,7 @@ const GWASQuantitative = ({ resetGWASType, refreshWorkflows }) => {
               <AddCohortButton />
             </div>
             <React.Fragment>
-              <div className='tour-div'>
+              <div className='tour-div' style={{marginTop: "15px"}}>
                 <TourButton stepInfo={stepInfo} />
                 <h4>&nbsp;Tutorial</h4>
               </div>
@@ -157,7 +157,7 @@ const GWASQuantitative = ({ resetGWASType, refreshWorkflows }) => {
       return (
         <React.Fragment>
           <React.Fragment>
-            <div className='tour-div'>
+            <div className='tour-div' style={{padding:0,marginTop: "-15px"}}>
               <TourButton stepInfo={stepInfo} />
               <h4>&nbsp;Tutorial</h4>
             </div>
@@ -187,7 +187,7 @@ const GWASQuantitative = ({ resetGWASType, refreshWorkflows }) => {
     case 2:
       return (
         <React.Fragment>
-          <div className='tour-div'>
+          <div className='tour-div' style={{padding:0,marginTop: "-15px"}}>
             <TourButton stepInfo={stepInfo} />
             <h4>&nbsp;Tutorial</h4>
           </div>
@@ -204,7 +204,7 @@ const GWASQuantitative = ({ resetGWASType, refreshWorkflows }) => {
     case 3:
       return (
         <React.Fragment>
-          <div className='tour-div'>
+          <div className='tour-div' style={{padding:0,marginTop: "-15px"}}>
             <TourButton stepInfo={stepInfo} />
             <h4>&nbsp;Tutorial</h4>
           </div>
@@ -220,7 +220,7 @@ const GWASQuantitative = ({ resetGWASType, refreshWorkflows }) => {
     case 4:
       return (
         <React.Fragment>
-          <div className='tour-div'>
+          <div className='tour-div' style={{padding:0,marginTop: "-15px"}}>
             <TourButton stepInfo={stepInfo} />
             <h4>&nbsp;Tutorial</h4>
           </div>
@@ -247,7 +247,7 @@ const GWASQuantitative = ({ resetGWASType, refreshWorkflows }) => {
     case 5:
       return (
         <React.Fragment>
-          <div className='tour-div'>
+          <div className='tour-div' style={{padding:0,marginTop: "-15px"}}>
             <TourButton stepInfo={stepInfo} />
             <h4>&nbsp;Tutorial</h4>
           </div>

--- a/src/Analysis/GWASWizard/GWASQuantitative.jsx
+++ b/src/Analysis/GWASWizard/GWASQuantitative.jsx
@@ -157,7 +157,7 @@ const GWASQuantitative = ({ resetGWASType, refreshWorkflows }) => {
       return (
         <React.Fragment>
           <React.Fragment>
-            <div className='tour-div' style={{padding:0,marginTop: "-15px"}}>
+            <div className='tour-div' style={{ padding:0, marginTop: "-15px"}}>
               <TourButton stepInfo={stepInfo} />
               <h4>&nbsp;Tutorial</h4>
             </div>
@@ -187,7 +187,7 @@ const GWASQuantitative = ({ resetGWASType, refreshWorkflows }) => {
     case 2:
       return (
         <React.Fragment>
-          <div className='tour-div' style={{padding:0,marginTop: "-15px"}}>
+          <div className='tour-div' style={{padding:0, marginTop: '-15px'}}>
             <TourButton stepInfo={stepInfo} />
             <h4>&nbsp;Tutorial</h4>
           </div>
@@ -204,7 +204,7 @@ const GWASQuantitative = ({ resetGWASType, refreshWorkflows }) => {
     case 3:
       return (
         <React.Fragment>
-          <div className='tour-div' style={{padding:0,marginTop: "-15px"}}>
+          <div className='tour-div' style={{padding:0, marginTop: '-15px'}}>
             <TourButton stepInfo={stepInfo} />
             <h4>&nbsp;Tutorial</h4>
           </div>
@@ -220,7 +220,7 @@ const GWASQuantitative = ({ resetGWASType, refreshWorkflows }) => {
     case 4:
       return (
         <React.Fragment>
-          <div className='tour-div' style={{padding:0,marginTop: "-15px"}}>
+          <div className='tour-div' style={{padding:0, marginTop: '-15px'}}>
             <TourButton stepInfo={stepInfo} />
             <h4>&nbsp;Tutorial</h4>
           </div>
@@ -247,7 +247,7 @@ const GWASQuantitative = ({ resetGWASType, refreshWorkflows }) => {
     case 5:
       return (
         <React.Fragment>
-          <div className='tour-div' style={{padding:0,marginTop: "-15px"}}>
+          <div className='tour-div' style={{padding:0, marginTop: '-15px'}}>
             <TourButton stepInfo={stepInfo} />
             <h4>&nbsp;Tutorial</h4>
           </div>

--- a/src/Analysis/GWASWizard/GWASQuantitative.jsx
+++ b/src/Analysis/GWASWizard/GWASQuantitative.jsx
@@ -131,11 +131,11 @@ const GWASQuantitative = ({ resetGWASType, refreshWorkflows }) => {
       return (!loading && sourceId
         ? (
           <React.Fragment>
-            <div data-tour='quant-step-1-new-cohort' style={{marginTop: "15px"}}>
+            <div data-tour='quant-step-1-new-cohort' className='GWASUI-mt-15'>
               <AddCohortButton />
             </div>
             <React.Fragment>
-              <div className='tour-div' style={{marginTop: "15px"}}>
+              <div className='tour-div GWASUI-mt-15'>
                 <TourButton stepInfo={stepInfo} />
                 <h4>&nbsp;Tutorial</h4>
               </div>
@@ -314,7 +314,7 @@ const GWASQuantitative = ({ resetGWASType, refreshWorkflows }) => {
         </div>
       )}
       <React.Fragment>
-        <Space direction={'vertical'} className='GWASUI-mt-15' style={{ width: '100%', marginTop: '15px' }}>
+        <Space direction={'vertical'} className='GWASUI-mt-15' style={{ width: '100%'}}>
           <Steps current={current}>
             {quantitativeSteps.map((item) => (
               <Step key={item.title} title={item.title} description={item.description} />

--- a/src/Analysis/GWASWizard/GWASQuantitative.jsx
+++ b/src/Analysis/GWASWizard/GWASQuantitative.jsx
@@ -314,7 +314,7 @@ const GWASQuantitative = ({ resetGWASType, refreshWorkflows }) => {
         </div>
       )}
       <React.Fragment>
-        <Space direction={'vertical'} style={{ width: '100%', marginTop: '15px' }}>
+        <Space direction={'vertical'} className='GWASUI-mt-15' style={{ width: '100%', marginTop: '15px' }}>
           <Steps current={current}>
             {quantitativeSteps.map((item) => (
               <Step key={item.title} title={item.title} description={item.description} />

--- a/src/Analysis/GWASWizard/GWASQuantitative.jsx
+++ b/src/Analysis/GWASWizard/GWASQuantitative.jsx
@@ -157,7 +157,7 @@ const GWASQuantitative = ({ resetGWASType, refreshWorkflows }) => {
       return (
         <React.Fragment>
           <React.Fragment>
-            <div className='tour-div' style={{ padding:0}}>
+            <div className='tour-div GWASUI-no-padding'>
               <TourButton stepInfo={stepInfo} />
               <h4>&nbsp;Tutorial</h4>
             </div>
@@ -187,7 +187,7 @@ const GWASQuantitative = ({ resetGWASType, refreshWorkflows }) => {
     case 2:
       return (
         <React.Fragment>
-          <div className='tour-div' style={{padding:0}}>
+          <div className='tour-div GWASUI-no-padding'>
             <TourButton stepInfo={stepInfo} />
             <h4>&nbsp;Tutorial</h4>
           </div>
@@ -204,7 +204,7 @@ const GWASQuantitative = ({ resetGWASType, refreshWorkflows }) => {
     case 3:
       return (
         <React.Fragment>
-          <div className='tour-div' style={{padding:0}}>
+          <div className='tour-div GWASUI-no-padding'>
             <TourButton stepInfo={stepInfo} />
             <h4>&nbsp;Tutorial</h4>
           </div>
@@ -220,7 +220,7 @@ const GWASQuantitative = ({ resetGWASType, refreshWorkflows }) => {
     case 4:
       return (
         <React.Fragment>
-          <div className='tour-div' style={{padding:0}}>
+          <div className='tour-div GWASUI-no-padding'>
             <TourButton stepInfo={stepInfo} />
             <h4>&nbsp;Tutorial</h4>
           </div>
@@ -247,7 +247,7 @@ const GWASQuantitative = ({ resetGWASType, refreshWorkflows }) => {
     case 5:
       return (
         <React.Fragment>
-          <div className='tour-div' style={{padding:0}}>
+          <div className='tour-div GWASUI-no-padding'>
             <TourButton stepInfo={stepInfo} />
             <h4>&nbsp;Tutorial</h4>
           </div>

--- a/src/Analysis/GWASWizard/GWASQuantitative.jsx
+++ b/src/Analysis/GWASWizard/GWASQuantitative.jsx
@@ -131,7 +131,7 @@ const GWASQuantitative = ({ resetGWASType, refreshWorkflows }) => {
       return (!loading && sourceId
         ? (
           <React.Fragment>
-            <div data-tour='quant-step-1-new-cohort'>
+            <div data-tour='quant-step-1-new-cohort' style={{marginTop: "15px"}}>
               <AddCohortButton />
             </div>
             <React.Fragment>
@@ -157,7 +157,7 @@ const GWASQuantitative = ({ resetGWASType, refreshWorkflows }) => {
       return (
         <React.Fragment>
           <React.Fragment>
-            <div className='tour-div' style={{ padding:0, marginTop: "-15px"}}>
+            <div className='tour-div' style={{ padding:0}}>
               <TourButton stepInfo={stepInfo} />
               <h4>&nbsp;Tutorial</h4>
             </div>
@@ -187,7 +187,7 @@ const GWASQuantitative = ({ resetGWASType, refreshWorkflows }) => {
     case 2:
       return (
         <React.Fragment>
-          <div className='tour-div' style={{padding:0, marginTop: '-15px'}}>
+          <div className='tour-div' style={{padding:0}}>
             <TourButton stepInfo={stepInfo} />
             <h4>&nbsp;Tutorial</h4>
           </div>
@@ -204,7 +204,7 @@ const GWASQuantitative = ({ resetGWASType, refreshWorkflows }) => {
     case 3:
       return (
         <React.Fragment>
-          <div className='tour-div' style={{padding:0, marginTop: '-15px'}}>
+          <div className='tour-div' style={{padding:0}}>
             <TourButton stepInfo={stepInfo} />
             <h4>&nbsp;Tutorial</h4>
           </div>
@@ -220,7 +220,7 @@ const GWASQuantitative = ({ resetGWASType, refreshWorkflows }) => {
     case 4:
       return (
         <React.Fragment>
-          <div className='tour-div' style={{padding:0, marginTop: '-15px'}}>
+          <div className='tour-div' style={{padding:0}}>
             <TourButton stepInfo={stepInfo} />
             <h4>&nbsp;Tutorial</h4>
           </div>
@@ -247,7 +247,7 @@ const GWASQuantitative = ({ resetGWASType, refreshWorkflows }) => {
     case 5:
       return (
         <React.Fragment>
-          <div className='tour-div' style={{padding:0, marginTop: '-15px'}}>
+          <div className='tour-div' style={{padding:0}}>
             <TourButton stepInfo={stepInfo} />
             <h4>&nbsp;Tutorial</h4>
           </div>

--- a/src/Analysis/GWASWizard/OutcomeSelectReview.jsx
+++ b/src/Analysis/GWASWizard/OutcomeSelectReview.jsx
@@ -69,7 +69,6 @@ const OutcomeSelectReview = ({
   return (
     <div>
       <Space direction={'vertical'} align={'center'} style={{ width: '100%' }}>
-        <hr />
         <h4 className='GWASUI-selectInstruction' data-tour='choosing-covariates'>
           Assess variables based on % missing metric and select the outcome phenotype
         </h4>

--- a/src/Analysis/GWASWizard/shared/CustomDichotomousSelect.jsx
+++ b/src/Analysis/GWASWizard/shared/CustomDichotomousSelect.jsx
@@ -35,10 +35,10 @@ const CustomDichotomousSelect = ({
     <React.Fragment>
       <div className='cd-flex'>
         <React.Fragment>
-          <div className='GWASUI-align' data-tour='choosing-dichotomous'>
+          <div className='GWASUI-align GWASUI-no-top-spacing' data-tour='choosing-dichotomous'>
             <div className='GWASUI-flexRow' data-tour='table-repeat'>
               <div className='GWASUI-flexCol GWASUI-subTable'>
-                <h3 className='GWASUI-selectInstruction' align={'center'}>Select NO cohort</h3>
+                <h3 className='GWASUI-selectInstruction GWASUI-no-top-spacing' align={'center'}>Select NO Cohort</h3>
                 <CohortSelect
                   selectedCohort={firstCohort}
                   handleCohortSelect={setFirstCohort}
@@ -48,7 +48,7 @@ const CustomDichotomousSelect = ({
                 />
               </div>
               <div className='GWASUI-flexCol GWASUI-subTable'>
-                <h3 className='GWASUI-selectInstruction' align={'center'}>Select YES cohort</h3>
+                <h3 className='GWASUI-selectInstruction' align={'center'}>Select YES Cohort</h3>
                 <CohortSelect
                   selectedCohort={secondCohort}
                   handleCohortSelect={setSecondCohort}

--- a/src/Analysis/GWASWizard/shared/CustomDichotomousSelect.jsx
+++ b/src/Analysis/GWASWizard/shared/CustomDichotomousSelect.jsx
@@ -37,7 +37,7 @@ const CustomDichotomousSelect = ({
         <React.Fragment>
           <div className='GWASUI-align GWASUI-no-top-spacing' data-tour='choosing-dichotomous'>
             <div className='GWASUI-flexRow' data-tour='table-repeat'>
-              <div className='GWASUI-flexCol GWASUI-subTable'>
+              <div className='GWASUI-flexCol GWASUI-subTable GWASUI-no-top-spacing'>
                 <h3 className='GWASUI-selectInstruction GWASUI-no-top-spacing' align={'center'}>Select NO Cohort</h3>
                 <CohortSelect
                   selectedCohort={firstCohort}
@@ -47,8 +47,8 @@ const CustomDichotomousSelect = ({
                   current={current}
                 />
               </div>
-              <div className='GWASUI-flexCol GWASUI-subTable'>
-                <h3 className='GWASUI-selectInstruction' align={'center'}>Select YES Cohort</h3>
+              <div className='GWASUI-flexCol GWASUI-subTable GWASUI-no-top-spacing'>
+                <h3 className='GWASUI-selectInstruction GWASUI-no-top-spacing' align={'center'}>Select YES Cohort</h3>
                 <CohortSelect
                   selectedCohort={secondCohort}
                   handleCohortSelect={setSecondCohort}

--- a/src/Analysis/GWASWizard/shared/WorkflowParameters.jsx
+++ b/src/Analysis/GWASWizard/shared/WorkflowParameters.jsx
@@ -40,7 +40,7 @@ const WorkflowParameters = ({
     </h4>
     <div className='GWASUI-mainArea'>
       <div data-tour='number-of-pcs'>
-        <label className='GWASUI-label asterisk' htmlFor='input-numOfPC'>
+        <label className='GWASUI-label GWASUI-asterisk' htmlFor='input-numOfPC'>
           Number of PCs to use &nbsp;
           <InputNumber
             id='input-numOfPC'
@@ -81,7 +81,7 @@ const WorkflowParameters = ({
       </div>
       <div data-tour='hare'>
         {workflowType === 'caseControl' && (
-          <label className='GWASUI-label asterisk' htmlFor='select-hare-case-control'>
+          <label className='GWASUI-label GWASUI-asterisk' htmlFor='select-hare-case-control'>
             Select HARE group &nbsp;
             <CovariateStatsByHareCC
               id='select-hare-case-control'
@@ -97,7 +97,7 @@ const WorkflowParameters = ({
           </label>
         )}
         {workflowType === 'quantitative' && (
-          <label className='GWASUI-label asterisk' htmlFor='select-hare-quantitative'>
+          <label className='GWASUI-label GWASUI-asterisk' htmlFor='select-hare-quantitative'>
             Select HARE group &nbsp;
             <CovariateStatsByHareQ
               id='select-hare-quantitative'

--- a/src/Analysis/GWASWizard/shared/WorkflowParameters.jsx
+++ b/src/Analysis/GWASWizard/shared/WorkflowParameters.jsx
@@ -40,8 +40,8 @@ const WorkflowParameters = ({
     </h4>
     <div className='GWASUI-mainArea'>
       <div data-tour='number-of-pcs'>
-        <label className='GWASUI-label' htmlFor='input-numOfPC'>
-          <span style={{ color: 'red' }}>*</span>Number of PCs to use &nbsp;
+        <label className='GWASUI-label asterisk' htmlFor='input-numOfPC'>
+          Number of PCs to use &nbsp;
           <InputNumber
             id='input-numOfPC'
             value={numOfPC}
@@ -81,8 +81,7 @@ const WorkflowParameters = ({
       </div>
       <div data-tour='hare'>
         {workflowType === 'caseControl' && (
-          <label className='GWASUI-label' htmlFor='select-hare-case-control'>
-            <span style={{ color: 'red' }}>*</span>
+          <label className='GWASUI-label asterisk' htmlFor='select-hare-case-control'>
             Select HARE group &nbsp;
             <CovariateStatsByHareCC
               id='select-hare-case-control'
@@ -98,8 +97,7 @@ const WorkflowParameters = ({
           </label>
         )}
         {workflowType === 'quantitative' && (
-          <label className='GWASUI-label' htmlFor='select-hare-quantitative'>
-            <span style={{ color: 'red' }}>*</span>
+          <label className='GWASUI-label asterisk' htmlFor='select-hare-quantitative'>
             Select HARE group &nbsp;
             <CovariateStatsByHareQ
               id='select-hare-quantitative'
@@ -110,7 +108,6 @@ const WorkflowParameters = ({
               sourceId={sourceId}
               handleHareChange={handleHareChange}
             />
-
           </label>
         )}
       </div>


### PR DESCRIPTION
Jira Ticket: [VADC-207](https://ctds-planx.atlassian.net/browse/VADC-207)

### New Features
This updates the styling for the GWAS pipeline per these business requirements: 

* The steps under the attrition table need to have equal padding vertically, in both flows
* Quantitive flow, step 2, tutorial button need to be centered vertically
* Quantitive flow, step 3, tutorial button need to be centered vertically (also too much space there)
* Quantitive flow, step 5, tutorial button need to be centered vertically
* Quantitive flow and CC flow, step 5, can we push all fields forward so the words are aligned and ``` * ``` sticks out where needed?
* Quantitive flow, step 5, tutorial button need to be centered vertically
* CC step 1,2,3,4 and 7, tutorial button need to be centered vertically
* CC step 4- too much space around tutorial button 
* CustomDichotomousSelect view: Make the 'C' in Cohort capitalized in table titles
* Remove extra top space around CustomDichotomousSelect view

This involved setting inline styles and classes for each step, editing JSX and removing unneeded ```<hr />``` elements from other components. Asterisks were removed from the JSX and are added as a before element with CSS to ensure alignment. These updates were reviewed and approved with Noah Oct 6th.

### Screenshots
#### BEFORE
![before-output](https://user-images.githubusercontent.com/113449836/194565394-81bee909-6ad3-4e84-85a1-fa4ceae24e6d.gif)

#### AFTER
![output](https://user-images.githubusercontent.com/113449836/194564298-e3a017aa-f996-4f9c-a2a7-4ac178222032.gif)


