### PR TITLE
Chore/adding_infobutton

### DIFF
--- a/docs/portal_config.md
+++ b/docs/portal_config.md
@@ -631,7 +631,7 @@ Below is an example, with inline comments describing what each JSON block config
         "name": "Program", // this configures the tag category name that will be shown on the tag selector
         "color": "rgba(129, 211, 248, 1)", // color can be any vaid CSS color string, including hex, rgb, rgba, hsl
         "display": true,
-        "tooltip": "additional data", // optional string to add data when hovered on the info button
+        "tooltip": "additional data", // optional string to add additional data when hovered on the info button
         "displayName": "All Programs" // optional string to customize tag category display name
       },
       {

--- a/docs/portal_config.md
+++ b/docs/portal_config.md
@@ -631,17 +631,20 @@ Below is an example, with inline comments describing what each JSON block config
         "name": "Program", // this configures the tag category name that will be shown on the tag selector
         "color": "rgba(129, 211, 248, 1)", // color can be any vaid CSS color string, including hex, rgb, rgba, hsl
         "display": true,
+        "tooltip": "addional data", // optional string to add data when hovered on the info button
         "displayName": "All Programs" // optional string to customize tag category display name
       },
       {
         "name": "Study Registration",
         "color": "rgba(236, 128, 141, 1)",
-        "display": true
+        "display": true,
+        "tooltip": "Study Registration Data"
       },
       {
         "name": "Data Type",
         "color": "rgba(112, 182, 3, 1)",
-        "display": true
+        "display": true,
+        "tooltip": "Data Type Data"
       }
     ],
     "tagsDisplayName": "Tags" // optional, overrides the name of the mandatory tags column

--- a/docs/portal_config.md
+++ b/docs/portal_config.md
@@ -631,7 +631,7 @@ Below is an example, with inline comments describing what each JSON block config
         "name": "Program", // this configures the tag category name that will be shown on the tag selector
         "color": "rgba(129, 211, 248, 1)", // color can be any vaid CSS color string, including hex, rgb, rgba, hsl
         "display": true,
-        "tooltip": "additional data", // optional string to add additional data when hovered on the info button
+        "tooltip": "additional data", // optional string to add data when hovered on the info button
         "displayName": "All Programs" // optional string to customize tag category display name
       },
       {

--- a/docs/portal_config.md
+++ b/docs/portal_config.md
@@ -631,7 +631,7 @@ Below is an example, with inline comments describing what each JSON block config
         "name": "Program", // this configures the tag category name that will be shown on the tag selector
         "color": "rgba(129, 211, 248, 1)", // color can be any vaid CSS color string, including hex, rgb, rgba, hsl
         "display": true,
-        "tooltip": "addional data", // optional string to add data when hovered on the info button
+        "tooltip": "additional data", // optional string to add data when hovered on the info button
         "displayName": "All Programs" // optional string to customize tag category display name
       },
       {

--- a/src/Discovery/DiscoveryDropdownTagViewer.tsx
+++ b/src/Discovery/DiscoveryDropdownTagViewer.tsx
@@ -9,6 +9,7 @@ import Tooltip from 'rc-tooltip';
 import { InfoCircleOutlined } from '@ant-design/icons'
 
 const { Option } = Select;
+//const tooltipText = ' test info';
 
 interface DiscoveryTagViewerProps {
   config: DiscoveryConfig
@@ -115,7 +116,7 @@ const DiscoveryDropdownTagViewer: React.FunctionComponent<DiscoveryTagViewerProp
 
           return (
             <Col
-              className='discovery-header__tag-group'
+            className='discovery-header__tag-group'
               key={category.name}
               xs={24}
               sm={24}
@@ -123,17 +124,19 @@ const DiscoveryDropdownTagViewer: React.FunctionComponent<DiscoveryTagViewerProp
               lg={12}
               xl={12}
               xxl={12}
+
             >
-              <table >
+              <table>
                 <tr>
-                  <td >
-                  <Col >
+                  <td>
+                  <Col>
+                  <div style={{ display: category.tooltip != null ? 'block' : 'none' }}>
                   <Tooltip
                   placement='left'
                   overlay={category.tooltip}
                   overlayClassName='g3-filter-section__and-or-toggle-helper-tooltip'
-                  arrowContent={<div className='rc-tooltip-arrow-inner' />}
-                  width='300px'
+                 arrowContent={<div className='rc-tooltip-arrow-inner' />}
+                  width='100%'
                   trigger={['hover', 'focus']}
                   id={'controlPanelTooltipAdditional_data'}
                 >
@@ -145,9 +148,10 @@ const DiscoveryDropdownTagViewer: React.FunctionComponent<DiscoveryTagViewerProp
                     <InfoCircleOutlined />
                   </span>
                 </Tooltip>
+                  </div>
                   </Col>
                   </td>
-                  <td width='500px' >
+                  <td width='100%'>
                   {tags}
                   </td>
                 </tr>

--- a/src/Discovery/DiscoveryDropdownTagViewer.tsx
+++ b/src/Discovery/DiscoveryDropdownTagViewer.tsx
@@ -29,7 +29,7 @@ const DiscoveryDropdownTagViewer: React.FunctionComponent<DiscoveryTagViewerProp
     const tagMap = {};
     studies.forEach((study) => {
       const tagField = props.config.minimalFieldMapping.tagsListFieldName;
-      study[tagField].forEach((tag) => {
+      study[tagField]?.forEach((tag) => {
         if (tag.category === category.name) {
           tagMap[tag.name] = 1;
         }

--- a/src/Discovery/DiscoveryDropdownTagViewer.tsx
+++ b/src/Discovery/DiscoveryDropdownTagViewer.tsx
@@ -5,8 +5,6 @@ import {
 } from 'antd';
 import { DiscoveryConfig } from './DiscoveryConfig';
 import { DiscoveryResource } from './Discovery';
-import { PureComponent } from 'react';
-import PropTypes from 'prop-types';
 import Tooltip from 'rc-tooltip';
 import { InfoCircleOutlined } from '@ant-design/icons'
 

--- a/src/Discovery/DiscoveryDropdownTagViewer.tsx
+++ b/src/Discovery/DiscoveryDropdownTagViewer.tsx
@@ -11,7 +11,6 @@ import Tooltip from 'rc-tooltip';
 import { InfoCircleOutlined } from '@ant-design/icons'
 
 const { Option } = Select;
-const tooltipText = ' test info';
 
 interface DiscoveryTagViewerProps {
   config: DiscoveryConfig
@@ -168,6 +167,3 @@ DiscoveryDropdownTagViewer.defaultProps = {
 };
 
 export default DiscoveryDropdownTagViewer;
-
-
-

--- a/src/Discovery/DiscoveryDropdownTagViewer.tsx
+++ b/src/Discovery/DiscoveryDropdownTagViewer.tsx
@@ -5,8 +5,13 @@ import {
 } from 'antd';
 import { DiscoveryConfig } from './DiscoveryConfig';
 import { DiscoveryResource } from './Discovery';
+import { PureComponent } from 'react';
+import PropTypes from 'prop-types';
+import Tooltip from 'rc-tooltip';
+import { InfoCircleOutlined } from '@ant-design/icons'
 
 const { Option } = Select;
+const tooltipText = ' test info';
 
 interface DiscoveryTagViewerProps {
   config: DiscoveryConfig
@@ -25,7 +30,7 @@ const DiscoveryDropdownTagViewer: React.FunctionComponent<DiscoveryTagViewerProp
     const tagMap = {};
     studies.forEach((study) => {
       const tagField = props.config.minimalFieldMapping.tagsListFieldName;
-      study[tagField]?.forEach((tag) => {
+      study[tagField].forEach((tag) => {
         if (tag.category === category.name) {
           tagMap[tag.name] = 1;
         }
@@ -122,7 +127,34 @@ const DiscoveryDropdownTagViewer: React.FunctionComponent<DiscoveryTagViewerProp
               xl={12}
               xxl={12}
             >
-              { tags }
+              <table >
+                <tr>
+                  <td >
+                  <Col >
+                  <Tooltip
+                  placement='left'
+                  overlay={category.tooltip}
+                  overlayClassName='g3-filter-section__and-or-toggle-helper-tooltip'
+                  arrowContent={<div className='rc-tooltip-arrow-inner' />}
+                  width='300px'
+                  trigger={['hover', 'focus']}
+                  id={'controlPanelTooltipAdditional_data'}
+                >
+                   <span
+                    role='button'
+                    aria-describedby={'controlPanelTooltipAdditional_data'}
+                    className={'g3-helper-tooltip'}
+                  >
+                    <InfoCircleOutlined />
+                  </span>
+                </Tooltip>
+                  </Col>
+                  </td>
+                  <td width='500px' >
+                  {tags}
+                  </td>
+                </tr>
+               </table>
             </Col>
           );
         })
@@ -136,3 +168,6 @@ DiscoveryDropdownTagViewer.defaultProps = {
 };
 
 export default DiscoveryDropdownTagViewer;
+
+
+

--- a/src/Discovery/DiscoveryTagViewer.tsx
+++ b/src/Discovery/DiscoveryTagViewer.tsx
@@ -4,6 +4,8 @@ import {
 } from 'antd';
 import { DiscoveryConfig } from './DiscoveryConfig';
 import { DiscoveryResource } from './Discovery';
+import Tooltip from 'rc-tooltip';
+import { InfoCircleOutlined } from '@ant-design/icons'
 
 const TAG_LIST_LIMIT = 8;
 interface DiscoveryTagViewerProps {
@@ -25,7 +27,7 @@ const DiscoveryTagViewer: React.FunctionComponent<DiscoveryTagViewerProps> = (pr
     const tagMap = {};
     studies.forEach((study) => {
       const tagField = props.config.minimalFieldMapping.tagsListFieldName;
-      study[tagField]?.forEach((tag) => {
+      study[tagField].forEach((tag) => {
         if (tag.category === category.name) {
           tagMap[tag.name] = 1;
         }
@@ -139,12 +141,42 @@ const DiscoveryTagViewer: React.FunctionComponent<DiscoveryTagViewerProps> = (pr
                 xl={6}
                 xxl={4}
               >
-                <h5 className='discovery-header__tag-group-header'>{categoryDisplayName}</h5>
-                { tags }
-              </Col>
-            );
-          })
-        }
+                <table>
+                <tr>
+
+                  <td>
+                  <Col>
+                  <div style={{ display: category.tooltip != null ? 'block' : 'none' }}>
+                  <Tooltip
+                  placement='left'
+                  overlay={category.tooltip}
+                  overlayClassName='g3-filter-section__and-or-toggle-helper-tooltip'
+                 arrowContent={<div className='rc-tooltip-arrow-inner' />}
+                  width='100%'
+                  trigger={['hover', 'focus']}
+                  id={'controlPanelTooltipAdditional_data'}
+                >
+                  <span
+                    role='button'
+                    aria-describedby={'controlPanelTooltipAdditional_data'}
+                    className={'g3-helper-tooltip'}
+                  >
+                    <InfoCircleOutlined/>
+                  </span>
+                </Tooltip>
+                  </div>
+                  </Col>
+                  </td>
+                  <td width='100%'>
+                  <h5 className='discovery-header__tag-group-header'>{categoryDisplayName}</h5>
+                  {tags}
+                  </td>
+                </tr>
+               </table>
+               </Col>
+          );
+        })
+      }
       </Row>
     </div>
   );


### PR DESCRIPTION
 I made necessary below changes for tooltip info button right next to each study filter category with additional data.
1. Updated the documentation at docs/portal_config.md  with new config.
2. Updated code in https://github.com/uc-cdis/data-portal/blob/master/src/Discovery/DiscoveryDropdownTagViewer.tsx and
https://github.com/uc-cdis/data-portal/blob/master/src/Discovery/DiscoveryTagViewer.tsx