### PR TITLE
Feat/gwas unified flow progress bar text

### DIFF
--- a/src/Analysis/GWASV2/Components/AttritionTableWrapper/AttritionTableWrapper.test.jsx
+++ b/src/Analysis/GWASV2/Components/AttritionTableWrapper/AttritionTableWrapper.test.jsx
@@ -25,7 +25,7 @@ const AttritionTableArgs = {
     concept_id: 'id',
     concept_name: 'concept name',
   },
-  newCovariateSubset: [
+  covariates: [
     {
       variable_type: 'custom_dichotomous',
       provided_name: 'providednamebyuser',

--- a/src/Analysis/GWASV2/Components/ProgressBar/ProgressBar.jsx
+++ b/src/Analysis/GWASV2/Components/ProgressBar/ProgressBar.jsx
@@ -13,7 +13,7 @@ const ProgressBar = ({ currentStep }) => (
           <Step
             key={item.title}
             icon={<React.Fragment>{index + 1}</React.Fragment>}
-            title={`${currentStep <= index ? item.title : item.secondaryTitle}`}
+            title={item.title}
           />
         ))}
       </Steps>

--- a/src/Analysis/GWASV2/Components/ProgressBar/ProgressBar.test.jsx
+++ b/src/Analysis/GWASV2/Components/ProgressBar/ProgressBar.test.jsx
@@ -1,8 +1,7 @@
 import React from 'react';
-import Enzyme, { render, mount } from 'enzyme';
+import Enzyme, { mount } from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
 import ProgressBar from './ProgressBar';
-import { gwasV2Steps } from '../../Shared/constants';
 
 Enzyme.configure({ adapter: new Adapter() });
 
@@ -18,13 +17,6 @@ window.matchMedia = window.matchMedia
       removeListener() {},
     };
   };
-
-/* HELPER METHODS */
-const testElementText = (wrapper, elNum, text) => {
-  const testElement = wrapper.find(`div.ant-steps-item:nth-child(${elNum})`);
-  expect(testElement).toHaveLength(1);
-  expect(testElement.text()).toEqual(text);
-};
 
 const testElementClass = (wrapper, elNum, className) => {
   /*

--- a/src/Analysis/GWASV2/Components/ProgressBar/ProgressBar.test.jsx
+++ b/src/Analysis/GWASV2/Components/ProgressBar/ProgressBar.test.jsx
@@ -51,26 +51,3 @@ describe('Test that active step class renders with active class when current is 
     });
   }
 });
-
-/* Test Dynamic Text for Steps */
-describe('Test that each step renders with correct text when currentStep is between 0 and 3', () => {
-  for (let i = 0; i < 4; i += 1) {
-    const wrapper = render(<ProgressBar currentStep={i} />);
-    const correctTextStep1 = i === 0 ? gwasV2Steps[0].title : gwasV2Steps[0].secondaryTitle;
-    const correctTextStep2 = i <= 1 ? gwasV2Steps[1].title : gwasV2Steps[1].secondaryTitle;
-    const correctTextStep3 = i <= 2 ? gwasV2Steps[2].title : gwasV2Steps[2].secondaryTitle;
-    const correctTextStep4 = i <= 3 ? gwasV2Steps[3].title : gwasV2Steps[3].secondaryTitle;
-    it(`should render first step with correct text: 1${correctTextStep1} when currentStep is ${i}`, () => {
-      testElementText(wrapper, 1, `1${correctTextStep1}`);
-    });
-    it(`should render second step with correct text: 2${correctTextStep2} when currentStep is ${i}`, () => {
-      testElementText(wrapper, 2, `2${correctTextStep2}`);
-    });
-    it(`should render third step with correct text: 3${correctTextStep3} when currentStep is ${i}`, () => {
-      testElementText(wrapper, 3, `3${correctTextStep3}`);
-    });
-    it(`should render fourth step with correct text: 4${correctTextStep4} when current is ${i}`, () => {
-      testElementText(wrapper, 4, `4${correctTextStep4}`);
-    });
-  }
-});

--- a/src/Analysis/GWASV2/Shared/constants.js
+++ b/src/Analysis/GWASV2/Shared/constants.js
@@ -2,18 +2,14 @@
 export const gwasV2Steps = [
   {
     title: 'Select Study Population',
-    secondaryTitle: 'Edit Study Population',
   },
   {
     title: 'Select Outcome Phenotype',
-    secondaryTitle: 'Edit Outcome Phenotype',
   },
   {
     title: 'Select Covariate Phenotype',
-    secondaryTitle: 'Edit Covariate Phenotype',
   },
   {
     title: 'Configure GWAS',
-    secondaryTitle: 'Configure GWAS',
   },
 ];


### PR DESCRIPTION
Jira Ticket: [VADC-379](https://ctds-planx.atlassian.net/browse/VADC-379)


### New Features
Following this update the Progress Bar does not say "Edit" after a step has been passed. It consistently says "Select" for the first three steps. As part of this, Jest code that tests for the step text changing functionality has been removed. 

### Bugfixes
The attrition table wrapper test has been updated to pass in a required prop for "covariates" so the test passes again. 

### After
<img width="1292" alt="image" src="https://user-images.githubusercontent.com/113449836/208527961-02c45fc2-0079-4561-9c74-80e7f4cafe20.png">
