### PR TITLE
Gracefully handle null scenario in WTSAuthz

### DIFF
--- a/src/Discovery/index.tsx
+++ b/src/Discovery/index.tsx
@@ -109,7 +109,7 @@ const DiscoveryWithMDSBackend: React.FC<{
           } else {
             let authMapping;
             if (isEnabled('discoveryUseAggWTS')) {
-              authMapping = props.userAggregateAuthMappings[(study.commons_url || hostnameWithSubdomain)];
+              authMapping = props.userAggregateAuthMappings[(study.commons_url || hostnameWithSubdomain)] || {};
             } else {
               authMapping = props.userAuthMapping;
             }


### PR DESCRIPTION
### Bug fixes
* Fixed an Aggregate authz related bug where a `null` response from a key in `wts/aggregate/authz/mapping` is gracefully handled by Data-Portal