### PR TITLE
disable filter button if study is loading

### DIFF
--- a/src/Discovery/Discovery.tsx
+++ b/src/Discovery/Discovery.tsx
@@ -758,7 +758,7 @@ const Discovery: React.FunctionComponent<Props> = (props: Props) => {
                     onClick={() => { setSearchableTagCollapsed(!searchableTagCollapsed); }}
                     icon={(searchableTagCollapsed) ? <DownOutlined /> : <UpOutlined />}
                   >
-                    {`${props.config.features.search.tagSearchDropdown.collapsibleButtonText || 'Tag Panel'}`}
+                    {`${props.config.features.search.tagSearchDropdown?.collapsibleButtonText || 'Tag Panel'}`}
                   </Button>
                 </div>
               </div>
@@ -807,6 +807,7 @@ const Discovery: React.FunctionComponent<Props> = (props: Props) => {
           setExportingToWorkspace={setExportingToWorkspace}
           filtersVisible={filtersVisible}
           setFiltersVisible={setFiltersVisible}
+          disableFilterButton={!props.studies.length}
         />
         <div className='discovery-studies__content'>
           {/* Advanced search panel */}

--- a/src/Discovery/DiscoveryActionBar.tsx
+++ b/src/Discovery/DiscoveryActionBar.tsx
@@ -47,6 +47,7 @@ interface Props {
   setExportingToWorkspace: (boolean) => void;
   filtersVisible: boolean;
   setFiltersVisible: (boolean) => void;
+  disableFilterButton: boolean;
   user: User,
   discovery: {
     actionToResume: 'download'|'export'|'manifest';
@@ -636,6 +637,7 @@ const DiscoveryActionBar = (props: Props) => {
             <Button
               className='discovery-adv-filter-button'
               onClick={() => props.setFiltersVisible(!props.filtersVisible)}
+              disabled={props.disableFilterButton}
               type='text'
             >
               {props.config.features.advSearchFilters.displayName || 'ADVANCED SEARCH'}

--- a/src/Discovery/DiscoveryAdvancedSearchPanel.tsx
+++ b/src/Discovery/DiscoveryAdvancedSearchPanel.tsx
@@ -56,7 +56,6 @@ const DiscoveryAdvancedSearchPanel = (props: Props) => (
         <Radio.Group
           size='small'
           buttonStyle='solid'
-          disabled={Object.keys(props.filterState).length === 0}
           onChange={({ target: { value } }: RadioChangeEvent) => {
             props.setFilterMultiSelectionLogic(value);
           }}

--- a/src/Discovery/DiscoveryConfig.d.ts
+++ b/src/Discovery/DiscoveryConfig.d.ts
@@ -38,6 +38,8 @@ export interface DiscoveryConfig {
             }
         },
         authorization: {
+            columnTooltip: string
+            supportedValues: any
             enabled: boolean,
             // requestAccess: { // not supported
             //     enabled: boolean,


### PR DESCRIPTION
Disable filter button if studies are still loading in deiscovery page. This is needed because the filter is using `lodash.memoize()` to create a cache for filter values. If the filter is opened before data loading finishes, there will be no value in the filter and it will not update later.

Demostration of the bug
![Kapture 2022-12-21 at 09 16 29](https://user-images.githubusercontent.com/2475897/208939859-eb6127cb-0cba-4cdc-9542-53a1039568fa.gif)


### Bug Fixes
- Discovery: disable filter button if studies are still loading

### Improvements
- Discovery: filter AND/OR logic toggle button will not be disabled
