### PR TITLE
Feat/gwas unified flow style sidebars

### DIFF
--- a/src/Analysis/GWASV2/Components/Covariates/Covariates.css
+++ b/src/Analysis/GWASV2/Components/Covariates/Covariates.css
@@ -1,5 +1,5 @@
-.GWASV2 .continuous-covariates {
-  width: 950px;
+.GWASV2 .select-covariates-container {
+  min-width: 988px;
 }
 
 .GWASV2 .submit-button {
@@ -13,12 +13,12 @@
 
 .GWASV2 .dichotomous-card {
   width: 189px;
-  background: #EBFAD3;
+  background: #ebfad3;
 }
 
 .GWASV2 .continuous-card {
   width: 189px;
-  background: #FDE3D6;
+  background: #fde3d6;
 }
 
 .GWASV2 .custom-dichotomous-covariates {

--- a/src/Analysis/GWASV2/GWASContainer.jsx
+++ b/src/Analysis/GWASV2/GWASContainer.jsx
@@ -18,69 +18,71 @@ const GWASContainer = () => {
 
   const generateStep = () => {
     switch (state.currentStep) {
-    case 0:
-      return (
-        <SelectStudyPopulation
-          selectedCohort={state.selectedStudyPopulationCohort}
-          dispatch={dispatch}
-        />
-      );
-    case 1:
-      return (
-        <SelectOutcome
-          studyPopulationCohort={state.selectedStudyPopulationCohort}
-          outcome={state.outcome}
-          dispatch={dispatch}
-        />
-      );
-    case 2:
-      return (
-        <SelectCovariates
-          studyPopulationCohort={state.selectedStudyPopulationCohort}
-          outcome={state.outcome}
-          covariates={state.covariates}
-          dispatch={dispatch}
-        />
-      );
-    case 3:
-      return (
-        <ConfigureGWAS
-          dispatch={dispatch}
-          numOfPCs={state.numPCs}
-          mafThreshold={state.mafThreshold}
-          imputationScore={state.imputationScore}
-          selectedHare={state.selectedHare}
-          covariates={state.covariates}
-          selectedCohort={state.selectedStudyPopulationCohort}
-          outcome={state.outcome}
-          showModal={false}
-        />
-      );
-    case 4:
-      return (
-        <ConfigureGWAS
-          dispatch={dispatch}
-          numOfPCs={state.numPCs}
-          mafThreshold={state.mafThreshold}
-          imputationScore={state.imputationScore}
-          selectedHare={state.selectedHare}
-          covariates={state.covariates}
-          selectedCohort={state.selectedStudyPopulationCohort}
-          outcome={state.outcome}
-          showModal
-          finalPopulationSizes={state.finalPopulationSizes}
-        />
-      );
-    default:
-      return null;
+      case 0:
+        return (
+          <SelectStudyPopulation
+            selectedCohort={state.selectedStudyPopulationCohort}
+            dispatch={dispatch}
+          />
+        );
+      case 1:
+        return (
+          <SelectOutcome
+            studyPopulationCohort={state.selectedStudyPopulationCohort}
+            outcome={state.outcome}
+            covariates={state.covariates}
+            dispatch={dispatch}
+          />
+        );
+      case 2:
+        return (
+          <SelectCovariates
+            studyPopulationCohort={state.selectedStudyPopulationCohort}
+            outcome={state.outcome}
+            covariates={state.covariates}
+            dispatch={dispatch}
+          />
+        );
+      case 3:
+        return (
+          <ConfigureGWAS
+            dispatch={dispatch}
+            numOfPCs={state.numPCs}
+            mafThreshold={state.mafThreshold}
+            imputationScore={state.imputationScore}
+            selectedHare={state.selectedHare}
+            covariates={state.covariates}
+            selectedCohort={state.selectedStudyPopulationCohort}
+            outcome={state.outcome}
+            showModal={false}
+          />
+        );
+      case 4:
+        return (
+          <ConfigureGWAS
+            dispatch={dispatch}
+            numOfPCs={state.numPCs}
+            mafThreshold={state.mafThreshold}
+            imputationScore={state.imputationScore}
+            selectedHare={state.selectedHare}
+            covariates={state.covariates}
+            selectedCohort={state.selectedStudyPopulationCohort}
+            outcome={state.outcome}
+            showModal
+            finalPopulationSizes={state.finalPopulationSizes}
+          />
+        );
+      default:
+        return null;
     }
   };
 
   let nextButtonEnabled = true;
   // step specific conditions where progress to next step needs to be blocked:
-  if ((state.currentStep === 0 && !state.selectedStudyPopulationCohort)
-    || (state.currentStep === 1 && !state.outcome)
-    || (state.currentStep === 3 && !state.selectedHare.concept_value)
+  if (
+    (state.currentStep === 0 && !state.selectedStudyPopulationCohort) ||
+    (state.currentStep === 1 && !state.outcome) ||
+    (state.currentStep === 3 && !state.selectedHare.concept_value)
   ) {
     nextButtonEnabled = false;
   }
@@ -100,10 +102,7 @@ const GWASContainer = () => {
       <div className='GWASV2'>
         <Space direction={'vertical'} className='steps-wrapper'>
           <div className='steps-content'>
-            <Space
-              direction={'vertical'}
-              align={'center'}
-            >
+            <Space direction={'vertical'} align={'center'}>
               {generateStep(state.currentStep)}
             </Space>
           </div>

--- a/src/Analysis/GWASV2/GWASContainer.jsx
+++ b/src/Analysis/GWASV2/GWASContainer.jsx
@@ -18,71 +18,71 @@ const GWASContainer = () => {
 
   const generateStep = () => {
     switch (state.currentStep) {
-      case 0:
-        return (
-          <SelectStudyPopulation
-            selectedCohort={state.selectedStudyPopulationCohort}
-            dispatch={dispatch}
-          />
-        );
-      case 1:
-        return (
-          <SelectOutcome
-            studyPopulationCohort={state.selectedStudyPopulationCohort}
-            outcome={state.outcome}
-            covariates={state.covariates}
-            dispatch={dispatch}
-          />
-        );
-      case 2:
-        return (
-          <SelectCovariates
-            studyPopulationCohort={state.selectedStudyPopulationCohort}
-            outcome={state.outcome}
-            covariates={state.covariates}
-            dispatch={dispatch}
-          />
-        );
-      case 3:
-        return (
-          <ConfigureGWAS
-            dispatch={dispatch}
-            numOfPCs={state.numPCs}
-            mafThreshold={state.mafThreshold}
-            imputationScore={state.imputationScore}
-            selectedHare={state.selectedHare}
-            covariates={state.covariates}
-            selectedCohort={state.selectedStudyPopulationCohort}
-            outcome={state.outcome}
-            showModal={false}
-          />
-        );
-      case 4:
-        return (
-          <ConfigureGWAS
-            dispatch={dispatch}
-            numOfPCs={state.numPCs}
-            mafThreshold={state.mafThreshold}
-            imputationScore={state.imputationScore}
-            selectedHare={state.selectedHare}
-            covariates={state.covariates}
-            selectedCohort={state.selectedStudyPopulationCohort}
-            outcome={state.outcome}
-            showModal
-            finalPopulationSizes={state.finalPopulationSizes}
-          />
-        );
-      default:
-        return null;
+    case 0:
+      return (
+        <SelectStudyPopulation
+          selectedCohort={state.selectedStudyPopulationCohort}
+          dispatch={dispatch}
+        />
+      );
+    case 1:
+      return (
+        <SelectOutcome
+          studyPopulationCohort={state.selectedStudyPopulationCohort}
+          outcome={state.outcome}
+          covariates={state.covariates}
+          dispatch={dispatch}
+        />
+      );
+    case 2:
+      return (
+        <SelectCovariates
+          studyPopulationCohort={state.selectedStudyPopulationCohort}
+          outcome={state.outcome}
+          covariates={state.covariates}
+          dispatch={dispatch}
+        />
+      );
+    case 3:
+      return (
+        <ConfigureGWAS
+          dispatch={dispatch}
+          numOfPCs={state.numPCs}
+          mafThreshold={state.mafThreshold}
+          imputationScore={state.imputationScore}
+          selectedHare={state.selectedHare}
+          covariates={state.covariates}
+          selectedCohort={state.selectedStudyPopulationCohort}
+          outcome={state.outcome}
+          showModal={false}
+        />
+      );
+    case 4:
+      return (
+        <ConfigureGWAS
+          dispatch={dispatch}
+          numOfPCs={state.numPCs}
+          mafThreshold={state.mafThreshold}
+          imputationScore={state.imputationScore}
+          selectedHare={state.selectedHare}
+          covariates={state.covariates}
+          selectedCohort={state.selectedStudyPopulationCohort}
+          outcome={state.outcome}
+          showModal
+          finalPopulationSizes={state.finalPopulationSizes}
+        />
+      );
+    default:
+      return null;
     }
   };
 
   let nextButtonEnabled = true;
   // step specific conditions where progress to next step needs to be blocked:
   if (
-    (state.currentStep === 0 && !state.selectedStudyPopulationCohort) ||
-    (state.currentStep === 1 && !state.outcome) ||
-    (state.currentStep === 3 && !state.selectedHare.concept_value)
+    (state.currentStep === 0 && !state.selectedStudyPopulationCohort)
+    || (state.currentStep === 1 && !state.outcome)
+    || (state.currentStep === 3 && !state.selectedHare.concept_value)
   ) {
     nextButtonEnabled = false;
   }

--- a/src/Analysis/GWASV2/Steps/SelectCovariates/SelectCovariates.css
+++ b/src/Analysis/GWASV2/Steps/SelectCovariates/SelectCovariates.css
@@ -23,11 +23,11 @@
 }
 
 .GWASV2
-  .select-covariates-container
-  .ant-table.ant-table-middle
-  .ant-table-tbody
-  > tr
-  > td {
+.select-covariates-container
+.ant-table.ant-table-middle
+.ant-table-tbody
+> tr
+> td {
   padding: 5px;
 }
 

--- a/src/Analysis/GWASV2/Steps/SelectCovariates/SelectCovariates.css
+++ b/src/Analysis/GWASV2/Steps/SelectCovariates/SelectCovariates.css
@@ -5,7 +5,6 @@
   padding: 20px;
   border: 1px solid #e2e2e3;
   background: #fff;
-  border-radius: 4px;
   height: 519px;
 }
 
@@ -24,11 +23,11 @@
 }
 
 .GWASV2
-.select-covariates-container
-.ant-table.ant-table-middle
-.ant-table-tbody
-> tr
-> td {
+  .select-covariates-container
+  .ant-table.ant-table-middle
+  .ant-table-tbody
+  > tr
+  > td {
   padding: 5px;
 }
 

--- a/src/Analysis/GWASV2/Steps/SelectOutcome/SelectOutcome.css
+++ b/src/Analysis/GWASV2/Steps/SelectOutcome/SelectOutcome.css
@@ -4,10 +4,6 @@
 
 .GWASV2 .select-outcome-container {
   padding: 20px;
-  border: 1px solid #e2e2e3;
   background: #fff;
   height: 519px;
-}
-.GWASV2 .select-outcome-container .GWASUI-flexRow {
-  width: 100%;
 }

--- a/src/Analysis/GWASV2/Steps/SelectOutcome/SelectOutcome.css
+++ b/src/Analysis/GWASV2/Steps/SelectOutcome/SelectOutcome.css
@@ -7,3 +7,7 @@
   background: #fff;
   height: 519px;
 }
+
+.GWASV2 .select-outcome-container .GWASUI-flexRow {
+  width: 100%;
+}

--- a/src/Analysis/GWASV2/Steps/SelectOutcome/SelectOutcome.css
+++ b/src/Analysis/GWASV2/Steps/SelectOutcome/SelectOutcome.css
@@ -1,5 +1,13 @@
-.select-outcome-container {
-  background: #e9eef2;
-  padding: 10px;
+.GWASUI-selectionUI {
+  border: 1px solid #e2e2e3;
+}
+
+.GWASV2 .select-outcome-container {
+  padding: 20px;
+  border: 1px solid #e2e2e3;
+  background: #fff;
   height: 519px;
+}
+.GWASV2 .select-outcome-container .GWASUI-flexRow {
+  width: 100%;
 }

--- a/src/Analysis/GWASV2/Steps/SelectOutcome/SelectOutcome.jsx
+++ b/src/Analysis/GWASV2/Steps/SelectOutcome/SelectOutcome.jsx
@@ -21,7 +21,6 @@ const SelectOutcome = ({
         <div className='select-outcome-container'>
           <ContinuousCovariates
             selectedStudyPopulationCohort={studyPopulationCohort}
-            selectedCovariates={[]} // TODO - add to props above as well and pass in here...
             outcome={outcome}
             handleClose={() => {
               setSelectionMode('');

--- a/src/Analysis/GWASV2/Steps/SelectOutcome/SelectOutcome.jsx
+++ b/src/Analysis/GWASV2/Steps/SelectOutcome/SelectOutcome.jsx
@@ -1,46 +1,58 @@
 import React, { useState } from 'react';
 import { PropTypes } from 'prop-types';
 import ContinuousCovariates from '../../Components/Covariates/ContinuousCovariates';
+import CovariatesCardsList from '../../Components/Covariates/CovariatesCardsList';
 import CustomDichotomousCovariates from '../../Components/Covariates/CustomDichotomousCovariates';
 import ACTIONS from '../../Utils/StateManagement/Actions';
+import './SelectOutcome.css';
+import '../../GWASV2.css';
 
-const SelectOutcome = ({ dispatch, studyPopulationCohort, outcome }) => {
+const SelectOutcome = ({
+  dispatch,
+  studyPopulationCohort,
+  outcome,
+  covariates,
+}) => {
   const [selectionMode, setSelectionMode] = useState('');
 
   const determineSelectOutcomeJsx = () => {
     if (selectionMode === 'continuous') {
       return (
-        <ContinuousCovariates
-          selectedStudyPopulationCohort={studyPopulationCohort}
-          selectedCovariates={[]} // TODO - add to props above as well and pass in here...
-          outcome={outcome}
-          handleClose={() => {
-            setSelectionMode('');
-          }}
-          dispatch={(chosenOutcome) => {
-            dispatch({
-              type: ACTIONS.SET_OUTCOME,
-              payload: chosenOutcome,
-            });
-          }}
-        />
+        <div className='select-outcome-container'>
+          <ContinuousCovariates
+            selectedStudyPopulationCohort={studyPopulationCohort}
+            selectedCovariates={[]} // TODO - add to props above as well and pass in here...
+            outcome={outcome}
+            handleClose={() => {
+              setSelectionMode('');
+            }}
+            dispatch={(chosenOutcome) => {
+              dispatch({
+                type: ACTIONS.SET_OUTCOME,
+                payload: chosenOutcome,
+              });
+            }}
+          />
+        </div>
       );
     }
     if (selectionMode === 'dichotomous') {
       return (
-        <CustomDichotomousCovariates
-          studyPopulationCohort={studyPopulationCohort}
-          outcome={outcome}
-          handleClose={() => {
-            setSelectionMode('');
-          }}
-          dispatch={(chosenOutcome) => {
-            dispatch({
-              type: ACTIONS.SET_OUTCOME,
-              payload: chosenOutcome,
-            });
-          }}
-        />
+        <div className='select-outcome-container'>
+          <CustomDichotomousCovariates
+            studyPopulationCohort={studyPopulationCohort}
+            outcome={outcome}
+            handleClose={() => {
+              setSelectionMode('');
+            }}
+            dispatch={(chosenOutcome) => {
+              dispatch({
+                type: ACTIONS.SET_OUTCOME,
+                payload: chosenOutcome,
+              });
+            }}
+          />
+        </div>
       );
     }
 
@@ -59,7 +71,22 @@ const SelectOutcome = ({ dispatch, studyPopulationCohort, outcome }) => {
   };
 
   // Outputs the JSX for the component:
-  return <div>{determineSelectOutcomeJsx()}</div>;
+  return (
+    <div className='GWASUI-row'>
+      <div className='GWASUI-double-column'>{determineSelectOutcomeJsx()}</div>
+      <div className='GWASUI-column GWASUI-card-column'>
+        <CovariatesCardsList
+          covariates={covariates}
+          deleteCovariate={(chosenCovariate) =>
+            dispatch({
+              type: ACTIONS.DELETE_COVARIATE,
+              payload: chosenCovariate,
+            })
+          }
+        />
+      </div>
+    </div>
+  );
 };
 
 SelectOutcome.propTypes = {

--- a/src/Analysis/GWASV2/Steps/SelectOutcome/SelectOutcome.jsx
+++ b/src/Analysis/GWASV2/Steps/SelectOutcome/SelectOutcome.jsx
@@ -76,10 +76,12 @@ const SelectOutcome = ({
       <div className='GWASUI-column GWASUI-card-column'>
         <CovariatesCardsList
           covariates={covariates}
-          deleteCovariate={(chosenCovariate) => dispatch({
-            type: ACTIONS.DELETE_COVARIATE,
-            payload: chosenCovariate,
-          })}
+          deleteCovariate={(chosenCovariate) =>
+            dispatch({
+              type: ACTIONS.DELETE_COVARIATE,
+              payload: chosenCovariate,
+            })
+          }
         />
       </div>
     </div>
@@ -90,11 +92,12 @@ SelectOutcome.propTypes = {
   dispatch: PropTypes.func.isRequired,
   studyPopulationCohort: PropTypes.object.isRequired,
   outcome: PropTypes.object,
-  covariates: PropTypes.object.isRequired,
+  covariates: PropTypes.object,
 };
 
 SelectOutcome.defaultProps = {
   outcome: null,
+  covariates: null,
 };
 
 export default SelectOutcome;

--- a/src/Analysis/GWASV2/Steps/SelectOutcome/SelectOutcome.jsx
+++ b/src/Analysis/GWASV2/Steps/SelectOutcome/SelectOutcome.jsx
@@ -76,12 +76,10 @@ const SelectOutcome = ({
       <div className='GWASUI-column GWASUI-card-column'>
         <CovariatesCardsList
           covariates={covariates}
-          deleteCovariate={(chosenCovariate) =>
-            dispatch({
-              type: ACTIONS.DELETE_COVARIATE,
-              payload: chosenCovariate,
-            })
-          }
+          deleteCovariate={(chosenCovariate) => dispatch({
+            type: ACTIONS.DELETE_COVARIATE,
+            payload: chosenCovariate,
+          })}
         />
       </div>
     </div>

--- a/src/Analysis/GWASV2/Steps/SelectOutcome/SelectOutcome.jsx
+++ b/src/Analysis/GWASV2/Steps/SelectOutcome/SelectOutcome.jsx
@@ -77,12 +77,10 @@ const SelectOutcome = ({
       <div className='GWASUI-column GWASUI-card-column'>
         <CovariatesCardsList
           covariates={covariates}
-          deleteCovariate={(chosenCovariate) =>
-            dispatch({
-              type: ACTIONS.DELETE_COVARIATE,
-              payload: chosenCovariate,
-            })
-          }
+          deleteCovariate={(chosenCovariate) => dispatch({
+            type: ACTIONS.DELETE_COVARIATE,
+            payload: chosenCovariate,
+          })}
         />
       </div>
     </div>
@@ -93,6 +91,7 @@ SelectOutcome.propTypes = {
   dispatch: PropTypes.func.isRequired,
   studyPopulationCohort: PropTypes.object.isRequired,
   outcome: PropTypes.object,
+  covariates: PropTypes.object.isRequired,
 };
 
 SelectOutcome.defaultProps = {

--- a/src/Analysis/GWASV2/Steps/SelectOutcome/SelectOutcome.jsx
+++ b/src/Analysis/GWASV2/Steps/SelectOutcome/SelectOutcome.jsx
@@ -90,12 +90,12 @@ SelectOutcome.propTypes = {
   dispatch: PropTypes.func.isRequired,
   studyPopulationCohort: PropTypes.object.isRequired,
   outcome: PropTypes.object,
-  covariates: PropTypes.object,
+  covariates: PropTypes.array,
 };
 
 SelectOutcome.defaultProps = {
   outcome: null,
-  covariates: null,
+  covariates: [],
 };
 
 export default SelectOutcome;


### PR DESCRIPTION
Jira Ticket: [VADC-364](https://ctds-planx.atlassian.net/browse/VADC-364)

### New Features
This adds a side bar for views 2.0,2.1, and 2.2 in the GWAS++ app. The size of the sidebar and the cards in it remains consistent between views 2 and 3. It also displays covariates after they've been added in step 2, such as when a user advances to step 3 and selects a covariate and then goes back to step 2. 

Note this ticket only addresses the sidebar. Addition of the outcome card and styling for the table size, charts and button positions will be done in separate tickets / PRs.

### Bug Fixes
Removed unneeded border radius from selection UI on view 3. 


### Screen shots
![output](https://user-images.githubusercontent.com/113449836/211620341-332cf1cd-2d12-48c6-8c45-1ace87158e3f.gif)


[VADC-364]: https://ctds-planx.atlassian.net/browse/VADC-364?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ