### PR TITLE
Feat/gwas unified flow outcome card

### DIFF
--- a/src/Analysis/GWASV2/Components/Covariates/Covariates.css
+++ b/src/Analysis/GWASV2/Components/Covariates/Covariates.css
@@ -11,13 +11,15 @@
   margin-top: 8px;
 }
 
+.GWASV2 .outcome-card {
+  background: #cae6f1;
+}
+
 .GWASV2 .dichotomous-card {
-  width: 189px;
   background: #ebfad3;
 }
 
 .GWASV2 .continuous-card {
-  width: 189px;
   background: #fde3d6;
 }
 

--- a/src/Analysis/GWASV2/Components/Covariates/CovariatesCardList.test.js
+++ b/src/Analysis/GWASV2/Components/Covariates/CovariatesCardList.test.js
@@ -1,0 +1,74 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import { DeleteOutlined } from '@ant-design/icons';
+import { Card } from 'antd';
+import CovariatesCardsList from './CovariatesCardsList';
+
+describe('CovariatesCardsList component', () => {
+  let wrapper;
+  let mockDeleteCovariate;
+
+  beforeEach(() => {
+    mockDeleteCovariate = jest.fn();
+
+    const mockProps = {
+      outcome: { provided_name: 'test outcome' },
+      covariates: [
+        { provided_name: 'test dichotomous covariate', concept_id: null },
+        { concept_name: 'test continuous covariate', concept_id: '123' },
+      ],
+      deleteCovariate: mockDeleteCovariate,
+    };
+
+    wrapper = mount(<CovariatesCardsList {...mockProps} />);
+    console.log(wrapper.debug());
+  });
+
+  it('should render an outcome card', () => {
+    expect(wrapper.find('.outcome-card').exists()).toBe(true);
+    expect(wrapper.find('.outcome-card .ant-card-meta-title').text()).toBe(
+      'Outcome'
+    );
+    expect(
+      wrapper.find('.outcome-card .ant-card-meta-description').text()
+    ).toBe('test outcome');
+  });
+
+  it('should render two covariate cards', () => {
+    expect(wrapper.find('.dichotomous-card').exists()).toBe(true);
+    expect(wrapper.find('.dichotomous-card .ant-card-meta-title').text()).toBe(
+      'Dichotomous Covariate'
+    );
+    expect(
+      wrapper.find('.dichotomous-card .ant-card-meta-description').text()
+    ).toBe('test dichotomous covariate');
+
+    expect(wrapper.find('.continuous-card').exists()).toBe(true);
+    expect(wrapper.find('.continuous-card .ant-card-meta-title').text()).toBe(
+      'Continuous Covariate'
+    );
+    expect(
+      wrapper.find('.continuous-card .ant-card-meta-description').text()
+    ).toBe('test continuous covariate');
+  });
+
+  it('should call deleteCovariate when the delete icon is clicked', () => {
+    wrapper
+      .find(DeleteOutlined)
+      .first()
+      .simulate('click');
+    expect(mockDeleteCovariate).toHaveBeenCalledWith({
+      provided_name: 'test dichotomous covariate',
+      concept_id: null,
+    });
+
+    wrapper
+      .find(DeleteOutlined)
+      .last()
+      .simulate('click');
+    expect(mockDeleteCovariate).toHaveBeenCalledWith({
+      concept_name: 'test continuous covariate',
+      concept_id: '123',
+    });
+  });
+});

--- a/src/Analysis/GWASV2/Components/Covariates/CovariatesCardList.test.jsx
+++ b/src/Analysis/GWASV2/Components/Covariates/CovariatesCardList.test.jsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import { mount } from 'enzyme';
 import { DeleteOutlined } from '@ant-design/icons';
-import { Card } from 'antd';
 import CovariatesCardsList from './CovariatesCardsList';
+import ValidInitialState from '../../TestData/InitialStates/ValidInitialState';
 
 describe('CovariatesCardsList component', () => {
   let wrapper;
@@ -12,16 +12,15 @@ describe('CovariatesCardsList component', () => {
     mockDeleteCovariate = jest.fn();
 
     const mockProps = {
-      outcome: { provided_name: 'test outcome' },
+      outcome: ValidInitialState.outcome,
       covariates: [
-        { provided_name: 'test dichotomous covariate', concept_id: null },
-        { concept_name: 'test continuous covariate', concept_id: '123' },
+        { provided_name: 'test dichotomous covariate', concept_id: 123 },
+        { concept_name: 'test continuous covariate', concept_id: 456 },
       ],
       deleteCovariate: mockDeleteCovariate,
     };
 
     wrapper = mount(<CovariatesCardsList {...mockProps} />);
-    console.log(wrapper.debug());
   });
 
   it('should render an outcome card', () => {
@@ -31,24 +30,36 @@ describe('CovariatesCardsList component', () => {
     );
     expect(
       wrapper.find('.outcome-card .ant-card-meta-description').text()
-    ).toBe('test outcome');
+    ).toBe('Attribute8');
   });
 
   it('should render two covariate cards', () => {
     expect(wrapper.find('.dichotomous-card').exists()).toBe(true);
-    expect(wrapper.find('.dichotomous-card .ant-card-meta-title').text()).toBe(
-      'Dichotomous Covariate'
-    );
     expect(
-      wrapper.find('.dichotomous-card .ant-card-meta-description').text()
+      wrapper
+        .find('.dichotomous-card .ant-card-meta-title')
+        .last()
+        .text()
+    ).toBe('Dichotomous Covariate');
+    expect(
+      wrapper
+        .find('.dichotomous-card .ant-card-meta-description')
+        .last()
+        .text()
     ).toBe('test dichotomous covariate');
 
     expect(wrapper.find('.continuous-card').exists()).toBe(true);
-    expect(wrapper.find('.continuous-card .ant-card-meta-title').text()).toBe(
-      'Continuous Covariate'
-    );
     expect(
-      wrapper.find('.continuous-card .ant-card-meta-description').text()
+      wrapper
+        .find('.continuous-card .ant-card-meta-title')
+        .last()
+        .text()
+    ).toBe('Continuous Covariate');
+    expect(
+      wrapper
+        .find('.continuous-card .ant-card-meta-description')
+        .last()
+        .text()
     ).toBe('test continuous covariate');
   });
 
@@ -59,7 +70,7 @@ describe('CovariatesCardsList component', () => {
       .simulate('click');
     expect(mockDeleteCovariate).toHaveBeenCalledWith({
       provided_name: 'test dichotomous covariate',
-      concept_id: null,
+      concept_id: 123,
     });
 
     wrapper
@@ -68,7 +79,7 @@ describe('CovariatesCardsList component', () => {
       .simulate('click');
     expect(mockDeleteCovariate).toHaveBeenCalledWith({
       concept_name: 'test continuous covariate',
-      concept_id: '123',
+      concept_id: 456,
     });
   });
 });

--- a/src/Analysis/GWASV2/Components/Covariates/CovariatesCardList.test.jsx
+++ b/src/Analysis/GWASV2/Components/Covariates/CovariatesCardList.test.jsx
@@ -6,11 +6,9 @@ import ValidInitialState from '../../TestData/InitialStates/ValidInitialState';
 
 describe('CovariatesCardsList component', () => {
   let wrapper;
-  let mockDeleteCovariate;
+  const mockDeleteCovariate = jest.fn();
 
   beforeEach(() => {
-    mockDeleteCovariate = jest.fn();
-
     const mockProps = {
       outcome: ValidInitialState.outcome,
       covariates: [
@@ -19,17 +17,16 @@ describe('CovariatesCardsList component', () => {
       ],
       deleteCovariate: mockDeleteCovariate,
     };
-
     wrapper = mount(<CovariatesCardsList {...mockProps} />);
   });
 
   it('should render an outcome card', () => {
     expect(wrapper.find('.outcome-card').exists()).toBe(true);
     expect(wrapper.find('.outcome-card .ant-card-meta-title').text()).toBe(
-      'Outcome'
+      'Outcome',
     );
     expect(
-      wrapper.find('.outcome-card .ant-card-meta-description').text()
+      wrapper.find('.outcome-card .ant-card-meta-description').text(),
     ).toBe('Attribute8');
   });
 
@@ -39,13 +36,13 @@ describe('CovariatesCardsList component', () => {
       wrapper
         .find('.dichotomous-card .ant-card-meta-title')
         .last()
-        .text()
+        .text(),
     ).toBe('Dichotomous Covariate');
     expect(
       wrapper
         .find('.dichotomous-card .ant-card-meta-description')
         .last()
-        .text()
+        .text(),
     ).toBe('test dichotomous covariate');
 
     expect(wrapper.find('.continuous-card').exists()).toBe(true);
@@ -53,13 +50,13 @@ describe('CovariatesCardsList component', () => {
       wrapper
         .find('.continuous-card .ant-card-meta-title')
         .last()
-        .text()
+        .text(),
     ).toBe('Continuous Covariate');
     expect(
       wrapper
         .find('.continuous-card .ant-card-meta-description')
         .last()
-        .text()
+        .text(),
     ).toBe('test continuous covariate');
   });
 
@@ -72,7 +69,6 @@ describe('CovariatesCardsList component', () => {
       provided_name: 'test dichotomous covariate',
       concept_id: 123,
     });
-
     wrapper
       .find(DeleteOutlined)
       .last()

--- a/src/Analysis/GWASV2/Components/Covariates/CovariatesCardsList.jsx
+++ b/src/Analysis/GWASV2/Components/Covariates/CovariatesCardsList.jsx
@@ -5,8 +5,16 @@ import { Card } from 'antd';
 
 const { Meta } = Card;
 
-const CovariatesCardsList = ({ covariates, deleteCovariate }) => (
+const CovariatesCardsList = ({ covariates, outcome, deleteCovariate }) => (
   <div className='GWASUI-cdList'>
+    {outcome && (
+      <Card className='outcome-card'>
+        <Meta
+          title='Outcome '
+          description={`${outcome.provided_name || outcome.concept_name}`}
+        />
+      </Card>
+    )}
     {covariates.map((covariate, key) => (
       <React.Fragment key={key}>
         {covariate.provided_name && (
@@ -53,8 +61,13 @@ const CovariatesCardsList = ({ covariates, deleteCovariate }) => (
 );
 
 CovariatesCardsList.propTypes = {
-  covariates: PropTypes.array.isRequired,
+  covariates: PropTypes.array,
+  outcome: PropTypes.object,
   deleteCovariate: PropTypes.func.isRequired,
+};
+CovariatesCardsList.defaultProps = {
+  outcome: null,
+  covariates: [],
 };
 
 export default CovariatesCardsList;

--- a/src/Analysis/GWASV2/Components/Covariates/CovariatesCardsList.jsx
+++ b/src/Analysis/GWASV2/Components/Covariates/CovariatesCardsList.jsx
@@ -16,10 +16,10 @@ const CovariatesCardsList = ({ covariates, outcome, deleteCovariate }) => (
       </Card>
     )}
     {covariates.map((covariate, key) => (
-      <React.Fragment key={key}>
+      <React.Fragment key={covariate + key}>
         {covariate.provided_name && (
           <Card
-            key={`cd-list-option-${key}`}
+            key={`cd-list-option-${covariate + key}`}
             className='dichotomous-card'
             actions={[
               <DeleteOutlined

--- a/src/Analysis/GWASV2/Components/Covariates/CovariatesCardsList.jsx
+++ b/src/Analysis/GWASV2/Components/Covariates/CovariatesCardsList.jsx
@@ -10,7 +10,7 @@ const CovariatesCardsList = ({ covariates, outcome, deleteCovariate }) => (
     {outcome && (
       <Card className='outcome-card'>
         <Meta
-          title='Outcome '
+          title='Outcome'
           description={`${outcome.provided_name || outcome.concept_name}`}
         />
       </Card>

--- a/src/Analysis/GWASV2/Steps/SelectCovariates/SelectCovariates.jsx
+++ b/src/Analysis/GWASV2/Steps/SelectCovariates/SelectCovariates.jsx
@@ -83,12 +83,10 @@ const SelectCovariates = ({
           <CovariatesCardsList
             covariates={covariates}
             outcome={outcome}
-            deleteCovariate={(chosenCovariate) =>
-              dispatch({
-                type: ACTIONS.DELETE_COVARIATE,
-                payload: chosenCovariate,
-              })
-            }
+            deleteCovariate={(chosenCovariate) => dispatch({
+              type: ACTIONS.DELETE_COVARIATE,
+              payload: chosenCovariate,
+            })}
           />
         </div>
       </div>

--- a/src/Analysis/GWASV2/Steps/SelectCovariates/SelectCovariates.jsx
+++ b/src/Analysis/GWASV2/Steps/SelectCovariates/SelectCovariates.jsx
@@ -82,10 +82,13 @@ const SelectCovariates = ({
         <div className='GWASUI-column GWASUI-card-column'>
           <CovariatesCardsList
             covariates={covariates}
-            deleteCovariate={(chosenCovariate) => dispatch({
-              type: ACTIONS.DELETE_COVARIATE,
-              payload: chosenCovariate,
-            })}
+            outcome={outcome}
+            deleteCovariate={(chosenCovariate) =>
+              dispatch({
+                type: ACTIONS.DELETE_COVARIATE,
+                payload: chosenCovariate,
+              })
+            }
           />
         </div>
       </div>

--- a/src/Analysis/GWASV2/Steps/SelectOutcome/SelectOutcome.jsx
+++ b/src/Analysis/GWASV2/Steps/SelectOutcome/SelectOutcome.jsx
@@ -77,12 +77,10 @@ const SelectOutcome = ({
         <CovariatesCardsList
           covariates={covariates}
           outcome={outcome}
-          deleteCovariate={(chosenCovariate) =>
-            dispatch({
-              type: ACTIONS.DELETE_COVARIATE,
-              payload: chosenCovariate,
-            })
-          }
+          deleteCovariate={(chosenCovariate) => dispatch({
+            type: ACTIONS.DELETE_COVARIATE,
+            payload: chosenCovariate,
+          })}
         />
       </div>
     </div>

--- a/src/Analysis/GWASV2/Steps/SelectOutcome/SelectOutcome.jsx
+++ b/src/Analysis/GWASV2/Steps/SelectOutcome/SelectOutcome.jsx
@@ -76,10 +76,13 @@ const SelectOutcome = ({
       <div className='GWASUI-column GWASUI-card-column'>
         <CovariatesCardsList
           covariates={covariates}
-          deleteCovariate={(chosenCovariate) => dispatch({
-            type: ACTIONS.DELETE_COVARIATE,
-            payload: chosenCovariate,
-          })}
+          outcome={outcome}
+          deleteCovariate={(chosenCovariate) =>
+            dispatch({
+              type: ACTIONS.DELETE_COVARIATE,
+              payload: chosenCovariate,
+            })
+          }
         />
       </div>
     </div>


### PR DESCRIPTION
Jira Ticket: [VADC-366](https://ctds-planx.atlassian.net/browse/VADC-366)

### New Features
This adds feature so that an outcome card shows in the the sidebar after a user selects an outcome and has been styled to match the design. 

### Bug Fixes
The covariate object has been added to the covariate card list keys to help avoid a duplicate key error in React. 

### Improvements
A test has been created for the CovariatesCardList.jsx

### Design
<img width="164" alt="image" src="https://user-images.githubusercontent.com/113449836/212348881-85116969-2866-4166-8a4c-3faf4719399f.png">

### Implementation

