### PR TITLE
VADC-393: fix query config import

### DIFF
--- a/src/Analysis/GWASV2/Components/SelectCohort/Utils/CohortDefinitions.jsx
+++ b/src/Analysis/GWASV2/Components/SelectCohort/Utils/CohortDefinitions.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import useQuery from 'react-query';
+import { useQuery } from 'react-query';
 import { Table, Spin } from 'antd';
 import { fetchCohortDefinitions, queryConfig } from '../../../Utils/cohortMiddlewareApi';
 import { useFetch, useFilter } from '../../../Utils/formHooks';

--- a/src/Analysis/GWASV2/Components/SelectCohort/Utils/CohortDefinitions.jsx
+++ b/src/Analysis/GWASV2/Components/SelectCohort/Utils/CohortDefinitions.jsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { useQuery, queryConfig } from 'react-query';
+import useQuery from 'react-query';
 import { Table, Spin } from 'antd';
-import { fetchCohortDefinitions } from '../../../Utils/cohortMiddlewareApi';
+import { fetchCohortDefinitions, queryConfig } from '../../../Utils/cohortMiddlewareApi';
 import { useFetch, useFilter } from '../../../Utils/formHooks';
 import { useSourceContext } from '../../../Utils/Source';
 


### PR DESCRIPTION
import `queryConfig` from `cohortMiddlewareApi.js` instead of `react-query` for cohort listing.

[VADC-393](https://ctds-planx.atlassian.net/browse/VADC-393)

[VADC-393]: https://ctds-planx.atlassian.net/browse/VADC-393?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ