### PR TITLE
Remove _unique_id from portal logic

### DIFF
--- a/src/Discovery/aggMDSUtils.jsx
+++ b/src/Discovery/aggMDSUtils.jsx
@@ -64,7 +64,6 @@ const loadStudiesFromAggMDSRequests = async (offset, limit) => {
       x.study_id = studyId;
       x.commons = commonsName;
       x.frontend_uid = `${commonsName}_${index}`;
-      x._unique_id = `${commonsName}_${x._unique_id}_${index}`;
       x.commons_url = commonsInfo.commons_url;
       x.tags = x.tags || [];
       x.tags.push(Object({ category: 'Commons', name: commonsName }));

--- a/src/Discovery/aggMDSUtils.jsx
+++ b/src/Discovery/aggMDSUtils.jsx
@@ -64,6 +64,7 @@ const loadStudiesFromAggMDSRequests = async (offset, limit) => {
       x.study_id = studyId;
       x.commons = commonsName;
       x.frontend_uid = `${commonsName}_${index}`;
+      x._unique_id = `${commonsName}_${x._unique_id}_${index}`;
       x.commons_url = commonsInfo.commons_url;
       x.tags = x.tags || [];
       x.tags.push(Object({ category: 'Commons', name: commonsName }));


### PR DESCRIPTION
### Improvements
* Prevent portal from updating `_unique_id`  to `${commonsName}_${x._unique_id}_${index}` to bring consistency to the id of the studies regardless of their  order in MDS