### PR TITLE
PXP-10565/PPS-177 fix: exclude file nodes from chart with options

### DIFF
--- a/data/dictionaryHelper.js
+++ b/data/dictionaryHelper.js
@@ -50,6 +50,7 @@ function getGraphQL(graphQLParams) {
   const { boardCounts } = graphQLParams;
   const { chartCounts } = graphQLParams;
   let { projectDetails } = graphQLParams;
+  const { chartNodesExcludeFiles } = graphQLParams;
   if (typeof projectDetails === 'string') {
     projectDetails = graphQLParams[projectDetails];
   }
@@ -57,6 +58,7 @@ function getGraphQL(graphQLParams) {
     boardCounts,
     chartCounts,
     projectDetails,
+    chartNodesExcludeFiles,
   };
 }
 

--- a/data/getTexts.js
+++ b/data/getTexts.js
@@ -6,11 +6,12 @@ const componentTexts = paramByApp(params, 'components');
 function getChartText() {
   const graphQL = getGraphQL(paramByApp(params, 'graphql'));
   const boardPluralNames = graphQL.boardCounts.map((item) => item.plural);
-  if (boardPluralNames.length < 4) { boardPluralNames.push('Files'); }
+  console.log(boardPluralNames);
+  if (boardPluralNames.length < 4 && !graphQL.chartNodesExcludeFiles) { boardPluralNames.push('Files'); }
   const detailPluralNames = graphQL.projectDetails.map((item) => item.plural);
-  if (detailPluralNames.length < 4) { detailPluralNames.push('Files'); }
+  if (detailPluralNames.length < 4 && !graphQL.chartNodesExcludeFiles) { detailPluralNames.push('Files'); }
   const indexChartNames = graphQL.boardCounts.map((item) => item.plural);
-  if (indexChartNames.length < 4) { indexChartNames.push('Files'); }
+  if (indexChartNames.length < 4 && !graphQL.chartNodesExcludeFiles) { indexChartNames.push('Files'); }
   return {
     boardPluralNames,
     chartNames: graphQL.chartCounts.map((item) => item.name),

--- a/data/getTexts.js
+++ b/data/getTexts.js
@@ -6,7 +6,6 @@ const componentTexts = paramByApp(params, 'components');
 function getChartText() {
   const graphQL = getGraphQL(paramByApp(params, 'graphql'));
   const boardPluralNames = graphQL.boardCounts.map((item) => item.plural);
-  console.log(boardPluralNames);
   if (boardPluralNames.length < 4 && !graphQL.chartNodesExcludeFiles) { boardPluralNames.push('Files'); }
   const detailPluralNames = graphQL.projectDetails.map((item) => item.plural);
   if (detailPluralNames.length < 4 && !graphQL.chartNodesExcludeFiles) { detailPluralNames.push('Files'); }

--- a/docs/portal_config.md
+++ b/docs/portal_config.md
@@ -42,7 +42,8 @@ Below is an example, with inline comments describing what each JSON block config
         "name": "Study"
       }
     ],
-    "projectDetails": "boardCounts" // required; which JSON block above to use for displaying aggregate properties on the submission page (www.project.io/submission)
+    "projectDetails": "boardCounts", // required; which JSON block above to use for displaying aggregate properties on the submission page (/submission)
+    "chartNodesExcludeFiles": true // optional; specifies whether to exclude File nodes from charts. Defaults to false
   },
   "components": {
     "appName": "Gen3 Generic Data Commons", // required; title of commons that appears on the homepage
@@ -78,6 +79,8 @@ Below is an example, with inline comments describing what each JSON block config
           "label": "Run analysis"
         }
       ],
+      "homepageChartNodesExcludeFiles": true, // optional; specifies whether to exclude File nodes from the homepage chart. Defaults to false
+      "homepageChartNodesChunkSize": 5, // optional; specifies the number of node for each chunked request for homepage nodes that is being send to Peregrine. Defaults to 15
       "homepageChartNodes": [ // optional; used for tiered access on the homepage. This means that the charts on the homepage will be available to the public.
         {
           "node": "case", // required; GraphQL field name of node to show a chart for
@@ -129,7 +132,7 @@ Below is an example, with inline comments describing what each JSON block config
           "name": "Documentation"
         }
       ],
-      "useProfileDropdown": false // optional; enables expiremental profile UI; defaults false, may change in future releases
+      "useProfileDropdown": false // optional; enables experimental profile UI; defaults false, may change in future releases
     },
     "login": { // required; what is displayed on the login page (/login)
       "title": "Gen3 Generic Data Commons", // optional; title for the login page
@@ -141,8 +144,8 @@ Below is an example, with inline comments describing what each JSON block config
     },
    "systemUse" : { // optional; will show a Use Message in a popup, to inform users of the use policy of the commons. It will display a message which requires acceptance before a user can use the site.
       "systemUseTitle" : "", // required; Title of the popup dialog
-      "systemUseText" : [""] // required; Message to show in a popup which is used to notify the user of site policy and use restrictions
-      "expireUseMsgDays" : optional; 0, // the number of days to keep cookie once the "Accept" button is clicked, the default is 0 which sets the cookie to be a browser session cookie
+      "systemUseText" : [""], // required; Message to show in a popup which is used to notify the user of site policy and use restrictions
+      "expireUseMsgDays" : 0, // optional; the number of days to keep cookie once the "Accept" button is clicked, the default is 0 which sets the cookie to be a browser session cookie
     },
     "footer": {
       "externalURL": "/external/footer" // iframe link to raw html from another source (ie frontend framework) to pull a footer from
@@ -172,12 +175,12 @@ Below is an example, with inline comments describing what each JSON block config
   "requiredCerts": [], // optional; do users need to take a quiz or agree to something before they can access the site?
   "featureFlags": { // optional; will hide certain parts of the site if needed
     "explorer": true, // required; indicates the flag and whether to hide it or not
-    "explorerPublic": true // optional; If set to true, the data explorer page would be treated as a public component and can be accessed without login. The Data Explorer page would be publicly accessible if 1. tiered access level is set to libre OR 2. this explorerPublic flag is set to true.
+    "explorerPublic": true, // optional; If set to true, the data explorer page would be treated as a public component and can be accessed without login. The Data Explorer page would be publicly accessible if 1. tiered access level is set to libre OR 2. this explorerPublic flag is set to true.
     "discovery": true, // optional; whether to enable the Discovery page. If true, `discoveryConfig` must be present as well.
-    "discoveryUseAggMDS": true // optional, false by default; if true, the Discovery page will use the Aggregate Metadata path instead of the Metadata path. This causes the Discovery page to serve as an "Ecosystem Browser". See docs/ecosystem_browser.md for more details.
+    "discoveryUseAggMDS": true, // optional, false by default; if true, the Discovery page will use the Aggregate Metadata path instead of the Metadata path. This causes the Discovery page to serve as an "Ecosystem Browser". See docs/ecosystem_browser.md for more details.
     "explorerStoreFilterInURL": true, // optional; whether to store/load applied filters in the URL during Data Explorer use.
-    This feature currently supports single select filters and range filters; it
-    lacks support for search filter state, accessibility state, table state.
+    // This feature currently supports single select filters and range filters; it
+    // lacks support for search filter state, accessibility state, table state.
     "explorerHideEmptyFilterSection": false, // optional, when filtering data hide FilterSection when they are empty.
     "explorerFilterValuesToHide": ["array of strings"], // optional, Values set in array will be hidden in guppy filters. Intended use is to hide missing data category from filters, for this it should be set to the same as `missing_data_alias` in Guppy server config
     "studyRegistration": true, // optional, whether to enable the study registration feature
@@ -428,13 +431,13 @@ Below is an example, with inline comments describing what each JSON block config
     "public": true, // optional, defaults to true. If false, requires user to sign in before seeing the Discovery page
     "features": {
       "exportToWorkspace": { // configures the export to workspace feature. If enabled, the Discovery page data must contain a field which is a list of GUIDs for each study. See `manifestFieldName`
-          "enable": boolean
-          "enableDownloadManifest": boolean // enables a button which allows user to download a manifest file for gen3 client
-          "downloadManifestButtonText": string // text to be displayed on the download manifest button
-          "manifestFieldName": string // the field in the Discovery page data that contains the list of GUIDs that link to each study's data files.
+          "enable": boolean,
+          "enableDownloadManifest": boolean, // enables a button which allows user to download a manifest file for gen3 client
+          "downloadManifestButtonText": string, // text to be displayed on the download manifest button
+          "manifestFieldName": string, // the field in the Discovery page data that contains the list of GUIDs that link to each study's data files.
           "documentationLinks": {
-              "gen3Client": string // link to documentation about the gen3 client. Used for button tooltips
-              "gen3Workspaces": string // link to documentation about gen3 workspaces. Used for button tooltips.
+              "gen3Client": string, // link to documentation about the gen3 client. Used for button tooltips
+              "gen3Workspaces": string, // link to documentation about gen3 workspaces. Used for button tooltips.
           }
       },
       "pageTitle": {
@@ -528,7 +531,7 @@ Below is an example, with inline comments describing what each JSON block config
       {
         "name": "Commons",
         "field": "commons_of_origin",
-        "hrefValueFromField": "commons_url", // If this attribute is present, the text in the column will be linked. The href value of the link will be the corresponding value of the fieldname in this attribute.
+        "hrefValueFromField": "commons_url", // If this attribute is present, the text in the column will be linked. The href value of the link will be the corresponding value of the field name in this attribute.
       }
     ],
     "studyPreviewField": { // if present, studyPreviewField shows a special preview field beneath each row of data in the table, useful for study descriptions.
@@ -539,7 +542,7 @@ Below is an example, with inline comments describing what each JSON block config
       "includeIfNotAvailable": true,
       "valueIfNotAvailable": "No description has been provided for this study."
     },
-    // consider updated "detailView" configufation with tabbing option
+    // consider updated "detailView" configuration with tabbing option
     "studyPageFields": { // studyPageFields configures the fields that are displayed when a user opens a study page by clicking on a row in the table.
       "header": { // if present, shows a header field at the top of the study page.
         "field": "name"
@@ -632,7 +635,7 @@ Below is an example, with inline comments describing what each JSON block config
     "tagCategories": [ // configures the categories displayed in the tag selector. If a tag category appears in the `tagsListFieldName` field but is not configured here, it will not be displayed in the tag selector.
       {
         "name": "Program", // this configures the tag category name that will be shown on the tag selector
-        "color": "rgba(129, 211, 248, 1)", // color can be any vaid CSS color string, including hex, rgb, rgba, hsl
+        "color": "rgba(129, 211, 248, 1)", // color can be any valid CSS color string, including hex, rgb, rgba, hsl
         "display": true,
         "displayName": "All Programs" // optional string to customize tag category display name
       },
@@ -647,10 +650,10 @@ Below is an example, with inline comments describing what each JSON block config
         "display": true
       }
     ],
-    "tagsDisplayName": "Tags" // optional, overrides the name of the mandatory tags column
+    "tagsDisplayName": "Tags", // optional, overrides the name of the mandatory tags column
     "tableScrollHeight": 450 // optional, no scroll if omitted
   },
-  "resourceBrowser": {), // see Resource Browser documentation
+  "resourceBrowser": {}, // see Resource Browser documentation
   "workspacePageTitle": "", // title to display above workspacePageDescription
   "workspacePageDescription": "", // html to display above the workspace options
   "studyViewerConfig": [],//See docs/study_viewer.md for more details.
@@ -698,7 +701,7 @@ Below is an example, with inline comments describing what each JSON block config
         "workspaceRegistrationConfig" : { // optional, config for Workspace Registration Request Access page.
         "workspacePolicyId": "workspace", // optional, name of the policy that is needed to provide workspace access; if missing, defaults to 'workspace'
         "workspaceInfoMessage": "Please fill out this form to request and be approved for access to workspace.", //optional, any info message to give users more context before they fill the request access form
-        "successRedirect" : { // optional, upon succesful submission of the registration form, the user is presented with a button to go to a specific page. defaults to `{ link: '/', text: 'Go to Home Page' }`
+        "successRedirect" : { // optional, upon successful submission of the registration form, the user is presented with a button to go to a specific page. defaults to `{ link: '/', text: 'Go to Home Page' }`
           "link": "/discovery",
           "text": "Go to Discovery Page"
         }

--- a/sanity-check.js
+++ b/sanity-check.js
@@ -9,8 +9,8 @@ function makeSureHomepageChartWorks() {
   function parseNodeType(countName) {
     return countName.substring(1, countName.length - '_count'.length);
   }
-  const boardCountNodes = params.config.graphql.boardCounts.map(e => parseNodeType(e.graphql));
-  const chartCountNodes = params.config.graphql.chartCounts.map(e => parseNodeType(e.graphql));
+  const boardCountNodes = params.config.graphql.boardCounts.map((e) => parseNodeType(e.graphql));
+  const chartCountNodes = params.config.graphql.chartCounts.map((e) => parseNodeType(e.graphql));
 
   /**
    * Check if all nodes exist in dictionary

--- a/src/Index/nctPage.jsx
+++ b/src/Index/nctPage.jsx
@@ -73,11 +73,10 @@ class IndexPageComponent extends React.Component {
       });
     }
 
-    // indexChartNames and chartNames has to > 1 in here since by default we push in 'Files' as chart if there is less than 4 chart fields
-    // FIXME: remove this fix once we get rid of the pushing 'Files' into charts by default logic
-    if ((homepageChartNodes && homepageChartNodes.length > 0)
-    || (components.charts && components.charts.indexChartNames && components.charts.indexChartNames.length > 1)
-    || (components.charts && components.charts.chartNames && components.charts.chartNames.length > 1)
+    // if any of these charts exist
+    if ((homepageChartNodes?.length)
+    || (components?.charts?.indexChartNames?.length)
+    || (components?.charts?.chartNames?.length)
     ) {
       homepageCharts.push(<div key={homepageCharts.length} className='index-page__slider-chart'><ReduxIndexBarChart /></div>);
     }

--- a/src/Index/page.jsx
+++ b/src/Index/page.jsx
@@ -74,11 +74,10 @@ class IndexPageComponent extends React.Component {
       });
     }
 
-    // indexChartNames and chartNames has to > 1 in here since by default we push in 'Files' as chart if there is less than 4 chart fields
-    // FIXME: remove this fix once we get rid of the pushing 'Files' into charts by default logic
-    if ((homepageChartNodes && homepageChartNodes.length > 0)
-    || (components.charts && components.charts.indexChartNames && components.charts.indexChartNames.length > 1)
-    || (components.charts && components.charts.chartNames && components.charts.chartNames.length > 1)
+    // if any of these charts exist
+    if ((homepageChartNodes?.length)
+    || (components?.charts?.indexChartNames?.length)
+    || (components?.charts?.chartNames?.length)
     ) {
       homepageCharts.push(<div key={homepageCharts.length} className='index-page__slider-chart'><ReduxIndexBarChart /></div>);
     }

--- a/src/Index/reducers.js
+++ b/src/Index/reducers.js
@@ -6,7 +6,7 @@ const index = (state = {}, action) => {
     const { projectNodeCounts, homepageChartNodes, fileNodes } = action;
     const nodesForIndexChart = homepageChartNodes.map((item) => item.node);
 
-    // constructing projct counts for index bar chart
+    // constructing project counts for index bar chart
     const projectsByName = {};
     Object.keys(projectNodeCounts).forEach((proj) => {
       let code = proj;
@@ -14,12 +14,12 @@ const index = (state = {}, action) => {
       if (projCodeIndex !== -1) {
         code = proj.substring(projCodeIndex + 1);
       }
-      let counts = 0;
+      let counts = [];
       if (projectNodeCounts[proj]) {
         counts = nodesForIndexChart.map((node) => projectNodeCounts[proj][node]);
       }
 
-      if (nodesForIndexChart.length < 4) {
+      if (nodesForIndexChart.length < 4 && !components.index.homepageChartNodesExcludeFiles) {
         const fileCountsForProj = fileNodes.reduce((acc, fileNode) => {
           let newAcc = acc;
           if (projectNodeCounts[proj][fileNode]) {
@@ -38,7 +38,7 @@ const index = (state = {}, action) => {
     });
 
     const countNames = homepageChartNodes.map((item) => item.name);
-    if (countNames.length < 4) {
+    if (countNames.length < 4 && !components.index.homepageChartNodesExcludeFiles) {
       countNames.push('Files');
     }
     return { ...state, projectsByName, countNames };
@@ -56,21 +56,21 @@ const index = (state = {}, action) => {
     const summaryCounts = {
       ...state.summaryCounts || {}, ...action.data.summaryCounts,
     };
-    const lastestListUpdating = Date.now();
+    const latestListUpdating = Date.now();
     // const { error, ...state } = state;
     return {
       ...state,
       projectsByName,
       summaryCounts,
-      lastestListUpdating,
+      latestListUpdating,
       countNames: components.charts.indexChartNames,
     };
   }
   case 'RECEIVE_HOMEPAGE_CHART_PROJECT_DETAIL': {
     const projectsByName = { ...state.projectsByName || {} };
     projectsByName[action.data.name] = action.data;
-    const lastestDetailsUpdating = Date.now();
-    return { ...state, projectsByName, lastestDetailsUpdating };
+    const latestListUpdating = Date.now();
+    return { ...state, projectsByName, latestListUpdating };
   }
   default:
     return state;

--- a/src/Index/utils.js
+++ b/src/Index/utils.js
@@ -1,6 +1,8 @@
 import _ from 'lodash';
 import { fetchWithCreds } from '../actions';
-import { homepageChartNodes, homepageChartNodesChunkSize, datasetUrl } from '../localconf';
+import {
+  homepageChartNodes, homepageChartNodesChunkSize, homepageChartNodesExcludeFiles, datasetUrl,
+} from '../localconf';
 import getReduxStore from '../reduxStore';
 import getHomepageChartProjectsList from './relayer';
 
@@ -78,7 +80,7 @@ export const mergeChunkedChartData = (chartDataArray) => {
   return mergedChartData;
 };
 
-// loadHomepageChartdataFromDatasets queries Peregrine's /datasets endpoint for
+// loadHomepageChartDataFromDatasets queries Peregrine's /datasets endpoint for
 // summary data (counts of projects, counts of subjects, etc).
 // If `public_datasets` is enabled in Peregrine's config, the /datasets endpoint
 // is publicly available, and can be accessed by logged-out users. Otherwise, the
@@ -93,7 +95,10 @@ export const loadHomepageChartDataFromDatasets = async (callback) => {
   const store = await getReduxStore();
   const fileNodes = store.getState().submission.file_nodes;
   const nodesForIndexChart = homepageChartNodes.map((item) => item.node);
-  const nodesToRequest = _.union(fileNodes, nodesForIndexChart);
+  let nodesToRequest = nodesForIndexChart;
+  if (!homepageChartNodesExcludeFiles) {
+    nodesToRequest = _.union(fileNodes, nodesForIndexChart);
+  }
   const requestUrls = getChunkedPeregrineRequestUrls(nodesToRequest, homepageChartNodesChunkSize);
 
   const fullResultPromise = [];

--- a/src/localconf.js
+++ b/src/localconf.js
@@ -247,6 +247,11 @@ function buildConfig(opts) {
     terraExportWarning = config.terraExportWarning;
   }
 
+  let homepageChartNodesExcludeFiles = false;
+  if (components.index.homepageChartNodesExcludeFiles) {
+    homepageChartNodesExcludeFiles = components.index.homepageChartNodesExcludeFiles;
+  }
+
   let homepageChartNodesChunkSize = 15;
   if (components.index.homepageChartNodesChunkSize) {
     homepageChartNodesChunkSize = components.index.homepageChartNodesChunkSize;
@@ -514,6 +519,7 @@ function buildConfig(opts) {
     stridesPortalURL,
     homepageChartNodes: components.index.homepageChartNodes,
     homepageChartNodesChunkSize,
+    homepageChartNodesExcludeFiles,
     customHomepageChartConfig: components.index.customHomepageChartConfig,
     datasetUrl,
     indexPublic,


### PR DESCRIPTION
Jira Ticket: [PXP-10565](https://ctds-planx.atlassian.net/browse/PXP-10565) [PXP-177](https://ctds-planx.atlassian.net/browse/PXP-177)

The current chart in homepage will automatically include file node counts in it. This PR add options to opt-out this auto-including feature


### New Features
- Homepage: added options to exclude File nodes from the charts

### Deployment changes
- New portal config options to exclude File nodes from the charts added: use `"graphql.chartNodesExcludeFiles"` to exclude File nodes from graphql chart, or use `"components.index.homepageChartNodesExcludeFiles"` to exclude File nodes from homepage chart. Note both of them are default to `false` so you have to explicitly set them to `true` to enable them

[PXP-10565]: https://ctds-planx.atlassian.net/browse/PXP-10565?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ