### PR TITLE
Feat/gwas unified flow table row selection

### DIFF
--- a/src/Analysis/GWASV2/Components/Covariates/Covariates.jsx
+++ b/src/Analysis/GWASV2/Components/Covariates/Covariates.jsx
@@ -10,7 +10,6 @@ import SearchBar from '../SearchBar/SearchBar';
 const Covariates = ({ selected, handleSelect }) => {
   const { source } = useSourceContext();
 
-  const [selectedRow, setSelectedRow] = useState(null);
   const covariates = useQuery(
     ['covariates', source],
     () => fetchCovariates(source),
@@ -90,13 +89,11 @@ const Covariates = ({ selected, handleSelect }) => {
             showSizeChanger: true,
             pageSizeOptions: ['10', '20', '50', '100', '500'],
           }}
-          onRow={(selectedRow) => {
-            return {
-              onClick: () => {
-                handleSelect(selectedRow);
-              },
-            };
-          }}
+          onRow={(selectedRow) => ({
+            onClick: () => {
+              handleSelect(selectedRow);
+            },
+          })}
           rowSelection={covariateSelection()}
           columns={covariateTableConfig}
           dataSource={displayedCovariates}

--- a/src/Analysis/GWASV2/Components/Covariates/Covariates.jsx
+++ b/src/Analysis/GWASV2/Components/Covariates/Covariates.jsx
@@ -13,7 +13,7 @@ const Covariates = ({ selected, handleSelect }) => {
   const covariates = useQuery(
     ['covariates', source],
     () => fetchCovariates(source),
-    queryConfig
+    queryConfig,
   );
 
   const [searchTerm, setSearchTerm] = useState('');
@@ -25,7 +25,7 @@ const Covariates = ({ selected, handleSelect }) => {
   const displayedCovariates = useFilter(
     fetchedCovariates,
     searchTerm,
-    'concept_name'
+    'concept_name',
   );
 
   const covariateSelection = () => ({

--- a/src/Analysis/GWASV2/Components/Covariates/Covariates.jsx
+++ b/src/Analysis/GWASV2/Components/Covariates/Covariates.jsx
@@ -10,10 +10,11 @@ import SearchBar from '../SearchBar/SearchBar';
 const Covariates = ({ selected, handleSelect }) => {
   const { source } = useSourceContext();
 
+  const [selectedRow, setSelectedRow] = useState(null);
   const covariates = useQuery(
     ['covariates', source],
     () => fetchCovariates(source),
-    queryConfig,
+    queryConfig
   );
 
   const [searchTerm, setSearchTerm] = useState('');
@@ -25,7 +26,7 @@ const Covariates = ({ selected, handleSelect }) => {
   const displayedCovariates = useFilter(
     fetchedCovariates,
     searchTerm,
-    'concept_name',
+    'concept_name'
   );
 
   const covariateSelection = () => ({
@@ -88,6 +89,13 @@ const Covariates = ({ selected, handleSelect }) => {
             defaultPageSize: 10,
             showSizeChanger: true,
             pageSizeOptions: ['10', '20', '50', '100', '500'],
+          }}
+          onRow={(record, index) => {
+            return {
+              onClick: () => {
+                handleSelect(record);
+              },
+            };
           }}
           rowSelection={covariateSelection()}
           columns={covariateTableConfig}

--- a/src/Analysis/GWASV2/Components/Covariates/Covariates.jsx
+++ b/src/Analysis/GWASV2/Components/Covariates/Covariates.jsx
@@ -90,10 +90,10 @@ const Covariates = ({ selected, handleSelect }) => {
             showSizeChanger: true,
             pageSizeOptions: ['10', '20', '50', '100', '500'],
           }}
-          onRow={(record, index) => {
+          onRow={(selectedRow) => {
             return {
               onClick: () => {
-                handleSelect(record);
+                handleSelect(selectedRow);
               },
             };
           }}

--- a/src/Analysis/GWASV2/Components/SelectCohort/Utils/CohortDefinitions.jsx
+++ b/src/Analysis/GWASV2/Components/SelectCohort/Utils/CohortDefinitions.jsx
@@ -56,13 +56,11 @@ const CohortDefinitions = ({
         showSizeChanger: true,
         pageSizeOptions: ['10', '20', '50', '100', '500'],
       }}
-      onRow={(selectedCohort) => {
-        return {
-          onClick: () => {
-            handleCohortSelect(selectedCohort);
-          },
-        };
-      }}
+      onRow={(selectedRow) => ({
+        onClick: () => {
+          handleCohortSelect(selectedRow);
+        },
+      })}
       rowSelection={cohortSelection(selectedCohort)}
       columns={cohortTableConfig}
       dataSource={displayedCohorts}

--- a/src/Analysis/GWASV2/Components/SelectCohort/Utils/CohortDefinitions.jsx
+++ b/src/Analysis/GWASV2/Components/SelectCohort/Utils/CohortDefinitions.jsx
@@ -18,7 +18,7 @@ const CohortDefinitions = ({
   const cohorts = useQuery(
     ['cohortdefinitions', source],
     () => fetchCohortDefinitions(source),
-    queryConfig
+    queryConfig,
   );
   const fetchedCohorts = useFetch(cohorts, 'cohort_definitions_and_stats');
   const displayedCohorts = useFilter(fetchedCohorts, searchTerm, 'cohort_name');

--- a/src/Analysis/GWASV2/Components/SelectCohort/Utils/CohortDefinitions.jsx
+++ b/src/Analysis/GWASV2/Components/SelectCohort/Utils/CohortDefinitions.jsx
@@ -2,7 +2,10 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { useQuery } from 'react-query';
 import { Table, Spin } from 'antd';
-import { fetchCohortDefinitions, queryConfig } from '../../../Utils/cohortMiddlewareApi';
+import {
+  fetchCohortDefinitions,
+  queryConfig,
+} from '../../../Utils/cohortMiddlewareApi';
 import { useFetch, useFilter } from '../../../Utils/formHooks';
 import { useSourceContext } from '../../../Utils/Source';
 
@@ -15,7 +18,7 @@ const CohortDefinitions = ({
   const cohorts = useQuery(
     ['cohortdefinitions', source],
     () => fetchCohortDefinitions(source),
-    queryConfig,
+    queryConfig
   );
   const fetchedCohorts = useFetch(cohorts, 'cohort_definitions_and_stats');
   const displayedCohorts = useFilter(fetchedCohorts, searchTerm, 'cohort_name');
@@ -52,6 +55,13 @@ const CohortDefinitions = ({
         defaultPageSize: 10,
         showSizeChanger: true,
         pageSizeOptions: ['10', '20', '50', '100', '500'],
+      }}
+      onRow={(selectedCohort) => {
+        return {
+          onClick: () => {
+            handleCohortSelect(selectedCohort);
+          },
+        };
       }}
       rowSelection={cohortSelection(selectedCohort)}
       columns={cohortTableConfig}

--- a/src/Analysis/GWASV2/GWASV2.css
+++ b/src/Analysis/GWASV2/GWASV2.css
@@ -74,6 +74,14 @@
   border: 2px solid #dedede;
 }
 
+.GWASV2 .GWASUI-table1 .ant-table-cell-row-hover {
+  cursor: pointer;
+}
+
+.GWASV2 .GWASUI-table1 .ant-table-cell-row-hover .ant-radio-inner {
+  border-color: #1890ff;
+}
+
 .GWASV2 .GWASUI-selectionUI {
   height: 519px;
   width: 988px;


### PR DESCRIPTION
Jira Ticket: [VADC-338](https://ctds-planx.atlassian.net/browse/VADC-338)

### New Features
This updates the AntD tables in the application so that the user only needs to click the table row itself in order to trigger radio button selection for the row.

This also adds a subtle CSS hover effect for the row's radio button  and cursor change, to communicate to the end user that the element is interactive. 

### Screenshot
![output](https://user-images.githubusercontent.com/113449836/214896265-d4cc1a54-46c7-43cc-b45f-7b04405e785c.gif)


[VADC-338]: https://ctds-planx.atlassian.net/browse/VADC-338?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ