### PR TITLE
Fix/retry request react-query

### DIFF
--- a/src/Analysis/GWASV2/Components/AttritionTableWrapper/AttritionTable/AttritionTable.stories.jsx
+++ b/src/Analysis/GWASV2/Components/AttritionTableWrapper/AttritionTable/AttritionTable.stories.jsx
@@ -10,11 +10,7 @@ export default {
   component: AttritionTable,
 };
 
-const mockedQueryClient = new QueryClient({
-  defaultOptions: {
-    queries: { retry: false },
-  },
-});
+const mockedQueryClient = new QueryClient();
 
 const MockTemplate = () => {
   const [covariateArrSizeTable1, setCovariateArrSizeTable1] = useState(10);

--- a/src/Analysis/GWASV2/Components/AttritionTableWrapper/AttritionTableWrapper.stories.jsx
+++ b/src/Analysis/GWASV2/Components/AttritionTableWrapper/AttritionTableWrapper.stories.jsx
@@ -11,11 +11,7 @@ export default {
   component: AttritionTableWrapper,
 };
 
-const mockedQueryClient = new QueryClient({
-  defaultOptions: {
-    queries: { retry: false },
-  },
-});
+const mockedQueryClient = new QueryClient();
 const Template = (args) => (
   <QueryClientProvider client={mockedQueryClient}>
     <SourceContextProvider>

--- a/src/Analysis/GWASV2/Components/AttritionTableWrapper/AttritionTableWrapper.test.jsx
+++ b/src/Analysis/GWASV2/Components/AttritionTableWrapper/AttritionTableWrapper.test.jsx
@@ -12,11 +12,7 @@ import AttritionTableWrapper from './AttritionTableWrapper';
 
 Enzyme.configure({ adapter: new Adapter() });
 
-const mockedQueryClient = new QueryClient({
-  defaultOptions: {
-    queries: { retry: false },
-  },
-});
+const mockedQueryClient = new QueryClient();
 
 const AttritionTableArgs = {
   sourceId: 1,

--- a/src/Analysis/GWASV2/Components/Covariates/ContinuousCovariates.stories.jsx
+++ b/src/Analysis/GWASV2/Components/Covariates/ContinuousCovariates.stories.jsx
@@ -12,11 +12,7 @@ export default {
 
 // useful examples: https://github.com/mswjs/msw-storybook-addon/tree/main/packages/docs/src/demos/react-query
 
-const mockedQueryClient = new QueryClient({
-  defaultOptions: {
-    queries: { retry: false },
-  },
-});
+const mockedQueryClient = new QueryClient();
 
 const Template = () => {
   return (

--- a/src/Analysis/GWASV2/Components/Covariates/Covariates.stories.jsx
+++ b/src/Analysis/GWASV2/Components/Covariates/Covariates.stories.jsx
@@ -11,11 +11,7 @@ export default {
 
 // useful examples: https://github.com/mswjs/msw-storybook-addon/tree/main/packages/docs/src/demos/react-query
 
-const mockedQueryClient = new QueryClient({
-  defaultOptions: {
-    queries: { retry: false },
-  },
-});
+const mockedQueryClient = new QueryClient();
 
 const Template = () => {
   const [selectedCovariate, setSelectedCovariate] = useState(null);
@@ -76,8 +72,8 @@ ErrorCase.parameters = {
   msw: {
     handlers: [
       rest.post('http://:cohortmiddlewarepath/cohort-middleware/concept/by-source-id/:sourceid/by-type', (req, res, ctx) => res(
-        ctx.delay(800),
-        ctx.status(403),
+        ctx.delay(3000),
+        ctx.status(403, "error"),
       )),
     ],
   },

--- a/src/Analysis/GWASV2/Components/Covariates/CustomDichotomousCovariates.stories.jsx
+++ b/src/Analysis/GWASV2/Components/Covariates/CustomDichotomousCovariates.stories.jsx
@@ -9,11 +9,7 @@ export default {
   component: CustomDichotomousCovariates,
 };
 
-const mockedQueryClient = new QueryClient({
-  defaultOptions: {
-    queries: { retry: false },
-  },
-});
+const mockedQueryClient = new QueryClient();
 
 const Template = (args) => (
   <QueryClientProvider client={mockedQueryClient}>

--- a/src/Analysis/GWASV2/Components/Diagrams/CohortsOverlapDiagram/CohortsOverlapDiagram.stories.jsx
+++ b/src/Analysis/GWASV2/Components/Diagrams/CohortsOverlapDiagram/CohortsOverlapDiagram.stories.jsx
@@ -9,11 +9,7 @@ export default {
   component: CohortsOverlapDiagram,
 };
 
-const mockedQueryClient = new QueryClient({
-  defaultOptions: {
-    queries: { retry: false },
-  },
-});
+const mockedQueryClient = new QueryClient();
 
 const Template = (args) => (
   <QueryClientProvider client={mockedQueryClient}>
@@ -42,6 +38,9 @@ const selectedControlCohort = {
 
 export const SuccessCase = Template.bind({});
 SuccessCase.args = {
+  dispatch: (payload) => {
+    console.log('dummy dispatch', payload);
+  },
   selectedStudyPopulationCohort: selectedStudyPopulationCohort,
   selectedCaseCohort: selectedCaseCohort,
   selectedControlCohort: selectedControlCohort,
@@ -75,12 +74,14 @@ SuccessCase.parameters = {
 // similar to test above, but with some overlap values fixed:
 export const SuccessCase2 = Template.bind({});
 SuccessCase2.args = {
-  sourceId: 123,
+  dispatch: (payload) => {
+    console.log('dummy dispatch', payload);
+  },
   selectedStudyPopulationCohort: selectedStudyPopulationCohort,
   selectedCaseCohort: selectedCaseCohort,
   selectedControlCohort: selectedControlCohort,
   selectedCovariates: [],
-  selectedDichotomousCovariates: [],
+  outcome: null,
 };
 let variableOverlap = 234;
 SuccessCase2.parameters = {
@@ -119,12 +120,14 @@ SuccessCase2.parameters = {
 
 export const ErrorCase = Template.bind({});
 ErrorCase.args = {
-  sourceId: 123,
+  dispatch: (payload) => {
+    console.log('dummy dispatch', payload);
+  },
   selectedStudyPopulationCohort: selectedStudyPopulationCohort,
   selectedCaseCohort: selectedCaseCohort,
   selectedControlCohort: selectedControlCohort,
   selectedCovariates: [],
-  selectedDichotomousCovariates: [],
+  outcome: null,
 };
 // mock endpoint failure:
 ErrorCase.parameters = {
@@ -132,7 +135,34 @@ ErrorCase.parameters = {
     handlers: [
       rest.post(
         'http://:cohortmiddlewarepath/cohort-middleware/cohort-stats/check-overlap/by-source-id/:sourceid/by-cohort-definition-ids/:cohortdefinitionA/:cohortdefinitionB',
-        (req, res, ctx) => res(ctx.delay(800), ctx.status(403))
+        (req, res, ctx) => res(
+          ctx.delay(800),
+          ctx.status(403),
+          ctx.json({errorMessage: `Error`, }),)
+      ),
+    ],
+  },
+};
+
+export const TimeoutCase = Template.bind({});
+TimeoutCase.args = {
+  dispatch: (payload) => {
+    console.log('dummy dispatch', payload);
+  },
+  selectedStudyPopulationCohort: selectedStudyPopulationCohort,
+  selectedCaseCohort: selectedCaseCohort,
+  selectedControlCohort: selectedControlCohort,
+  selectedCovariates: [],
+  outcome: null,
+};
+// mock endpoint timeout:
+TimeoutCase.parameters = {
+  msw: {
+    handlers: [
+      rest.post(
+        'http://:cohortmiddlewarepath/cohort-middleware/cohort-stats/check-overlap/by-source-id/:sourceid/by-cohort-definition-ids/:cohortdefinitionA/:cohortdefinitionB',
+        (req, res, ctx) => res(
+          ctx.delay(3000), ctx.status(504), ctx.json("server timeout"))
       ),
     ],
   },

--- a/src/Analysis/GWASV2/Components/Diagrams/CohortsOverlapDiagram/Simple3SetsEulerDiagram.stories.jsx
+++ b/src/Analysis/GWASV2/Components/Diagrams/CohortsOverlapDiagram/Simple3SetsEulerDiagram.stories.jsx
@@ -19,13 +19,14 @@ FirstStepActive.args = {
   set123Size: 123,
 };
 
+// Test whether we get an error when the overlap size is bigger than the group size:
 export const SecondStepError = Template.bind({});
 SecondStepError.args = {
   set1Size: 1000,
   set2Size: 900,
   set3Size: 4000,
   set12Size: 100,
-  set13Size: 20000,
+  set13Size: 20000, // impossible overlap
   set23Size: 300,
   set123Size: 123,
 };

--- a/src/Analysis/GWASV2/Components/Diagrams/PhenotypeHistogram/PhenotypeHistogram.stories.jsx
+++ b/src/Analysis/GWASV2/Components/Diagrams/PhenotypeHistogram/PhenotypeHistogram.stories.jsx
@@ -51,6 +51,9 @@ const selectedCovariates = [
 
 export const SuccessCase = Template.bind({});
 SuccessCase.args = {
+  dispatch: (payload) => {
+    console.log('dummy dispatch', payload);
+  },
   selectedStudyPopulationCohort: selectedStudyPopulationCohort,
   selectedCovariates: selectedCovariates,
   outcome: null,
@@ -90,6 +93,9 @@ SuccessCase.parameters = {
 
 export const ErrorCase = Template.bind({});
 ErrorCase.args = {
+  dispatch: (payload) => {
+    console.log('dummy dispatch', payload);
+  },
   selectedStudyPopulationCohort: selectedStudyPopulationCohort,
   selectedCovariates: selectedCovariates,
   outcome: null,

--- a/src/Analysis/GWASV2/Components/Diagrams/PhenotypeHistogram/PhenotypeHistogram.stories.jsx
+++ b/src/Analysis/GWASV2/Components/Diagrams/PhenotypeHistogram/PhenotypeHistogram.stories.jsx
@@ -9,11 +9,7 @@ export default {
   component: PhenotypeHistogram,
 };
 
-const mockedQueryClient = new QueryClient({
-  defaultOptions: {
-    queries: { retry: false },
-  },
-});
+const mockedQueryClient = new QueryClient();
 
 const Template = (args) => (
   <QueryClientProvider client={mockedQueryClient}>

--- a/src/Analysis/GWASV2/Components/SelectCohort/SelectCohort.stories.jsx
+++ b/src/Analysis/GWASV2/Components/SelectCohort/SelectCohort.stories.jsx
@@ -17,11 +17,7 @@ export default {
 
 // useful examples: https://github.com/mswjs/msw-storybook-addon/tree/main/packages/docs/src/demos/react-query
 
-const mockedQueryClient = new QueryClient({
-  defaultOptions: {
-    queries: { retry: false },
-  },
-});
+const mockedQueryClient = new QueryClient();
 
 const MockTemplate = () => {
   const initialState = {

--- a/src/Analysis/GWASV2/Components/SelectCohort/SelectCohortDropDown.stories.jsx
+++ b/src/Analysis/GWASV2/Components/SelectCohort/SelectCohortDropDown.stories.jsx
@@ -15,11 +15,7 @@ export default {
 
 // useful examples: https://github.com/mswjs/msw-storybook-addon/tree/main/packages/docs/src/demos/react-query
 
-const mockedQueryClient = new QueryClient({
-  defaultOptions: {
-    queries: { retry: false },
-  },
-});
+const mockedQueryClient = new QueryClient();
 
 const MockTemplate = () => {
   const handleCohortSelect = (selectedCohort) => {

--- a/src/Analysis/GWASV2/Components/SelectConfiguration/SelectConfiguration.stories.jsx
+++ b/src/Analysis/GWASV2/Components/SelectConfiguration/SelectConfiguration.stories.jsx
@@ -12,11 +12,7 @@ export default {
   component: SelectionConfiguration,
 };
 
-const mockedQueryClient = new QueryClient({
-  defaultOptions: {
-    queries: { retry: false },
-  },
-});
+const mockedQueryClient = new QueryClient();
 
 const MockTemplate = () => {
   const [state, dispatch] = useReducer(reducer, ValidState);

--- a/src/Analysis/GWASV2/Components/SelectHare/SelectHareDropDown.test.jsx
+++ b/src/Analysis/GWASV2/Components/SelectHare/SelectHareDropDown.test.jsx
@@ -35,11 +35,7 @@ useSourceFetch.mockResolvedValue({
 });
 
 // Other generic arguments and functions shared by tests below:
-const mockedQueryClient = new QueryClient({
-  defaultOptions: {
-    queries: { retry: false },
-  },
-});
+const mockedQueryClient = new QueryClient();
 const mountDropDownForOutcome = (
   selectedStudyPopulationCohort,
   covariates,

--- a/src/Analysis/GWASV2/Steps/ConfigureGWAS/ConfigureGWAS.stories.jsx
+++ b/src/Analysis/GWASV2/Steps/ConfigureGWAS/ConfigureGWAS.stories.jsx
@@ -13,11 +13,7 @@ export default {
   component: ConfigureGWAS,
 };
 
-const mockedQueryClient = new QueryClient({
-  defaultOptions: {
-    queries: { retry: false },
-  },
-});
+const mockedQueryClient = new QueryClient();
 
 const MockTemplate = () => {
   const initialState = {

--- a/src/Analysis/GWASV2/Utils/cohortMiddlewareApi.js
+++ b/src/Analysis/GWASV2/Utils/cohortMiddlewareApi.js
@@ -27,8 +27,12 @@ export const fetchConceptStatsByHare = async (
     headers,
     body: JSON.stringify(variablesPayload),
   };
-  const getConceptStats = await fetch(conceptStatsEndPoint, reqBody);
-  return getConceptStats.json();
+  const response = await fetch(conceptStatsEndPoint, reqBody);
+  if (!response.ok) {
+    const message = `An error has occured: ${response.status}`;
+    throw new Error(message);
+  }
+  return response.json();
 };
 
 export const fetchOverlapInfo = async (
@@ -55,8 +59,12 @@ export const fetchOverlapInfo = async (
     headers,
     body: JSON.stringify(variablesPayload),
   };
-  const getOverlapStats = await fetch(statsEndPoint, reqBody);
-  return getOverlapStats.json();
+  const response = await fetch(statsEndPoint, reqBody);
+  if (!response.ok) {
+    const message = `An error has occured: ${response.status}`;
+    throw new Error(message);
+  }
+  return response.json();
 };
 
 // Basically a copy of fetchOverlapInfo above, but without the HARE arguments:
@@ -77,8 +85,12 @@ export const fetchSimpleOverlapInfo = async (
     headers,
     body: JSON.stringify(variablesPayload),
   };
-  const getOverlapStats = await fetch(statsEndPoint, reqBody);
-  return getOverlapStats.json();
+  const response = await fetch(statsEndPoint, reqBody);
+  if (!response.ok) {
+    const message = `An error has occured: ${response.status}`;
+    throw new Error(message);
+  }
+  return response.json();
 };
 
 export const fetchHistogramInfo = async (
@@ -98,8 +110,12 @@ export const fetchHistogramInfo = async (
     headers,
     body: JSON.stringify(variablesPayload),
   };
-  const requestResponse = await fetch(endPoint, reqBody);
-  return requestResponse.json();
+  const response = await fetch(endPoint, reqBody);
+  if (!response.ok) {
+    const message = `An error has occured: ${response.status}`;
+    throw new Error(message);
+  }
+  return response.json();
 };
 
 export const fetchConceptStatsByHareSubset = async (
@@ -118,8 +134,12 @@ export const fetchConceptStatsByHareSubset = async (
     headers,
     body: JSON.stringify(variablesPayload),
   };
-  const getConceptStats = await fetch(conceptStatsEndPoint, reqBody);
-  return getConceptStats.json();
+  const response = await fetch(conceptStatsEndPoint, reqBody);
+  if (!response.ok) {
+    const message = `An error has occured: ${response.status}`;
+    throw new Error(message);
+  }
+  return response.json();
 };
 
 export const addCDFilter = (cohortId, otherCohortId, covariateArr) => {
@@ -176,14 +196,22 @@ export const fetchCovariateStats = async (
     headers,
     body: JSON.stringify(covariateIds),
   };
-  const getConceptStats = await fetch(conceptStatsEndpoint, reqBody);
-  return getConceptStats.json();
+  const response = await fetch(conceptStatsEndpoint, reqBody);
+  if (!response.ok) {
+    const message = `An error has occured: ${response.status}`;
+    throw new Error(message);
+  }
+  return response.json();
 };
 
 export const fetchCohortDefinitions = async (sourceId) => {
   const cohortEndPoint = `${cohortMiddlewarePath}cohortdefinition-stats/by-source-id/${sourceId}`;
-  const getCohortDefinitions = await fetch(cohortEndPoint);
-  return getCohortDefinitions.json();
+  const response = await fetch(cohortEndPoint);
+  if (!response.ok) {
+    const message = `An error has occured: ${response.status}`;
+    throw new Error(message);
+  }
+  return response.json();
 };
 
 export const fetchCovariates = async (sourceId) => {
@@ -197,14 +225,22 @@ export const fetchCovariates = async (sourceId) => {
     headers,
     body: JSON.stringify(allowedConceptTypes),
   };
-  const getConcepts = await fetch(conceptEndpoint, reqBody);
-  return getConcepts.json();
+  const response = await fetch(conceptEndpoint, reqBody);
+  if (!response.ok) {
+    const message = `An error has occured: ${response.status}`;
+    throw new Error(message);
+  }
+  return response.json();
 };
 
 export const fetchSources = async () => {
   const sourcesEndpoint = `${cohortMiddlewarePath}sources`;
-  const getSources = await fetch(sourcesEndpoint);
-  return getSources.json();
+  const response = await fetch(sourcesEndpoint);
+  if (!response.ok) {
+    const message = `An error has occured: ${response.status}`;
+    throw new Error(message);
+  }
+  return response.json();
 };
 
 export const useSourceFetch = () => {
@@ -226,6 +262,7 @@ export const queryConfig = {
   refetchOnMount: false,
   refetchOnWindowFocus: false,
   refetchOnReconnect: false,
+  retry: false,
 };
 
 export const getAllHareItems = (


### PR DESCRIPTION
Jira Ticket: [VADC-388](https://ctds-planx.atlassian.net/browse/VADC-388)


### Bug Fixes
 - disable retries of failed requests at a global level for the GWAS app. See https://react-query-v3.tanstack.com/guides/query-retries
 - align storybook request config w/ real app: for some reason, storybook was using a different config for react-query than the app, leading to confusion and impossible to reproduce/mock scenarios.
 - web-service errors are now explicitly catched and thrown. The previous code only worked for errors that happen to not have a json text in them.



[VADC-388]: https://ctds-planx.atlassian.net/browse/VADC-388?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ