### PR TITLE
Fix/gwas unified flow virtual tour buttons

### DIFF
--- a/src/Analysis/GWASV2/Components/Covariates/Covariates.css
+++ b/src/Analysis/GWASV2/Components/Covariates/Covariates.css
@@ -12,7 +12,7 @@
 }
 
 /* Buttons */
-.GWASV2 .custom-dichotomous-covariates .button-wrapper {
+.GWASV2 .custom-dichotomous-covariates .dichotomous-button-wrapper {
   display: flex;
 }
 
@@ -72,19 +72,19 @@
 
 .GWASV2 .continuous-covariates .select-covariates-container .ant-select,
 .GWASV2
-.continuous-covariates
-.select-covariates-container
-.ant-select-dropdown {
+  .continuous-covariates
+  .select-covariates-container
+  .ant-select-dropdown {
   width: 100%;
   min-width: inherit;
 }
 
 .GWASV2
-.continuous-covariates
-.ant-table.ant-table-middle
-.ant-table-tbody
-> tr
-> td {
+  .continuous-covariates
+  .ant-table.ant-table-middle
+  .ant-table-tbody
+  > tr
+  > td {
   padding: 5px 8px;
 }
 

--- a/src/Analysis/GWASV2/Components/Covariates/Covariates.css
+++ b/src/Analysis/GWASV2/Components/Covariates/Covariates.css
@@ -12,7 +12,7 @@
 }
 
 /* Buttons */
-.GWASV2 .dichotomous-button-wrapper {
+.GWASV2 .custom-dichotomous-covariates .button-wrapper {
   display: flex;
 }
 

--- a/src/Analysis/GWASV2/Components/Covariates/Covariates.css
+++ b/src/Analysis/GWASV2/Components/Covariates/Covariates.css
@@ -12,9 +12,10 @@
 }
 
 /* Buttons */
-.GWASV2 .button-wrapper {
+.GWASV2 .dichotomous-button-wrapper {
   display: flex;
 }
+
 .GWASV2 .submit-button,
 .GWASV2 .cancel-button {
   margin: 6px 0 12px auto;

--- a/src/Analysis/GWASV2/Components/Covariates/Covariates.css
+++ b/src/Analysis/GWASV2/Components/Covariates/Covariates.css
@@ -12,6 +12,9 @@
 }
 
 /* Buttons */
+.GWASV2 .button-wrapper {
+  display: flex;
+}
 .GWASV2 .submit-button,
 .GWASV2 .cancel-button {
   margin: 6px 0 12px auto;
@@ -68,19 +71,19 @@
 
 .GWASV2 .continuous-covariates .select-covariates-container .ant-select,
 .GWASV2
-.continuous-covariates
-.select-covariates-container
-.ant-select-dropdown {
+  .continuous-covariates
+  .select-covariates-container
+  .ant-select-dropdown {
   width: 100%;
   min-width: inherit;
 }
 
 .GWASV2
-.continuous-covariates
-.ant-table.ant-table-middle
-.ant-table-tbody
-> tr
-> td {
+  .continuous-covariates
+  .ant-table.ant-table-middle
+  .ant-table-tbody
+  > tr
+  > td {
   padding: 5px 8px;
 }
 

--- a/src/Analysis/GWASV2/Components/Covariates/Covariates.css
+++ b/src/Analysis/GWASV2/Components/Covariates/Covariates.css
@@ -72,19 +72,19 @@
 
 .GWASV2 .continuous-covariates .select-covariates-container .ant-select,
 .GWASV2
-  .continuous-covariates
-  .select-covariates-container
-  .ant-select-dropdown {
+.continuous-covariates
+.select-covariates-container
+.ant-select-dropdown {
   width: 100%;
   min-width: inherit;
 }
 
 .GWASV2
-  .continuous-covariates
-  .ant-table.ant-table-middle
-  .ant-table-tbody
-  > tr
-  > td {
+.continuous-covariates
+.ant-table.ant-table-middle
+.ant-table-tbody
+> tr
+> td {
   padding: 5px 8px;
 }
 

--- a/src/Analysis/GWASV2/Components/Covariates/CustomDichotomousCovariates.jsx
+++ b/src/Analysis/GWASV2/Components/Covariates/CustomDichotomousCovariates.jsx
@@ -48,31 +48,35 @@ const CustomDichotomousCovariates = ({
           value={providedName}
           placeholder='Provide a name...'
         />
-        <button
-          type='button'
-          className='GWASUI-dichBtn cancel-button'
-          data-tour='submit-cancel-buttons'
-          onClick={() => handleClose()}
-        >
-          Cancel
-        </button>
-        <div>
+        <span className='button-wrapper' data-tour='submit-cancel-buttons'>
           <button
             type='button'
-            disabled={customDichotomousValidation}
-            className={`submit-button ${
-              !customDichotomousValidation ? 'GWASUI-btnEnable' : ''
-            } GWASUI-dichBtn`}
-            onClick={() => handleDichotomousSubmit()}
+            className='GWASUI-dichBtn cancel-button'
+            onClick={() => handleClose()}
           >
-            {submitButtonLabel}
+            Cancel
           </button>
-        </div>
+          <div>
+            <button
+              type='button'
+              disabled={customDichotomousValidation}
+              className={`submit-button ${
+                !customDichotomousValidation ? 'GWASUI-btnEnable' : ''
+              } GWASUI-dichBtn`}
+              onClick={() => handleDichotomousSubmit()}
+            >
+              {submitButtonLabel}
+            </button>
+          </div>
+        </span>
       </div>
       <React.Fragment>
         <div>
           <div className='GWASUI-flexRow'>
-            <div data-tour='select-dichotomous' className='GWASUI-flexColumn dichotomous-selection'>
+            <div
+              data-tour='select-dichotomous'
+              className='GWASUI-flexColumn dichotomous-selection'
+            >
               <div className='dichotomous-directions'>
                 Define a dichotomous variable by study population with 2 other
                 cohorts.
@@ -88,7 +92,10 @@ const CustomDichotomousCovariates = ({
                 />
               </div>
             </div>
-            <div data-tour='cohorts-overlap-diagram' className='cohorts-overlap-diagram'>
+            <div
+              data-tour='cohorts-overlap-diagram'
+              className='cohorts-overlap-diagram'
+            >
               {!firstPopulation || !secondPopulation ? (
                 <div>Select your cohorts to assess overlap</div>
               ) : (

--- a/src/Analysis/GWASV2/Components/Covariates/CustomDichotomousCovariates.jsx
+++ b/src/Analysis/GWASV2/Components/Covariates/CustomDichotomousCovariates.jsx
@@ -31,10 +31,9 @@ const CustomDichotomousCovariates = ({
     handleClose();
   };
 
-  const customDichotomousValidation =
-    providedName.length === 0 ||
-    firstPopulation === undefined ||
-    secondPopulation === undefined;
+  const customDichotomousValidation = providedName.length === 0
+    || firstPopulation === undefined
+    || secondPopulation === undefined;
 
   return (
     <div className='custom-dichotomous-covariates'>

--- a/src/Analysis/GWASV2/Components/Covariates/CustomDichotomousCovariates.jsx
+++ b/src/Analysis/GWASV2/Components/Covariates/CustomDichotomousCovariates.jsx
@@ -31,9 +31,10 @@ const CustomDichotomousCovariates = ({
     handleClose();
   };
 
-  const customDichotomousValidation = providedName.length === 0
-    || firstPopulation === undefined
-    || secondPopulation === undefined;
+  const customDichotomousValidation =
+    providedName.length === 0 ||
+    firstPopulation === undefined ||
+    secondPopulation === undefined;
 
   return (
     <div className='custom-dichotomous-covariates'>
@@ -48,7 +49,10 @@ const CustomDichotomousCovariates = ({
           value={providedName}
           placeholder='Provide a name...'
         />
-        <span className='button-wrapper' data-tour='submit-cancel-buttons'>
+        <span
+          className='dichotomous-button-wrapper'
+          data-tour='submit-cancel-buttons'
+        >
           <button
             type='button'
             className='GWASUI-dichBtn cancel-button'


### PR DESCRIPTION
Jira Ticket: [VADC-397](https://ctds-planx.atlassian.net/browse/VADC-397)

### Bug Fixes
This fixes the virtual tour so that when the tour shows information for both the cancel and submit or add buttons in Dichotomous Covariate selection in steps 2 and 3, both buttons are highlighted instead of just the cancel button. 

This required adding a wrapping span for the buttons and styling it. 

### Before
<img width="1444" alt="image" src="https://user-images.githubusercontent.com/113449836/215194780-50dc53dc-e29d-4320-8d43-bf8155b77751.png">

### After
<img width="1444" alt="image" src="https://user-images.githubusercontent.com/113449836/215194631-dafccb40-b524-437a-8119-0447ae9ac3fd.png">



[VADC-391]: https://ctds-planx.atlassian.net/browse/VADC-391?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[VADC-397]: https://ctds-planx.atlassian.net/browse/VADC-397?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ