### PR TITLE
Fix misleading `/auth/proxy` use

### DIFF
--- a/src/actions.js
+++ b/src/actions.js
@@ -485,8 +485,8 @@ export const fetchUserAccess = async (dispatch) => {
           case 401: // user is not logged in
           case 403: // user is not allowed to access the resource
             return false;
-          case 200: // valid input -> check "ok" field for authorization
-            return fetchRes.ok;
+          case 200: // user is authorized
+            return true;
           default:
             console.error(`Unknown status "${fetchRes.status}" returned by arborist call`);
             return false;

--- a/testSchema.sh
+++ b/testSchema.sh
@@ -11,7 +11,6 @@ gtex "gen3.biodatacatalyst.nhlbi.nih.gov"
 anvil "gen3.theanvil.io"
 dev "qa.planx-pla.net"
 genomel "genomel.bionimbus.org"
-acct "acct.bionimbus.org"
 )
 index=0
 while [[ $index -lt ${#testCases[@]} ]]; do


### PR DESCRIPTION
`fetch()` always returns an `ok` field, it has nothing to do with the arborist API: https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API/Using_Fetch#checking_that_the_fetch_was_successful

This was probably confused with the `auth` field in arborist's `/auth/request` endpoint, which should be checked instead of assuming that 200 == authorized. The `/auth/proxy` endpoint behavior is different.

relates to https://github.com/uc-cdis/arborist/pull/155

### Improvements
- Fix misleading use of `fetch()` response `.ok` when calling `/auth/proxy`