### PR TITLE
VADC-431: add uid to argo-wrapper requests

### DIFF
--- a/src/Analysis/GWASResults/GWASJob.jsx
+++ b/src/Analysis/GWASResults/GWASJob.jsx
@@ -41,11 +41,11 @@ const GWASJob = ({ workflow }) => {
     let buttonClickHandler;
 
     if (phase === gwasStatus.succeeded) {
-      actionUrl = `${gwasWorkflowPath}status/${workflowName}`;
+      actionUrl = `${gwasWorkflowPath}status/${workflowName}?uid=${workflow.uid}`;
       buttonText = 'download outputs';
       buttonClickHandler = handleWorkflowOutput;
     } else if (phase === gwasStatus.failed) {
-      actionUrl = `${gwasWorkflowPath}logs/${workflowName}`;
+      actionUrl = `${gwasWorkflowPath}logs/${workflowName}?uid=${workflow.uid}`;
       buttonText = 'view logs';
       buttonClickHandler = handleWorkflowLogs;
     }
@@ -118,7 +118,7 @@ const GWASJob = ({ workflow }) => {
   };
 
   async function fetchWorkflowStatus() {
-    const statusEndpoint = `${gwasWorkflowPath}status/${workflow.name}`;
+    const statusEndpoint = `${gwasWorkflowPath}status/${workflow.name}?uid=${workflow.uid}`;
     const status = await fetch(statusEndpoint);
     return status.json();
   }

--- a/src/Analysis/GWASResults/GWASWorkflowList.stories.jsx
+++ b/src/Analysis/GWASResults/GWASWorkflowList.stories.jsx
@@ -74,10 +74,10 @@ MockedSuccess.parameters = {
         (req, res, ctx) => {
           const { argowrapperpath } = req.params;
           const { workflowid } = req.params;
-          const { workflowuid } = req.params;
+          const workflowuid = req.url.search;
           console.log(argowrapperpath);
-          console.log(workflowid);
-          console.log(workflowuid);
+          console.log('workflowid:' + workflowid);
+          console.log('workflowuid:' + workflowuid);
 
           return res(
             ctx.delay(500),

--- a/src/Analysis/GWASResults/GWASWorkflowList.stories.jsx
+++ b/src/Analysis/GWASResults/GWASWorkflowList.stories.jsx
@@ -43,6 +43,7 @@ const getMockWorkflowList = () => {
   if (requestCount % 3 == 0) {
     workflowList.splice(0, 0, {
       name: 'argo-wrapper-workflow-' + requestCount,
+      uid: 'uid-' + requestCount,
       phase: getMockPhase(requestCount),
     });
     rowCount++;
@@ -69,17 +70,20 @@ MockedSuccess.parameters = {
         }
       ),
       rest.get(
-        'http://:argowrapperpath/ga4gh/wes/v2/status/:workflowid',
+        'http://:argowrapperpath/ga4gh/wes/v2/status/:workflowid?uid=:workflowuid',
         (req, res, ctx) => {
           const { argowrapperpath } = req.params;
           const { workflowid } = req.params;
+          const { workflowuid } = req.params;
           console.log(argowrapperpath);
           console.log(workflowid);
+          console.log(workflowuid);
 
           return res(
             ctx.delay(500),
             ctx.json({
               name: workflowid,
+              uid: workflowuid,
               wf_name: workflowid + ' name',
               arguments: {
                 parameters: [


### PR DESCRIPTION
Jira Ticket: [VADC-431](https://ctds-planx.atlassian.net/browse/VADC-431)

### New Features

* Add `uid` query param to `GWASJob.jsx` endpoints to support archived workflows


[VADC-431]: https://ctds-planx.atlassian.net/browse/VADC-431?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ