### PR TITLE
Feat/results table new fields

### DIFF
--- a/src/Analysis/GWASResultsV2/TestData/TableData.js
+++ b/src/Analysis/GWASResultsV2/TestData/TableData.js
@@ -1,17 +1,19 @@
 const TableData = [
   {
     uid: '123',
+    wf_name: 'Use Added WF Name 1',
     name: 'Workflow 1',
     startedAt: '2022-02-15T13:00:00Z',
     phase: 'Pending',
-    DateTimeSubmitted: '2022-02-15T13:30:00Z',
+    submittedAt: '2022-02-15T13:30:00Z',
   },
   {
     uid: '456',
+    wf_name: 'Use Added WF Name 2',
     name: 'Workflow 2',
     startedAt: '2022-02-16T10:00:00Z',
     phase: 'Running',
-    DateTimeSubmitted: '2022-02-16T10:30:00Z',
+    submittedAt: '2022-02-16T10:30:00Z',
   },
 ];
 

--- a/src/Analysis/GWASResultsV2/TestData/TableData.js
+++ b/src/Analysis/GWASResultsV2/TestData/TableData.js
@@ -1,7 +1,7 @@
 const TableData = [
   {
     uid: '123',
-    wf_name: 'Use Added WF Name 1',
+    wf_name: 'User Added WF Name 1',
     name: 'Workflow 1',
     startedAt: '2022-02-15T13:00:00Z',
     phase: 'Pending',
@@ -9,7 +9,7 @@ const TableData = [
   },
   {
     uid: '456',
-    wf_name: 'Use Added WF Name 2',
+    wf_name: 'User Added WF Name 2',
     name: 'Workflow 2',
     startedAt: '2022-02-16T10:00:00Z',
     phase: 'Running',

--- a/src/Analysis/GWASResultsV2/Views/Home/Home.stories.jsx
+++ b/src/Analysis/GWASResultsV2/Views/Home/Home.stories.jsx
@@ -3,7 +3,7 @@ import { QueryClient, QueryClientProvider } from 'react-query';
 import SharedContext from '../../Utils/SharedContext';
 import { rest } from 'msw';
 import Home from './Home';
-import testTableData from '../../TestData/testTableData';
+import testTableData from '../../TestData/TableData';
 
 const setCurrentView = (input) => {
   alert(`setCurrentView called with ${input}`);
@@ -21,17 +21,18 @@ const mockedQueryClient = new QueryClient({
   },
 });
 
-const MockTemplate = () =>
-    <QueryClientProvider client={mockedQueryClient}>
-      <SharedContext.Provider
-        value={{
-          setSelectedRowData,
-          setCurrentView,
-        }}
-      >
-        <Home />
-      </SharedContext.Provider>
-    </QueryClientProvider>
+const MockTemplate = () => (
+  <QueryClientProvider client={mockedQueryClient}>
+    <SharedContext.Provider
+      value={{
+        setSelectedRowData,
+        setCurrentView,
+      }}
+    >
+      <Home />
+    </SharedContext.Provider>
+  </QueryClientProvider>
+);
 
 let requestCount = 0;
 let rowCount = 1;
@@ -63,7 +64,7 @@ const getMockWorkflowList = () => {
       name: 'argo-wrapper-workflow-' + requestCount,
       uid: 'uid-' + requestCount,
       phase: getMockPhase(requestCount),
-      startedAt: new Date(new Date() - Math.random()*(1e+12))
+      startedAt: new Date(new Date() - Math.random() * 1e12),
     });
     rowCount++;
   }
@@ -73,7 +74,7 @@ const getMockWorkflowList = () => {
     workflowList[2].phase = gwasStatus.pending;
     workflowList[3].phase = gwasStatus.pending;
   }
-  console.log('workflowList: ',workflowList)
+  console.log('workflowList: ', workflowList);
   return workflowList;
 };
 

--- a/src/Analysis/GWASResultsV2/Views/Home/Home.test.jsx
+++ b/src/Analysis/GWASResultsV2/Views/Home/Home.test.jsx
@@ -41,7 +41,7 @@ describe('Home component', () => {
     render(testJSX());
     await screen.findByText('Error loading data for table');
     expect(
-      screen.getByText('Error loading data for table'),
+      screen.getByText('Error loading data for table')
     ).toBeInTheDocument();
   });
 
@@ -50,9 +50,9 @@ describe('Home component', () => {
       json: jest.fn().mockResolvedValueOnce(TableData),
     });
     render(testJSX());
-    await screen.findByText(TableData[0].name);
+    await screen.findByText(TableData[0].wf_name);
     TableData.forEach((item) => {
-      expect(screen.getByText(item.name)).toBeInTheDocument();
+      expect(screen.getByText(item.wf_name)).toBeInTheDocument();
     });
   });
 });

--- a/src/Analysis/GWASResultsV2/Views/Home/Home.test.jsx
+++ b/src/Analysis/GWASResultsV2/Views/Home/Home.test.jsx
@@ -41,7 +41,7 @@ describe('Home component', () => {
     render(testJSX());
     await screen.findByText('Error loading data for table');
     expect(
-      screen.getByText('Error loading data for table')
+      screen.getByText('Error loading data for table'),
     ).toBeInTheDocument();
   });
 

--- a/src/Analysis/GWASResultsV2/Views/Home/HomeTable/HomeTable.jsx
+++ b/src/Analysis/GWASResultsV2/Views/Home/HomeTable/HomeTable.jsx
@@ -17,7 +17,7 @@ const HomeTable = ({ data }) => {
     },
     {
       title: 'Workflow name',
-      dataIndex: 'name',
+      dataIndex: 'wf_name',
       key: 'name',
       sorter: (a, b) => a.name.localeCompare(b.name),
     },
@@ -45,8 +45,7 @@ const HomeTable = ({ data }) => {
     {
       title: 'Date/Time Submitted',
       key: 'DateTimeSubmitted',
-      render: (record) => record.DateTimeSubmitted
-        || `item.DateTimeSubmitted missing at ${new Date().toLocaleString()}`,
+      render: (record) => record.submittedAt,
     },
     {
       title: 'View Details',

--- a/src/Analysis/GWASResultsV2/Views/Home/HomeTable/HomeTable.test.jsx
+++ b/src/Analysis/GWASResultsV2/Views/Home/HomeTable/HomeTable.test.jsx
@@ -16,7 +16,7 @@ describe('HomeTable component', () => {
     render(
       <SharedContext.Provider value={mockContext}>
         <HomeTable data={data} />
-      </SharedContext.Provider>
+      </SharedContext.Provider>,
     );
 
     // Check that each of the values from data that needed to be shown appear in the dom

--- a/src/Analysis/GWASResultsV2/Views/Home/HomeTable/HomeTable.test.jsx
+++ b/src/Analysis/GWASResultsV2/Views/Home/HomeTable/HomeTable.test.jsx
@@ -16,10 +16,10 @@ describe('HomeTable component', () => {
     render(
       <SharedContext.Provider value={mockContext}>
         <HomeTable data={data} />
-      </SharedContext.Provider>,
+      </SharedContext.Provider>
     );
 
-    // Check that each of the values from data appear in the dom
+    // Check that each of the values from data that needed to be shown appear in the dom
     data.forEach((item) => {
       expect(screen.getAllByText(item.uid)[0]).toBeInTheDocument();
       expect(screen.getAllByText(item.wf_name)[0]).toBeInTheDocument();

--- a/src/Analysis/GWASResultsV2/Views/Home/HomeTable/HomeTable.test.jsx
+++ b/src/Analysis/GWASResultsV2/Views/Home/HomeTable/HomeTable.test.jsx
@@ -16,15 +16,16 @@ describe('HomeTable component', () => {
     render(
       <SharedContext.Provider value={mockContext}>
         <HomeTable data={data} />
-      </SharedContext.Provider>,
+      </SharedContext.Provider>
     );
 
     // Check that each of the values from data appear in the dom
     data.forEach((item) => {
-      Object.values(item).forEach((value) => {
-        const textTestNodes = screen.getAllByText(value);
-        expect(textTestNodes[0]).toBeInTheDocument();
-      });
+      expect(screen.getAllByText(item.uid)[0]).toBeInTheDocument();
+      expect(screen.getAllByText(item.wf_name)[0]).toBeInTheDocument();
+      expect(screen.getAllByText(item.startedAt)[0]).toBeInTheDocument();
+      expect(screen.getAllByText(item.phase)[0]).toBeInTheDocument();
+      expect(screen.getAllByText(item.submittedAt)[0]).toBeInTheDocument();
     });
 
     // Check that the execution and results buttons render for each row

--- a/src/Analysis/GWASResultsV2/Views/Home/HomeTable/HomeTable.test.jsx
+++ b/src/Analysis/GWASResultsV2/Views/Home/HomeTable/HomeTable.test.jsx
@@ -16,7 +16,7 @@ describe('HomeTable component', () => {
     render(
       <SharedContext.Provider value={mockContext}>
         <HomeTable data={data} />
-      </SharedContext.Provider>
+      </SharedContext.Provider>,
     );
 
     // Check that each of the values from data appear in the dom


### PR DESCRIPTION
Jira Ticket: [VADC-497](https://ctds-planx.atlassian.net/browse/VADC-497)

### New Features
This updates the Home view on the ResultsV2 app to use the wf_name and submittedAt values returned from the API request per business requirements. The tests for the home view are updated to check for these values now. 

### Bugfixes
This also fixes an import error in src/Analysis/GWASResultsV2/Views/Home/Home.stories.jsx
### Implementation
After the update, the user's input workflow names are displayed, along with the times they were submitted

<img width="1342" alt="image" src="https://user-images.githubusercontent.com/113449836/228646117-e95d21a7-db11-478b-8652-d319cf5e8fdb.png">



[VADC-497]: https://ctds-planx.atlassian.net/browse/VADC-497?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ