### PR TITLE
Fix: always refetch workflows list

### DIFF
--- a/src/Analysis/GWASResultsV2/Views/Home/Home.jsx
+++ b/src/Analysis/GWASResultsV2/Views/Home/Home.jsx
@@ -15,9 +15,6 @@ const Home = () => {
   }
   const GWASWorkflows = () => {
     const { data, status } = useQuery('workflows', fetchGwasWorkflows, {
-      refetchOnMount: false,
-      refetchOnWindowFocus: false,
-      refetchOnReconnect: false,
       refetchInterval,
     });
     if (status === 'loading') {


### PR DESCRIPTION
Jira Ticket: [VADC-536](https://ctds-planx.atlassian.net/browse/VADC-536)


### Bug Fixes
- Workflows list now always refreshes immediately when VA Results app opens


[VADC-536]: https://ctds-planx.atlassian.net/browse/VADC-536?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ