### PR TITLE
feat: solution for downloading a PNG file for a given SVG based visualization

### DIFF
--- a/src/Analysis/GWASApp/Components/Diagrams/CohortsOverlapDiagram/Simple3SetsEulerDiagram.jsx
+++ b/src/Analysis/GWASApp/Components/Diagrams/CohortsOverlapDiagram/Simple3SetsEulerDiagram.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import * as d3 from 'd3-selection';
 import * as venn from '@upsetjs/venn.js';
 import './CohortsOverlapDiagram.css';
+import { Button } from 'antd';
 
 const Simple3SetsEulerDiagram = ({
   set1Size,
@@ -63,6 +64,30 @@ const Simple3SetsEulerDiagram = ({
   ];
   const maxDiagramSize = 305;
 
+  const saveImage = () => {
+    console.log('saving image');
+    const html = d3.select("svg")
+      .attr("version", 1.1)
+      .attr("xmlns", "http://www.w3.org/2000/svg")
+      .node().parentNode.innerHTML;
+    const svgData = 'data:image/svg+xml;base64,'+ btoa(html); //TODO use buf.toString('base64') instead
+
+    const tmpImage = new Image;
+    tmpImage.src = svgData;
+    tmpImage.onload = function() {
+      const hiddenCanvas = document.getElementById("hiddenCanvas");
+      const canvasContext = hiddenCanvas.getContext("2d");
+      canvasContext.drawImage(tmpImage, 0, 0, hiddenCanvas.width, hiddenCanvas.height);
+      const canvasData = hiddenCanvas.toDataURL("image/png");
+
+      const a = document.createElement("a");
+      a.download = "euler_diagram.png";
+      a.href = canvasData;
+      a.click();
+    };
+
+  }
+
   useEffect(() => {
     // some basic validation:
     if (
@@ -84,7 +109,11 @@ const Simple3SetsEulerDiagram = ({
   }, [sets]);
 
   return (
-    <div id='euler' className='euler-diagram' data-testid='euler-diagram' />
+    <div>
+      <canvas id="hiddenCanvas" style={{display: 'none'}} width={1600} height={800}></canvas>
+      <div id='euler' className='euler-diagram' data-testid='euler-diagram' />
+      <Button onClick={saveImage}>Download Image</Button>
+    </div>
   );
 };
 

--- a/src/Analysis/GWASApp/Components/Diagrams/CohortsOverlapDiagram/Simple3SetsEulerDiagram.jsx
+++ b/src/Analysis/GWASApp/Components/Diagrams/CohortsOverlapDiagram/Simple3SetsEulerDiagram.jsx
@@ -66,22 +66,26 @@ const Simple3SetsEulerDiagram = ({
 
   const saveImage = () => {
     console.log('saving image');
-    const html = d3.select("svg")
+    let svgAsInnerHTML = d3.select("svg")
       .attr("version", 1.1)
       .attr("xmlns", "http://www.w3.org/2000/svg")
+      .attr("xmlns:xlink", "http://www.w3.org/1999/xlink") //https://stackoverflow.com/questions/59138117/svg-namespace-prefix-xlink-for-href-on-image-is-not-defined - this deprecated xlink is still used by PheWeb
       .node().parentNode.innerHTML;
-    const svgData = 'data:image/svg+xml;base64,'+ btoa(html); //TODO use buf.toString('base64') instead
+    // workaround specific for PheWeb Manhattan plot where we have log₁₀ as the axis label, breaking window.btoa() below because this is non-ascii...
+    svgAsInnerHTML = svgAsInnerHTML.replace("₁", "1");
+    svgAsInnerHTML = svgAsInnerHTML.replace("₀", "0");
 
+    const svgData = 'data:image/svg+xml;base64,'+ window.btoa(svgAsInnerHTML); //TODO use buf.toString('base64') instead
     const tmpImage = new Image;
     tmpImage.src = svgData;
     tmpImage.onload = function() {
-      const hiddenCanvas = document.getElementById("hiddenCanvas");
+      const hiddenCanvas = document.createElement("canvas");
       const canvasContext = hiddenCanvas.getContext("2d");
       canvasContext.drawImage(tmpImage, 0, 0, hiddenCanvas.width, hiddenCanvas.height);
       const canvasData = hiddenCanvas.toDataURL("image/png");
 
       const a = document.createElement("a");
-      a.download = "euler_diagram.png";
+      a.download = "plot.png";
       a.href = canvasData;
       a.click();
     };
@@ -110,7 +114,6 @@ const Simple3SetsEulerDiagram = ({
 
   return (
     <div>
-      <canvas id="hiddenCanvas" style={{display: 'none'}} width={1600} height={800}></canvas>
       <div id='euler' className='euler-diagram' data-testid='euler-diagram' />
       <Button onClick={saveImage}>Download Image</Button>
     </div>


### PR DESCRIPTION
Jira Ticket: [VADC-471](https://ctds-planx.atlassian.net/browse/VADC-471)


### New Features
- Download option for a D3js (SVG) based visualization (simplified version - based on info found at https://stackoverflow.com/a/23177883, http://techslides.com/save-svg-as-an-image)

<img width="854" alt="Screenshot 2023-04-20 at 18 04 26" src="https://user-images.githubusercontent.com/2900303/233423716-f7484935-c883-47d6-a4f0-264c62116bf3.png">



[VADC-471]: https://ctds-planx.atlassian.net/browse/VADC-471?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ