### PR TITLE
Fix/change home table key

### DIFF
--- a/src/Analysis/GWASResultsV2/Views/Home/HomeTable/HomeTable.jsx
+++ b/src/Analysis/GWASResultsV2/Views/Home/HomeTable/HomeTable.jsx
@@ -13,9 +13,9 @@ const HomeTable = ({ data }) => {
   const columns = [
     {
       title: 'Run ID',
-      dataIndex: 'uid',
-      key: 'uid',
-      sorter: (a, b) => a.uid.localeCompare(b.uid),
+      dataIndex: 'name',
+      key: 'name',
+      sorter: (a, b) => a.name.localeCompare(b.name),
     },
     {
       title: 'Workflow name',

--- a/src/Analysis/GWASResultsV2/Views/Home/HomeTable/HomeTable.test.jsx
+++ b/src/Analysis/GWASResultsV2/Views/Home/HomeTable/HomeTable.test.jsx
@@ -16,7 +16,7 @@ describe('HomeTable component', () => {
     render(
       <SharedContext.Provider value={mockContext}>
         <HomeTable data={data} />
-      </SharedContext.Provider>
+      </SharedContext.Provider>,
     );
 
     // Check that each of the values from data that needed to be shown appear in the dom
@@ -29,11 +29,11 @@ describe('HomeTable component', () => {
       expect(screen.getAllByText(item.name)[0]).toBeInTheDocument();
       expect(screen.getAllByText(item.wf_name)[0]).toBeInTheDocument();
       expect(
-        screen.getAllByText(formattedStartTestDate)[0]
+        screen.getAllByText(formattedStartTestDate)[0],
       ).toBeInTheDocument();
       expect(screen.getAllByText(item.phase)[0]).toBeInTheDocument();
       expect(
-        screen.getAllByText(formattedSubmittedTestDate)[0]
+        screen.getAllByText(formattedSubmittedTestDate)[0],
       ).toBeInTheDocument();
     });
 

--- a/src/Analysis/GWASResultsV2/Views/Home/HomeTable/HomeTable.test.jsx
+++ b/src/Analysis/GWASResultsV2/Views/Home/HomeTable/HomeTable.test.jsx
@@ -16,7 +16,7 @@ describe('HomeTable component', () => {
     render(
       <SharedContext.Provider value={mockContext}>
         <HomeTable data={data} />
-      </SharedContext.Provider>,
+      </SharedContext.Provider>
     );
 
     // Check that each of the values from data that needed to be shown appear in the dom
@@ -26,14 +26,14 @@ describe('HomeTable component', () => {
       const submittedTestDate = new Date(item.submittedAt);
       const formattedSubmittedTestDate = submittedTestDate.toLocaleDateString();
 
-      expect(screen.getAllByText(item.uid)[0]).toBeInTheDocument();
+      expect(screen.getAllByText(item.name)[0]).toBeInTheDocument();
       expect(screen.getAllByText(item.wf_name)[0]).toBeInTheDocument();
       expect(
-        screen.getAllByText(formattedStartTestDate)[0],
+        screen.getAllByText(formattedStartTestDate)[0]
       ).toBeInTheDocument();
       expect(screen.getAllByText(item.phase)[0]).toBeInTheDocument();
       expect(
-        screen.getAllByText(formattedSubmittedTestDate)[0],
+        screen.getAllByText(formattedSubmittedTestDate)[0]
       ).toBeInTheDocument();
     });
 


### PR DESCRIPTION
Jira Ticket: [VADC-541](https://ctds-planx.atlassian.net/browse/VADC-541)

### New Features
This updates the home table and its test to use the ```name``` key and its value instead of the ```uid``` key from the data returned from the server. 

**Note:** This is targeting Master - Let me know if this should target a different branch to aid updating preprod or other environments for Results V2 App release 1 testing. 

### Implementation
<img width="1383" alt="image" src="https://user-images.githubusercontent.com/113449836/233731938-3145921e-0f49-43d2-96da-4f1176654235.png">


[VADC-541]: https://ctds-planx.atlassian.net/browse/VADC-541?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ