### PR TITLE
fix(gwasAppButtonWidth): Updated CSS for progress bar buttons. Update…

### DIFF
--- a/src/Analysis/GWASApp/Components/ProgressBar/ProgressBar.css
+++ b/src/Analysis/GWASApp/Components/ProgressBar/ProgressBar.css
@@ -40,6 +40,10 @@
   width: auto;
 }
 
+.progress-bar .ant-btn {
+  width: auto;
+}
+
 .progress-bar .ant-steps-item-container {
   border-bottom: 3px solid black;
 }


### PR DESCRIPTION
Jira Ticket: [VADC-599](https://ctds-planx.atlassian.net/browse/VADC-599)
### Bug Fixes

This updates the progress bar on GWAS App for production so the text in the button fits inside of the button. This issue has already been addressed in QA. 

#### Before
<img width="274" alt="image" src="https://github.com/uc-cdis/data-portal/assets/113449836/a8606cbe-4be1-4c7d-b7a3-1da6f40a87c4">

#### After
<img width="274" alt="image" src="https://github.com/uc-cdis/data-portal/assets/113449836/17f7ddc9-b828-41b0-ae1b-9523acea9f38">




[VADC-599]: https://ctds-planx.atlassian.net/browse/VADC-599?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ