### PR TITLE
Feat/two attrition tables

### DIFF
--- a/src/Analysis/GWASResults/TestData/InputViewData/AttritionTableJSON.js
+++ b/src/Analysis/GWASResults/TestData/InputViewData/AttritionTableJSON.js
@@ -96,6 +96,57 @@ const AttritionTableJSON = [
       },
     ],
   },
+  {
+    "table_type": "control",
+    "rows": [
+      {
+        "type": "cohort",
+        "name": "Catch All (do not run generate)",
+        "size": 510647,
+        "concept_breakdown": [
+          {
+            "concept_value_name": "non-Hispanic Black",
+            "persons_in_cohort_with_value": 102054
+          },
+          {
+            "concept_value_name": "non-Hispanic Asian",
+            "persons_in_cohort_with_value": 102441
+          },
+          {
+            "concept_value_name": "non-Hispanic White",
+            "persons_in_cohort_with_value": 204213
+          },
+          {
+            "concept_value_name": "Hispanic",
+            "persons_in_cohort_with_value": 101939
+          }
+        ]
+      },
+      {
+        "type": "outcome",
+        "name": "phenotypeName",
+        "size": 444,
+        "concept_breakdown": [
+          {
+            "concept_value_name": "non-Hispanic Black",
+            "persons_in_cohort_with_value": 95
+          },
+          {
+            "concept_value_name": "non-Hispanic Asian",
+            "persons_in_cohort_with_value": 91
+          },
+          {
+            "concept_value_name": "non-Hispanic White",
+            "persons_in_cohort_with_value": 169
+          },
+          {
+            "concept_value_name": "Hispanic",
+            "persons_in_cohort_with_value": 89
+          }
+        ]
+      }
+    ]
+  }
 ];
 
 export default AttritionTableJSON;

--- a/src/Analysis/GWASResults/TestData/InputViewData/AttritionTableJSON.js
+++ b/src/Analysis/GWASResults/TestData/InputViewData/AttritionTableJSON.js
@@ -97,56 +97,56 @@ const AttritionTableJSON = [
     ],
   },
   {
-    "table_type": "control",
-    "rows": [
+    table_type: 'control',
+    rows: [
       {
-        "type": "cohort",
-        "name": "Catch All (do not run generate)",
-        "size": 510647,
-        "concept_breakdown": [
+        type: 'cohort',
+        name: 'Catch All (do not run generate)',
+        size: 510647,
+        concept_breakdown: [
           {
-            "concept_value_name": "non-Hispanic Black",
-            "persons_in_cohort_with_value": 102054
+            concept_value_name: 'non-Hispanic Black',
+            persons_in_cohort_with_value: 102054,
           },
           {
-            "concept_value_name": "non-Hispanic Asian",
-            "persons_in_cohort_with_value": 102441
+            concept_value_name: 'non-Hispanic Asian',
+            persons_in_cohort_with_value: 102441,
           },
           {
-            "concept_value_name": "non-Hispanic White",
-            "persons_in_cohort_with_value": 204213
+            concept_value_name: 'non-Hispanic White',
+            persons_in_cohort_with_value: 204213,
           },
           {
-            "concept_value_name": "Hispanic",
-            "persons_in_cohort_with_value": 101939
-          }
-        ]
+            concept_value_name: 'Hispanic',
+            persons_in_cohort_with_value: 101939,
+          },
+        ],
       },
       {
-        "type": "outcome",
-        "name": "phenotypeName",
-        "size": 444,
-        "concept_breakdown": [
+        type: 'outcome',
+        name: 'phenotypeName',
+        size: 444,
+        concept_breakdown: [
           {
-            "concept_value_name": "non-Hispanic Black",
-            "persons_in_cohort_with_value": 95
+            concept_value_name: 'non-Hispanic Black',
+            persons_in_cohort_with_value: 95,
           },
           {
-            "concept_value_name": "non-Hispanic Asian",
-            "persons_in_cohort_with_value": 91
+            concept_value_name: 'non-Hispanic Asian',
+            persons_in_cohort_with_value: 91,
           },
           {
-            "concept_value_name": "non-Hispanic White",
-            "persons_in_cohort_with_value": 169
+            concept_value_name: 'non-Hispanic White',
+            persons_in_cohort_with_value: 169,
           },
           {
-            "concept_value_name": "Hispanic",
-            "persons_in_cohort_with_value": 89
-          }
-        ]
-      }
-    ]
-  }
+            concept_value_name: 'Hispanic',
+            persons_in_cohort_with_value: 89,
+          },
+        ],
+      },
+    ],
+  },
 ];
 
 export default AttritionTableJSON;

--- a/src/Analysis/GWASResults/Views/Input/AttritionTable/AttritionTable.css
+++ b/src/Analysis/GWASResults/Views/Input/AttritionTable/AttritionTable.css
@@ -74,6 +74,10 @@
   height: 40px;
 }
 
+.attrition-table .row-type {
+  text-transform: capitalize;
+}
+
 .attrition-table table .attrition-table--leftpad {
   padding-left: 26px;
 }

--- a/src/Analysis/GWASResults/Views/Input/AttritionTable/AttritionTableWrapper.test.jsx
+++ b/src/Analysis/GWASResults/Views/Input/AttritionTable/AttritionTableWrapper.test.jsx
@@ -3,13 +3,13 @@ import { render, waitFor, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { useQuery } from 'react-query';
 import SharedContext from '../../../Utils/SharedContext';
-import AttritionTable from './AttrtitionTable';
+import AttritionTableWrapper from './AttrtitionTableWrapper';
 import PHASES from '../../../Utils/PhasesEnumeration';
 import AttritionTableJSON from '../../../TestData/InputViewData/AttritionTableJSON';
 
 jest.mock('react-query');
 
-describe('Attrition Table', () => {
+describe('Attrition Table Wrapper', () => {
   const selectedRowData = {
     name: 'workflow_name',
     uid: 'workflow_id',
@@ -24,7 +24,7 @@ describe('Attrition Table', () => {
 
     render(
       <SharedContext.Provider value={{ selectedRowData }}>
-        <AttritionTable />
+        <AttritionTableWrapper />
       </SharedContext.Provider>,
     );
     expect(screen.getByTestId('loading-error-message')).toBeInTheDocument();
@@ -38,7 +38,7 @@ describe('Attrition Table', () => {
 
     render(
       <SharedContext.Provider value={{ selectedRowData }}>
-        <AttritionTable />
+        <AttritionTableWrapper />
       </SharedContext.Provider>,
     );
     expect(screen.getByTestId('spinner')).toBeInTheDocument();
@@ -52,7 +52,7 @@ describe('Attrition Table', () => {
 
     render(
       <SharedContext.Provider value={{ selectedRowData }}>
-        <AttritionTable />
+        <AttritionTableWrapper />
       </SharedContext.Provider>,
     );
 
@@ -67,12 +67,13 @@ describe('Attrition Table', () => {
     });
     render(
       <SharedContext.Provider value={{ selectedRowData }}>
-        <AttritionTable />
+        <AttritionTableWrapper />
       </SharedContext.Provider>,
     );
 
     await waitFor(() => {
-      expect(screen.getByText('Attrition Table')).toBeInTheDocument();
+      expect(screen.getByText('Case Cohort')).toBeInTheDocument();
+      expect(screen.getByText('Control Cohort')).toBeInTheDocument();
       expect(screen.getByText('Type')).toBeInTheDocument();
       expect(screen.getByText('Name')).toBeInTheDocument();
       expect(screen.getByText('Size')).toBeInTheDocument();

--- a/src/Analysis/GWASResults/Views/Input/AttritionTable/AttritionTableWrapper.test.jsx
+++ b/src/Analysis/GWASResults/Views/Input/AttritionTable/AttritionTableWrapper.test.jsx
@@ -60,7 +60,7 @@ describe('Attrition Table Wrapper', () => {
     );
   });
 
-  it('renders the logs when data is fetched successfully', async () => {
+  it('renders the headers and data when data is fetched successfully', async () => {
     useQuery.mockReturnValueOnce({
       status: 'success',
       data: AttritionTableJSON,
@@ -86,6 +86,16 @@ describe('Attrition Table Wrapper', () => {
       checkForAtLeastOneInstanceOfText('Non-Hispanic Asian');
       checkForAtLeastOneInstanceOfText('Non-Hispanic White');
       checkForAtLeastOneInstanceOfText('Hispanic');
+
+      AttritionTableJSON.forEach((tableObj) => {
+        tableObj.rows.forEach((rowObj) => {
+          checkForAtLeastOneInstanceOfText(rowObj.name);
+          checkForAtLeastOneInstanceOfText(rowObj.size);
+          rowObj.concept_breakdown.forEach((conceptObj) => {
+            checkForAtLeastOneInstanceOfText(conceptObj.persons_in_cohort_with_value);
+          });
+        });
+      });
     });
   });
 });

--- a/src/Analysis/GWASResults/Views/Input/AttritionTable/AttritionTableWrapper.test.jsx
+++ b/src/Analysis/GWASResults/Views/Input/AttritionTable/AttritionTableWrapper.test.jsx
@@ -72,8 +72,8 @@ describe('Attrition Table Wrapper', () => {
     );
 
     const checkForAtLeastOneInstanceOfText = (input) => {
-      const typeHeader = screen.getAllByText(input);
-      expect(typeHeader[0]).toBeInTheDocument();
+      const textArr = screen.getAllByText(input);
+      expect(textArr[0]).toBeInTheDocument();
     };
 
     await waitFor(() => {

--- a/src/Analysis/GWASResults/Views/Input/AttritionTable/AttritionTableWrapper.test.jsx
+++ b/src/Analysis/GWASResults/Views/Input/AttritionTable/AttritionTableWrapper.test.jsx
@@ -71,10 +71,10 @@ describe('Attrition Table Wrapper', () => {
       </SharedContext.Provider>,
     );
 
-      const checkForAtLeastOneInstanceOfText = (input) => {
-        const typeHeader = screen.getAllByText(input);
-        expect(typeHeader[0]).toBeInTheDocument();
-      }
+    const checkForAtLeastOneInstanceOfText = (input) => {
+      const typeHeader = screen.getAllByText(input);
+      expect(typeHeader[0]).toBeInTheDocument();
+    };
 
     await waitFor(() => {
       expect(screen.getByText('Case Cohort Attrition Table')).toBeInTheDocument();

--- a/src/Analysis/GWASResults/Views/Input/AttritionTable/AttritionTableWrapper.test.jsx
+++ b/src/Analysis/GWASResults/Views/Input/AttritionTable/AttritionTableWrapper.test.jsx
@@ -71,16 +71,21 @@ describe('Attrition Table Wrapper', () => {
       </SharedContext.Provider>,
     );
 
+      const checkForAtLeastOneInstanceOfText = (input) => {
+        const typeHeader = screen.getAllByText(input);
+        expect(typeHeader[0]).toBeInTheDocument();
+      }
+
     await waitFor(() => {
-      expect(screen.getByText('Case Cohort')).toBeInTheDocument();
-      expect(screen.getByText('Control Cohort')).toBeInTheDocument();
-      expect(screen.getByText('Type')).toBeInTheDocument();
-      expect(screen.getByText('Name')).toBeInTheDocument();
-      expect(screen.getByText('Size')).toBeInTheDocument();
-      expect(screen.getByText('Non-Hispanic Black')).toBeInTheDocument();
-      expect(screen.getByText('Non-Hispanic Asian')).toBeInTheDocument();
-      expect(screen.getByText('Non-Hispanic White')).toBeInTheDocument();
-      expect(screen.getByText('Hispanic')).toBeInTheDocument();
+      expect(screen.getByText('Case Cohort Attrition Table')).toBeInTheDocument();
+      expect(screen.getByText('Control Cohort Attrition Table')).toBeInTheDocument();
+      checkForAtLeastOneInstanceOfText('Type');
+      checkForAtLeastOneInstanceOfText('Name');
+      checkForAtLeastOneInstanceOfText('Size');
+      checkForAtLeastOneInstanceOfText('Non-Hispanic Black');
+      checkForAtLeastOneInstanceOfText('Non-Hispanic Asian');
+      checkForAtLeastOneInstanceOfText('Non-Hispanic White');
+      checkForAtLeastOneInstanceOfText('Hispanic');
     });
   });
 });

--- a/src/Analysis/GWASResults/Views/Input/AttritionTable/AttrtitionTable.jsx
+++ b/src/Analysis/GWASResults/Views/Input/AttritionTable/AttrtitionTable.jsx
@@ -12,6 +12,13 @@ const AttritionTable = ({ tableData, title }) => {
     return matchingObject?.persons_in_cohort_with_value || <h3>❌</h3>;
   };
 
+  const displayRowType = (rowType) => {
+    if (rowType) {
+      return rowType === 'outcome' ? 'Outcome Phenotype' : rowType
+    }
+    return <h3>❌</h3>;
+  }
+
   return (
     <section data-testid='attrition-table' className='attrition-table'>
       <div className='attrition-table'>
@@ -41,7 +48,7 @@ const AttritionTable = ({ tableData, title }) => {
               <tbody>
                 {tableData.rows.map((row, index) => (
                   <tr key={index}>
-                    <td>{row?.type || <h3>❌</h3>}</td>
+                    <td className="row-type">{displayRowType(row?.type)}</td>
                     <td>{row?.name || <h3>❌</h3>}</td>
                     <td className='attrition-table--rightborder'>
                       {row?.size || <h3>❌</h3>}

--- a/src/Analysis/GWASResults/Views/Input/AttritionTable/AttrtitionTable.jsx
+++ b/src/Analysis/GWASResults/Views/Input/AttritionTable/AttrtitionTable.jsx
@@ -14,10 +14,10 @@ const AttritionTable = ({ tableData, title }) => {
 
   const displayRowType = (rowType) => {
     if (rowType) {
-      return rowType === 'outcome' ? 'Outcome Phenotype' : rowType
+      return rowType === 'outcome' ? 'Outcome Phenotype' : rowType;
     }
     return <h3>❌</h3>;
-  }
+  };
 
   return (
     <section data-testid='attrition-table' className='attrition-table'>
@@ -48,7 +48,7 @@ const AttritionTable = ({ tableData, title }) => {
               <tbody>
                 {tableData.rows.map((row, index) => (
                   <tr key={index}>
-                    <td className="row-type">{displayRowType(row?.type)}</td>
+                    <td className='row-type'>{displayRowType(row?.type)}</td>
                     <td>{row?.name || <h3>❌</h3>}</td>
                     <td className='attrition-table--rightborder'>
                       {row?.size || <h3>❌</h3>}

--- a/src/Analysis/GWASResults/Views/Input/AttritionTable/AttrtitionTable.jsx
+++ b/src/Analysis/GWASResults/Views/Input/AttritionTable/AttrtitionTable.jsx
@@ -5,7 +5,6 @@ import './AttritionTable.css';
 
 const { Panel } = Collapse;
 const AttritionTable = ({ tableData, title }) => {
-  console.log('tableData', tableData);
   const getBreakDownForGroup = (groupName, conceptBreakdownArray) => {
     const matchingObject = conceptBreakdownArray.find(
       (obj) => obj.concept_value_name === groupName,

--- a/src/Analysis/GWASResults/Views/Input/AttritionTable/AttrtitionTable.jsx
+++ b/src/Analysis/GWASResults/Views/Input/AttritionTable/AttrtitionTable.jsx
@@ -5,7 +5,7 @@ import './AttritionTable.css';
 
 const { Panel } = Collapse;
 const AttritionTable = ({tableData, title}) => {
-
+console.log("tableData",tableData)
   const getBreakDownForGroup = (groupName, conceptBreakdownArray) => {
     const matchingObject = conceptBreakdownArray.find(
       (obj) => obj.concept_value_name === groupName,

--- a/src/Analysis/GWASResults/Views/Input/AttritionTable/AttrtitionTable.jsx
+++ b/src/Analysis/GWASResults/Views/Input/AttritionTable/AttrtitionTable.jsx
@@ -1,11 +1,11 @@
-import React, { useContext } from 'react';
+import React from 'react';
 import { Collapse } from 'antd';
 import PropTypes from 'prop-types';
 import './AttritionTable.css';
 
 const { Panel } = Collapse;
-const AttritionTable = ({tableData, title}) => {
-console.log("tableData",tableData)
+const AttritionTable = ({ tableData, title }) => {
+  console.log('tableData', tableData);
   const getBreakDownForGroup = (groupName, conceptBreakdownArray) => {
     const matchingObject = conceptBreakdownArray.find(
       (obj) => obj.concept_value_name === groupName,
@@ -80,8 +80,7 @@ console.log("tableData",tableData)
 };
 AttritionTable.propTypes = {
   tableData: PropTypes.object.isRequired,
-  title: PropTypes.string,
+  title: PropTypes.string.isRequired,
 };
-
 
 export default AttritionTable;

--- a/src/Analysis/GWASResults/Views/Input/AttritionTable/AttrtitionTable.jsx
+++ b/src/Analysis/GWASResults/Views/Input/AttritionTable/AttrtitionTable.jsx
@@ -1,46 +1,13 @@
 import React, { useContext } from 'react';
-import { useQuery } from 'react-query';
-import { Spin, Collapse } from 'antd';
-import {
-  getDataForWorkflowArtifact,
-  queryConfig,
-} from '../../../Utils/gwasWorkflowApi';
+import { Collapse } from 'antd';
 import SharedContext from '../../../Utils/SharedContext';
-import LoadingErrorMessage from '../../../Components/LoadingErrorMessage/LoadingErrorMessage';
 import './AttritionTable.css';
 
 const { Panel } = Collapse;
-const AttritionTable = () => {
+const AttritionTable = ({data, title}) => {
   const { selectedRowData } = useContext(SharedContext);
   const { name, uid } = selectedRowData;
-  const { data, status } = useQuery(
-    [`getDataForWorkflowArtifact${name}`, name, uid, 'attrition_json_index'],
-    () => getDataForWorkflowArtifact(name, uid, 'attrition_json_index'),
-    queryConfig,
-  );
 
-  if (status === 'error') {
-    return (
-      <LoadingErrorMessage
-        data-testid='loading-error-message'
-        message='Error getting attrition table data'
-      />
-    );
-  }
-
-  if (status === 'loading') {
-    return (
-      <div className='spinner-container' data-testid='spinner'>
-        <Spin />
-      </div>
-    );
-  }
-
-  if (!data || data.length === 0 || data.error) {
-    return (
-      <LoadingErrorMessage message='Issue Loading Data for Attrition Table' />
-    );
-  }
 
   const getBreakDownForGroup = (groupName, conceptBreakdownArray) => {
     const matchingObject = conceptBreakdownArray.find(
@@ -56,7 +23,7 @@ const AttritionTable = () => {
           defaultActiveKey={['1']}
           onClick={(event) => event.stopPropagation()}
         >
-          <Panel key='1' header='Attrition Table'>
+          <Panel key='1' header={title}>
             <table>
               <thead>
                 <tr>
@@ -76,7 +43,7 @@ const AttritionTable = () => {
                 </tr>
               </thead>
               <tbody>
-                {data[0].rows.map((row, index) => (
+                {data.rows.map((row, index) => (
                   <tr key={index}>
                     <td>{row?.type || <h3>❌</h3>}</td>
                     <td>{row?.name || <h3>❌</h3>}</td>

--- a/src/Analysis/GWASResults/Views/Input/AttritionTable/AttrtitionTable.jsx
+++ b/src/Analysis/GWASResults/Views/Input/AttritionTable/AttrtitionTable.jsx
@@ -1,13 +1,10 @@
 import React, { useContext } from 'react';
 import { Collapse } from 'antd';
-import SharedContext from '../../../Utils/SharedContext';
+import PropTypes from 'prop-types';
 import './AttritionTable.css';
 
 const { Panel } = Collapse;
-const AttritionTable = ({data, title}) => {
-  const { selectedRowData } = useContext(SharedContext);
-  const { name, uid } = selectedRowData;
-
+const AttritionTable = ({tableData, title}) => {
 
   const getBreakDownForGroup = (groupName, conceptBreakdownArray) => {
     const matchingObject = conceptBreakdownArray.find(
@@ -43,7 +40,7 @@ const AttritionTable = ({data, title}) => {
                 </tr>
               </thead>
               <tbody>
-                {data.rows.map((row, index) => (
+                {tableData.rows.map((row, index) => (
                   <tr key={index}>
                     <td>{row?.type || <h3>❌</h3>}</td>
                     <td>{row?.name || <h3>❌</h3>}</td>
@@ -81,4 +78,10 @@ const AttritionTable = ({data, title}) => {
     </section>
   );
 };
+AttritionTable.propTypes = {
+  tableData: PropTypes.object.isRequired,
+  title: PropTypes.string,
+};
+
+
 export default AttritionTable;

--- a/src/Analysis/GWASResults/Views/Input/AttritionTable/AttrtitionTableWrapper.jsx
+++ b/src/Analysis/GWASResults/Views/Input/AttritionTable/AttrtitionTableWrapper.jsx
@@ -36,7 +36,7 @@ const AttritionTableWrapper = () => {
     );
   }
 
-  if (!data || data.length === 0 || data[0].table_type !== 'case' || data.error ) {
+  if (!data || data.length === 0 || data[0].table_type !== 'case' || data.error) {
     return (
       <LoadingErrorMessage message='Error Getting Attrition Table Data' />
     );

--- a/src/Analysis/GWASResults/Views/Input/AttritionTable/AttrtitionTableWrapper.jsx
+++ b/src/Analysis/GWASResults/Views/Input/AttritionTable/AttrtitionTableWrapper.jsx
@@ -48,13 +48,12 @@ const AttritionTableWrapper = () => {
       <LoadingErrorMessage message='Data for Attrition Table Missing Case Cohort Data' />
     );
   }
-  console.log("data",data)
 
   return (
     <section data-testid='attrition-table-wrapper' className='attrition-table-wrapper'>
-      <AttritionTable data={data[0]} title="Case Cohort Attribution Table"/>
+      <AttritionTable tableData={data[0]} title="Case Cohort Attribution Table"/>
       {data[1]?.table_type === 'control' &&
-      <AttritionTable data={data[1]} title="Control Cohort Attribution Table" />}
+      <AttritionTable tableData={data[1]} title="Control Cohort Attribution Table" />}
     </section>
   );
 };

--- a/src/Analysis/GWASResults/Views/Input/AttritionTable/AttrtitionTableWrapper.jsx
+++ b/src/Analysis/GWASResults/Views/Input/AttritionTable/AttrtitionTableWrapper.jsx
@@ -36,15 +36,9 @@ const AttritionTableWrapper = () => {
     );
   }
 
-  if (!data || data.length === 0 || data.error) {
+  if (!data || data.length === 0 || data[0].table_type !== 'case' || data.error ) {
     return (
-      <LoadingErrorMessage message='Issue Loading Data for Attrition Table' />
-    );
-  }
-
-  if (data[0].table_type !== 'case') {
-    return (
-      <LoadingErrorMessage message='Issue with Case Cohort Data for Attrition Table' />
+      <LoadingErrorMessage message='Error Getting Attrition Table Data' />
     );
   }
 

--- a/src/Analysis/GWASResults/Views/Input/AttritionTable/AttrtitionTableWrapper.jsx
+++ b/src/Analysis/GWASResults/Views/Input/AttritionTable/AttrtitionTableWrapper.jsx
@@ -1,6 +1,6 @@
 import React, { useContext } from 'react';
 import { useQuery } from 'react-query';
-import { Spin, Collapse } from 'antd';
+import { Spin } from 'antd';
 import {
   getDataForWorkflowArtifact,
   queryConfig,
@@ -10,7 +10,6 @@ import LoadingErrorMessage from '../../../Components/LoadingErrorMessage/Loading
 import './AttritionTable.css';
 import AttritionTable from './AttrtitionTable';
 
-const { Panel } = Collapse;
 const AttritionTableWrapper = () => {
   const { selectedRowData } = useContext(SharedContext);
   const { name, uid } = selectedRowData;
@@ -51,9 +50,9 @@ const AttritionTableWrapper = () => {
 
   return (
     <section data-testid='attrition-table-wrapper' className='attrition-table-wrapper'>
-      <AttritionTable tableData={data[0]} title="Case Cohort Attrition Table"/>
-      {data[1]?.table_type === 'control' &&
-      <AttritionTable tableData={data[1]} title="Control Cohort Attrition Table" />}
+      <AttritionTable tableData={data[0]} title='Case Cohort Attrition Table' />
+      {data[1]?.table_type === 'control'
+      && <AttritionTable tableData={data[1]} title='Control Cohort Attrition Table' />}
     </section>
   );
 };

--- a/src/Analysis/GWASResults/Views/Input/AttritionTable/AttrtitionTableWrapper.jsx
+++ b/src/Analysis/GWASResults/Views/Input/AttritionTable/AttrtitionTableWrapper.jsx
@@ -44,7 +44,7 @@ const AttritionTableWrapper = () => {
 
   if (data[0].table_type !== 'case') {
     return (
-      <LoadingErrorMessage message='Data for Attrition Table Missing Case Cohort Data' />
+      <LoadingErrorMessage message='Issue with Case Cohort Data for Attrition Table' />
     );
   }
 

--- a/src/Analysis/GWASResults/Views/Input/AttritionTable/AttrtitionTableWrapper.jsx
+++ b/src/Analysis/GWASResults/Views/Input/AttritionTable/AttrtitionTableWrapper.jsx
@@ -1,0 +1,61 @@
+import React, { useContext } from 'react';
+import { useQuery } from 'react-query';
+import { Spin, Collapse } from 'antd';
+import {
+  getDataForWorkflowArtifact,
+  queryConfig,
+} from '../../../Utils/gwasWorkflowApi';
+import SharedContext from '../../../Utils/SharedContext';
+import LoadingErrorMessage from '../../../Components/LoadingErrorMessage/LoadingErrorMessage';
+import './AttritionTable.css';
+import AttritionTable from './AttrtitionTable';
+
+const { Panel } = Collapse;
+const AttritionTableWrapper = () => {
+  const { selectedRowData } = useContext(SharedContext);
+  const { name, uid } = selectedRowData;
+  const { data, status } = useQuery(
+    [`getDataForWorkflowArtifact${name}`, name, uid, 'attrition_json_index'],
+    () => getDataForWorkflowArtifact(name, uid, 'attrition_json_index'),
+    queryConfig,
+  );
+
+  if (status === 'error') {
+    return (
+      <LoadingErrorMessage
+        data-testid='loading-error-message'
+        message='Error getting attrition table data'
+      />
+    );
+  }
+
+  if (status === 'loading') {
+    return (
+      <div className='spinner-container' data-testid='spinner'>
+        <Spin />
+      </div>
+    );
+  }
+
+  if (!data || data.length === 0 || data.error) {
+    return (
+      <LoadingErrorMessage message='Issue Loading Data for Attrition Table' />
+    );
+  }
+
+  if (data[0].table_type !== 'case') {
+    return (
+      <LoadingErrorMessage message='Data for Attrition Table Missing Case Cohort Data' />
+    );
+  }
+  console.log("data",data)
+
+  return (
+    <section data-testid='attrition-table-wrapper' className='attrition-table-wrapper'>
+      <AttritionTable data={data[0]} title="Case Cohort Attribution Table"/>
+      {data[1]?.table_type === 'control' &&
+      <AttritionTable data={data[1]} title="Control Cohort Attribution Table" />}
+    </section>
+  );
+};
+export default AttritionTableWrapper;

--- a/src/Analysis/GWASResults/Views/Input/AttritionTable/AttrtitionTableWrapper.jsx
+++ b/src/Analysis/GWASResults/Views/Input/AttritionTable/AttrtitionTableWrapper.jsx
@@ -51,9 +51,9 @@ const AttritionTableWrapper = () => {
 
   return (
     <section data-testid='attrition-table-wrapper' className='attrition-table-wrapper'>
-      <AttritionTable tableData={data[0]} title="Case Cohort Attribution Table"/>
+      <AttritionTable tableData={data[0]} title="Case Cohort Attrition Table"/>
       {data[1]?.table_type === 'control' &&
-      <AttritionTable tableData={data[1]} title="Control Cohort Attribution Table" />}
+      <AttritionTable tableData={data[1]} title="Control Cohort Attrition Table" />}
     </section>
   );
 };

--- a/src/Analysis/GWASResults/Views/Input/Input.jsx
+++ b/src/Analysis/GWASResults/Views/Input/Input.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import DetailPageHeader from '../../Components/DetailPageHeader/DetailPageHeader';
 import JobDetails from './JobDetails/JobDetails';
-import AttritionTable from './AttritionTable/AttrtitionTable';
+import AttritionTableWrapper from './AttritionTable/AttrtitionTableWrapper';
 import './Input.css';
 
 const Input = () => {
@@ -18,7 +18,7 @@ const Input = () => {
   return (
     <div className='results-view'>
       {displayTopSection()}
-      <AttritionTable />
+      <AttritionTableWrapper />
       <JobDetails />
     </div>
   );

--- a/src/CoreMetadata/CoreMetadataHeader.jsx
+++ b/src/CoreMetadata/CoreMetadataHeader.jsx
@@ -95,7 +95,7 @@ class CoreMetadataHeader extends Component {
         } else {
           // set to empty so it wont check again
           this.setState({
-            downloadButton: (<React.Fragment />),
+            downloadButton: (<p className='h3-typo' id='no-permission'>You do not have access to download this data.</p>),
           });
         }
       });

--- a/src/CoreMetadata/CoreMetadataHeader.jsx
+++ b/src/CoreMetadata/CoreMetadataHeader.jsx
@@ -95,7 +95,7 @@ class CoreMetadataHeader extends Component {
         } else {
           // set to empty so it wont check again
           this.setState({
-            downloadButton: (<p className='h3-typo' id='no-permission'>You do not have permission to access the contents of this file.</p>),
+            downloadButton: (<React.Fragment />),
           });
         }
       });

--- a/src/CoreMetadata/CoreMetadataHeader.jsx
+++ b/src/CoreMetadata/CoreMetadataHeader.jsx
@@ -95,7 +95,7 @@ class CoreMetadataHeader extends Component {
         } else {
           // set to empty so it wont check again
           this.setState({
-            downloadButton: (<p className='h3-typo' id='no-permission'>You do not have access to download this data.</p>),
+            downloadButton: (<p className='h3-typo' id='no-permission'>You do not have permission to access the contents of this file.</p>),
           });
         }
       });


### PR DESCRIPTION
Jira Ticket: [VADC-613](https://ctds-planx.atlassian.net/browse/VADC-613)

### New Features
This refactors the Attrition Table component in the Results App so that the input view renders two tables, one above the other, when the returned JSON data contains objects for both the "table_type":case  and "table_type": control. The case table renders first, above the control table. If the case table data is missing an error message will be shown. The control table is optional and depends on the user's input when creating their GWAS submission. 

The appearance and labels matches the existing Attrition tables in the GWAS App, except for the “Chart” column (which is only shown in GWAS App)

### Design
![image](https://github.com/uc-cdis/data-portal/assets/113449836/b7ad03d7-37b4-427d-96be-b6d8af9e85e5)


### Implementation
![output](https://github.com/uc-cdis/data-portal/assets/113449836/91943945-a9e4-4246-963c-466c237de2e3)



[VADC-613]: https://ctds-planx.atlassian.net/browse/VADC-613?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ