### PR TITLE
(PXP-11006): add to discovery page setup ability to select guidType for the api call

### DIFF
--- a/docs/portal_config.md
+++ b/docs/portal_config.md
@@ -446,6 +446,7 @@ Below is an example, with inline comments describing what each JSON block config
         "enabled": true,
         "text": "My Special Test Discovery Page"
       },
+      "guidType": "discovery_metadata" // optional, default value is "discovery_metadata" changes the _guid_type in the api call that fetches mds records
       "search": {
         "searchBar": {
           "enabled": true,

--- a/src/Discovery/DiscoveryConfig.d.ts
+++ b/src/Discovery/DiscoveryConfig.d.ts
@@ -9,7 +9,7 @@ export interface DiscoveryConfig {
             enableDownloadZip: boolean
             downloadZipButtonText?: string
             verifyExternalLogins?: boolean
-        }
+        },
         // explorationIntegration: {
         //     enabled: boolean // not supported
         // },
@@ -21,7 +21,8 @@ export interface DiscoveryConfig {
         pageTitle: {
             enabled: boolean
             text: string
-        }
+        },
+        guidType?: string,
         search: {
             searchBar: {
                 enabled: boolean,

--- a/src/Discovery/index.tsx
+++ b/src/Discovery/index.tsx
@@ -82,7 +82,7 @@ const DiscoveryWithMDSBackend: React.FC<{
       } else {
         loadStudiesFunction = loadStudiesFromMDS;
       }
-      const rawStudiesRegistered = await loadStudiesFunction();
+      const rawStudiesRegistered = await loadStudiesFunction(props.config?.features?.guidType);
       let rawStudiesUnregistered = [];
       if (isEnabled('studyRegistration')) {
         rawStudiesUnregistered = await loadStudiesFromMDS('unregistered_discovery_metadata');


### PR DESCRIPTION
Jira Ticket: [PXP-11006](https://ctds-planx.atlassian.net/browse/PXP-11006)
### New Features
- add to discovery page setup ability to select guidType for the api call
