### PR TITLE
Fix/results app home table fix

### DIFF
--- a/src/Analysis/GWASResults/Views/Home/HomeTable/HomeTable.jsx
+++ b/src/Analysis/GWASResults/Views/Home/HomeTable/HomeTable.jsx
@@ -1,7 +1,5 @@
 import React, { useContext, useEffect, useState } from 'react';
-import {
-  Button, Table, Space, Input, DatePicker, Select,
-} from 'antd';
+import { Button, Table, Space, Input, DatePicker, Select } from 'antd';
 import { SearchOutlined } from '@ant-design/icons';
 import PropTypes from 'prop-types';
 import moment from 'moment';
@@ -105,7 +103,8 @@ const HomeTable = ({ data }) => {
   };
 
   const jobStatusDropdownOptions = [];
-  Object.values(PHASES).forEach((phase) => jobStatusDropdownOptions.push({ value: phase, label: phase }),
+  Object.values(PHASES).forEach((phase) =>
+    jobStatusDropdownOptions.push({ value: phase, label: phase })
   );
 
   const columns = [
@@ -116,8 +115,8 @@ const HomeTable = ({ data }) => {
       show: homeTableState.columnManagement.showRunId,
       sorter: (a, b) => a.name.localeCompare(b.name),
       sortOrder:
-        homeTableState.sortInfo?.columnKey === 'name'
-        && homeTableState.sortInfo.order,
+        homeTableState.sortInfo?.columnKey === 'name' &&
+        homeTableState.sortInfo.order,
       children: [
         {
           title: (
@@ -139,8 +138,8 @@ const HomeTable = ({ data }) => {
       show: homeTableState.columnManagement.showWorkflowName,
       sorter: (a, b) => a.wf_name.localeCompare(b.wf_name),
       sortOrder:
-        homeTableState.sortInfo?.columnKey === 'wf_name'
-        && homeTableState.sortInfo.order,
+        homeTableState.sortInfo?.columnKey === 'wf_name' &&
+        homeTableState.sortInfo.order,
       children: [
         {
           title: (
@@ -162,8 +161,8 @@ const HomeTable = ({ data }) => {
       show: homeTableState.columnManagement.showDateSubmitted,
       sorter: (a, b) => a.submittedAt.localeCompare(b.submittedAt),
       sortOrder:
-        homeTableState.sortInfo?.columnKey === 'submittedAt'
-        && homeTableState.sortInfo.order,
+        homeTableState.sortInfo?.columnKey === 'submittedAt' &&
+        homeTableState.sortInfo.order,
       children: [
         {
           title: (
@@ -187,8 +186,8 @@ const HomeTable = ({ data }) => {
       key: 'phase',
       show: homeTableState.columnManagement.showJobStatus,
       sortOrder:
-        homeTableState.sortInfo?.columnKey === 'phase'
-        && homeTableState.sortInfo.order,
+        homeTableState.sortInfo?.columnKey === 'phase' &&
+        homeTableState.sortInfo.order,
       children: [
         {
           title: (
@@ -221,10 +220,16 @@ const HomeTable = ({ data }) => {
       title: 'Date/Time Finished',
       key: 'finishedAt',
       show: homeTableState.columnManagement.showDateFinished,
-      sorter: (a, b) => a.finishedAt.localeCompare(b.finishedAt),
+      sorter: (a, b) => {
+        if (!a.finishedAt) return -1;
+        else if (!b.finishedAt) return -1;
+        else {
+          return a?.finishedAt.localeCompare(b?.finishedAt);
+        }
+      },
       sortOrder:
-        homeTableState.sortInfo?.columnKey === 'finishedAt'
-        && homeTableState.sortInfo.order,
+        homeTableState.sortInfo?.columnKey === 'finishedAt' &&
+        homeTableState.sortInfo.order,
       dataIndex: 'finishedAt',
       children: [
         {
@@ -239,7 +244,8 @@ const HomeTable = ({ data }) => {
             />
           ),
           dataIndex: 'finishedAt',
-          render: (value) => (value ? <DateForTable utcFormattedDate={value} /> : '—/—/----'),
+          render: (value) =>
+            value ? <DateForTable utcFormattedDate={value} /> : '—/—/----',
         },
       ],
     },
@@ -299,7 +305,8 @@ const HomeTable = ({ data }) => {
     setFilteredData(filterTableData(data, homeTableState));
   }, [homeTableState, data]);
 
-  const checkForShownColumn = () => Object.values(homeTableState.columnManagement).includes(true);
+  const checkForShownColumn = () =>
+    Object.values(homeTableState.columnManagement).includes(true);
 
   return (
     <div className='home-table'>
@@ -308,9 +315,13 @@ const HomeTable = ({ data }) => {
           dataSource={isIterable(filteredData) && [...filteredData]}
           columns={columns}
           rowKey={(record) => record.uid}
-          rowClassName={(record) => record.uid === selectedRowData?.uid && 'selected-row'}
+          rowClassName={(record) =>
+            record.uid === selectedRowData?.uid && 'selected-row'
+          }
           onRow={(record) => ({
-            onClick: () => { setSelectedRowData(record); },
+            onClick: () => {
+              setSelectedRowData(record);
+            },
           })}
           onChange={handleTableChange}
           pagination={{

--- a/src/Analysis/GWASResults/Views/Home/HomeTable/HomeTable.jsx
+++ b/src/Analysis/GWASResults/Views/Home/HomeTable/HomeTable.jsx
@@ -300,7 +300,6 @@ const HomeTable = ({ data }) => {
   ].filter((item) => item.show);
 
   const initiallySortedData = initialTableSort(data);
-
   const [filteredData, setFilteredData] = useState(initiallySortedData);
   useEffect(() => {
     setFilteredData(filterTableData(initiallySortedData, homeTableState));

--- a/src/Analysis/GWASResults/Views/Home/HomeTable/HomeTable.jsx
+++ b/src/Analysis/GWASResults/Views/Home/HomeTable/HomeTable.jsx
@@ -1,5 +1,7 @@
 import React, { useContext, useEffect, useState } from 'react';
-import { Button, Table, Space, Input, DatePicker, Select } from 'antd';
+import {
+  Button, Table, Space, Input, DatePicker, Select,
+} from 'antd';
 import { SearchOutlined } from '@ant-design/icons';
 import PropTypes from 'prop-types';
 import moment from 'moment';
@@ -104,8 +106,7 @@ const HomeTable = ({ data }) => {
   };
 
   const jobStatusDropdownOptions = [];
-  Object.values(PHASES).forEach((phase) =>
-    jobStatusDropdownOptions.push({ value: phase, label: phase })
+  Object.values(PHASES).forEach((phase) => jobStatusDropdownOptions.push({ value: phase, label: phase }),
   );
 
   const columns = [
@@ -116,8 +117,8 @@ const HomeTable = ({ data }) => {
       show: homeTableState.columnManagement.showRunId,
       sorter: (a, b) => a.name.localeCompare(b.name),
       sortOrder:
-        homeTableState.sortInfo?.columnKey === 'name' &&
-        homeTableState.sortInfo.order,
+        homeTableState.sortInfo?.columnKey === 'name'
+        && homeTableState.sortInfo.order,
       children: [
         {
           title: (
@@ -139,8 +140,8 @@ const HomeTable = ({ data }) => {
       show: homeTableState.columnManagement.showWorkflowName,
       sorter: (a, b) => a.wf_name.localeCompare(b.wf_name),
       sortOrder:
-        homeTableState.sortInfo?.columnKey === 'wf_name' &&
-        homeTableState.sortInfo.order,
+        homeTableState.sortInfo?.columnKey === 'wf_name'
+        && homeTableState.sortInfo.order,
       children: [
         {
           title: (
@@ -162,8 +163,8 @@ const HomeTable = ({ data }) => {
       show: homeTableState.columnManagement.showDateSubmitted,
       sorter: (a, b) => a.submittedAt.localeCompare(b.submittedAt),
       sortOrder:
-        homeTableState.sortInfo?.columnKey === 'submittedAt' &&
-        homeTableState.sortInfo.order,
+        homeTableState.sortInfo?.columnKey === 'submittedAt'
+        && homeTableState.sortInfo.order,
       children: [
         {
           title: (
@@ -187,8 +188,8 @@ const HomeTable = ({ data }) => {
       key: 'phase',
       show: homeTableState.columnManagement.showJobStatus,
       sortOrder:
-        homeTableState.sortInfo?.columnKey === 'phase' &&
-        homeTableState.sortInfo.order,
+        homeTableState.sortInfo?.columnKey === 'phase'
+        && homeTableState.sortInfo.order,
       children: [
         {
           title: (
@@ -227,8 +228,8 @@ const HomeTable = ({ data }) => {
         return a?.finishedAt.localeCompare(b?.finishedAt);
       },
       sortOrder:
-        homeTableState.sortInfo?.columnKey === 'finishedAt' &&
-        homeTableState.sortInfo.order,
+        homeTableState.sortInfo?.columnKey === 'finishedAt'
+        && homeTableState.sortInfo.order,
       dataIndex: 'finishedAt',
       children: [
         {
@@ -243,8 +244,7 @@ const HomeTable = ({ data }) => {
             />
           ),
           dataIndex: 'finishedAt',
-          render: (value) =>
-            value ? <DateForTable utcFormattedDate={value} /> : '—/—/----',
+          render: (value) => (value ? <DateForTable utcFormattedDate={value} /> : '—/—/----'),
         },
       ],
     },
@@ -306,8 +306,7 @@ const HomeTable = ({ data }) => {
     setFilteredData(filterTableData(initiallySortedData, homeTableState));
   }, [homeTableState, data]);
 
-  const checkForShownColumn = () =>
-    Object.values(homeTableState.columnManagement).includes(true);
+  const checkForShownColumn = () => Object.values(homeTableState.columnManagement).includes(true);
 
   return (
     <div className='home-table'>
@@ -316,9 +315,7 @@ const HomeTable = ({ data }) => {
           dataSource={isIterable(filteredData) && [...filteredData]}
           columns={columns}
           rowKey={(record) => record.uid}
-          rowClassName={(record) =>
-            record.uid === selectedRowData?.uid && 'selected-row'
-          }
+          rowClassName={(record) => record.uid === selectedRowData?.uid && 'selected-row'}
           onRow={(record) => ({
             onClick: () => {
               setSelectedRowData(record);

--- a/src/Analysis/GWASResults/Views/Home/HomeTable/HomeTable.jsx
+++ b/src/Analysis/GWASResults/Views/Home/HomeTable/HomeTable.jsx
@@ -8,11 +8,12 @@ import ActionsDropdown from './ActionsDropdown/ActionsDropdown';
 import Icons from './TableIcons/Icons';
 import DateForTable from '../../../Components/DateForTable/DateForTable';
 import PHASES from '../../../Utils/PhasesEnumeration';
-import filterTableData from './filterTableData';
+import filterTableData from './tableDataProcessing/filterTableData';
 import VIEWS from '../../../Utils/ViewsEnumeration';
 import isIterable from '../../../Utils/isIterable';
 import LoadingErrorMessage from '../../../Components/LoadingErrorMessage/LoadingErrorMessage';
 import './HomeTable.css';
+import initialTableSort from './tableDataProcessing/initialTableSort';
 
 const { RangePicker } = DatePicker;
 
@@ -222,10 +223,8 @@ const HomeTable = ({ data }) => {
       show: homeTableState.columnManagement.showDateFinished,
       sorter: (a, b) => {
         if (!a.finishedAt) return -1;
-        else if (!b.finishedAt) return -1;
-        else {
-          return a?.finishedAt.localeCompare(b?.finishedAt);
-        }
+        if (!b.finishedAt) return -1;
+        return a?.finishedAt.localeCompare(b?.finishedAt);
       },
       sortOrder:
         homeTableState.sortInfo?.columnKey === 'finishedAt' &&
@@ -300,9 +299,11 @@ const HomeTable = ({ data }) => {
     },
   ].filter((item) => item.show);
 
-  const [filteredData, setFilteredData] = useState(data);
+  const initiallySortedData = initialTableSort(data);
+
+  const [filteredData, setFilteredData] = useState(initiallySortedData);
   useEffect(() => {
-    setFilteredData(filterTableData(data, homeTableState));
+    setFilteredData(filterTableData(initiallySortedData, homeTableState));
   }, [homeTableState, data]);
 
   const checkForShownColumn = () =>

--- a/src/Analysis/GWASResults/Views/Home/HomeTable/HomeTable.jsx
+++ b/src/Analysis/GWASResults/Views/Home/HomeTable/HomeTable.jsx
@@ -14,8 +14,8 @@ import filterTableData from './tableDataProcessing/filterTableData';
 import VIEWS from '../../../Utils/ViewsEnumeration';
 import isIterable from '../../../Utils/isIterable';
 import LoadingErrorMessage from '../../../Components/LoadingErrorMessage/LoadingErrorMessage';
-import './HomeTable.css';
 import initialTableSort from './tableDataProcessing/initialTableSort';
+import './HomeTable.css';
 
 const { RangePicker } = DatePicker;
 

--- a/src/Analysis/GWASResults/Views/Home/HomeTable/HomeTable.jsx
+++ b/src/Analysis/GWASResults/Views/Home/HomeTable/HomeTable.jsx
@@ -10,11 +10,14 @@ import ActionsDropdown from './ActionsDropdown/ActionsDropdown';
 import Icons from './TableIcons/Icons';
 import DateForTable from '../../../Components/DateForTable/DateForTable';
 import PHASES from '../../../Utils/PhasesEnumeration';
-import filterTableData from './tableDataProcessing/filterTableData';
+import {
+  filterTableData,
+  initialTableSort,
+} from './tableDataProcessing/tableDataProcessing';
 import VIEWS from '../../../Utils/ViewsEnumeration';
 import isIterable from '../../../Utils/isIterable';
 import LoadingErrorMessage from '../../../Components/LoadingErrorMessage/LoadingErrorMessage';
-import initialTableSort from './tableDataProcessing/initialTableSort';
+
 import './HomeTable.css';
 
 const { RangePicker } = DatePicker;

--- a/src/Analysis/GWASResults/Views/Home/HomeTable/tableDataProcessing/filterTableData.js
+++ b/src/Analysis/GWASResults/Views/Home/HomeTable/tableDataProcessing/filterTableData.js
@@ -52,7 +52,6 @@ const filterTableData = (data, homeTableState) => {
       homeTableState.finishedAtSelections,
     );
   }
-
   return filteredDataResult;
 };
 

--- a/src/Analysis/GWASResults/Views/Home/HomeTable/tableDataProcessing/filterTableData.js
+++ b/src/Analysis/GWASResults/Views/Home/HomeTable/tableDataProcessing/filterTableData.js
@@ -32,7 +32,7 @@ const filterTableData = (data, homeTableState) => {
       homeTableState.wfNameSearchTerm,
     );
   }
-  if (homeTableState.submittedAtSelections.length > 1) {
+  if (homeTableState.submittedAtSelections.length > 0) {
     filteredDataResult = filterByDateRange(
       filteredDataResult,
       'submittedAt',

--- a/src/Analysis/GWASResults/Views/Home/HomeTable/tableDataProcessing/filterTableData.js
+++ b/src/Analysis/GWASResults/Views/Home/HomeTable/tableDataProcessing/filterTableData.js
@@ -1,24 +1,20 @@
 import moment from 'moment';
 
-const filterBySearchTerm = (data, key, searchTerm) =>
-  data.filter((obj) =>
-    obj[key]
-      .toString()
-      .toLowerCase()
-      .includes(searchTerm.toLowerCase())
+const filterBySearchTerm = (data, key, searchTerm) => data.filter((obj) => obj[key]
+  .toString()
+  .toLowerCase()
+  .includes(searchTerm.toLowerCase()),
+);
+
+const filterByJobStatuses = (data, jobStatusSelections) => data.filter((item) => jobStatusSelections.includes(item.phase));
+
+const filterByDateRange = (data, key, dateSelection) => data.filter((obj) => {
+  const utcDate = moment.utc(obj[key]);
+  return (
+    utcDate.isSameOrAfter(dateSelection[0], 'day')
+      && utcDate.isSameOrBefore(dateSelection[1], 'day')
   );
-
-const filterByJobStatuses = (data, jobStatusSelections) =>
-  data.filter((item) => jobStatusSelections.includes(item.phase));
-
-const filterByDateRange = (data, key, dateSelection) =>
-  data.filter((obj) => {
-    const utcDate = moment.utc(obj[key]);
-    return (
-      utcDate.isSameOrAfter(dateSelection[0], 'day') &&
-      utcDate.isSameOrBefore(dateSelection[1], 'day')
-    );
-  });
+});
 
 const filterTableData = (data, homeTableState) => {
   let filteredDataResult = data;
@@ -26,34 +22,34 @@ const filterTableData = (data, homeTableState) => {
     filteredDataResult = filterBySearchTerm(
       filteredDataResult,
       'name',
-      homeTableState.nameSearchTerm
+      homeTableState.nameSearchTerm,
     );
   }
   if (homeTableState.wfNameSearchTerm.length > 0) {
     filteredDataResult = filterBySearchTerm(
       filteredDataResult,
       'wf_name',
-      homeTableState.wfNameSearchTerm
+      homeTableState.wfNameSearchTerm,
     );
   }
   if (homeTableState.submittedAtSelections.length > 1) {
     filteredDataResult = filterByDateRange(
       filteredDataResult,
       'submittedAt',
-      homeTableState.submittedAtSelections
+      homeTableState.submittedAtSelections,
     );
   }
   if (homeTableState.jobStatusSelections.length > 0) {
     filteredDataResult = filterByJobStatuses(
       filteredDataResult,
-      homeTableState.jobStatusSelections
+      homeTableState.jobStatusSelections,
     );
   }
   if (homeTableState.finishedAtSelections.length > 0) {
     filteredDataResult = filterByDateRange(
       filteredDataResult,
       'finishedAt',
-      homeTableState.finishedAtSelections
+      homeTableState.finishedAtSelections,
     );
   }
 

--- a/src/Analysis/GWASResults/Views/Home/HomeTable/tableDataProcessing/filterTableData.js
+++ b/src/Analysis/GWASResults/Views/Home/HomeTable/tableDataProcessing/filterTableData.js
@@ -1,20 +1,24 @@
 import moment from 'moment';
 
-const filterBySearchTerm = (data, key, searchTerm) => data.filter((obj) => obj[key]
-  .toString()
-  .toLowerCase()
-  .includes(searchTerm.toLowerCase()),
-);
-
-const filterByJobStatuses = (data, jobStatusSelections) => data.filter((item) => jobStatusSelections.includes(item.phase));
-
-const filterByDateRange = (data, key, dateSelection) => data.filter((obj) => {
-  const utcDate = moment.utc(obj[key]);
-  return (
-    utcDate.isSameOrAfter(dateSelection[0])
-      && utcDate.isSameOrBefore(dateSelection[1])
+const filterBySearchTerm = (data, key, searchTerm) =>
+  data.filter((obj) =>
+    obj[key]
+      .toString()
+      .toLowerCase()
+      .includes(searchTerm.toLowerCase())
   );
-});
+
+const filterByJobStatuses = (data, jobStatusSelections) =>
+  data.filter((item) => jobStatusSelections.includes(item.phase));
+
+const filterByDateRange = (data, key, dateSelection) =>
+  data.filter((obj) => {
+    const utcDate = moment.utc(obj[key]);
+    return (
+      utcDate.isSameOrAfter(dateSelection[0], 'day') &&
+      utcDate.isSameOrBefore(dateSelection[1], 'day')
+    );
+  });
 
 const filterTableData = (data, homeTableState) => {
   let filteredDataResult = data;
@@ -22,36 +26,37 @@ const filterTableData = (data, homeTableState) => {
     filteredDataResult = filterBySearchTerm(
       filteredDataResult,
       'name',
-      homeTableState.nameSearchTerm,
+      homeTableState.nameSearchTerm
     );
   }
   if (homeTableState.wfNameSearchTerm.length > 0) {
     filteredDataResult = filterBySearchTerm(
       filteredDataResult,
       'wf_name',
-      homeTableState.wfNameSearchTerm,
+      homeTableState.wfNameSearchTerm
     );
   }
-  if (homeTableState.submittedAtSelections.length > 0) {
+  if (homeTableState.submittedAtSelections.length > 1) {
     filteredDataResult = filterByDateRange(
       filteredDataResult,
       'submittedAt',
-      homeTableState.submittedAtSelections,
+      homeTableState.submittedAtSelections
     );
   }
   if (homeTableState.jobStatusSelections.length > 0) {
     filteredDataResult = filterByJobStatuses(
       filteredDataResult,
-      homeTableState.jobStatusSelections,
+      homeTableState.jobStatusSelections
     );
   }
   if (homeTableState.finishedAtSelections.length > 0) {
     filteredDataResult = filterByDateRange(
       filteredDataResult,
       'finishedAt',
-      homeTableState.finishedAtSelections,
+      homeTableState.finishedAtSelections
     );
   }
+
   return filteredDataResult;
 };
 

--- a/src/Analysis/GWASResults/Views/Home/HomeTable/tableDataProcessing/initialTableSort.js
+++ b/src/Analysis/GWASResults/Views/Home/HomeTable/tableDataProcessing/initialTableSort.js
@@ -1,0 +1,9 @@
+const initialTableSort = (data) => {
+  return data.sort((a, b) => {
+    if (!a.finishedAt) return -1;
+    if (!b.finishedAt) return -1;
+    return b?.finishedAt.localeCompare(a?.finishedAt);
+  });
+};
+
+export default initialTableSort;

--- a/src/Analysis/GWASResults/Views/Home/HomeTable/tableDataProcessing/initialTableSort.js
+++ b/src/Analysis/GWASResults/Views/Home/HomeTable/tableDataProcessing/initialTableSort.js
@@ -1,9 +1,7 @@
-const initialTableSort = (data) => {
-  return data.sort((a, b) => {
-    if (!a.finishedAt) return -1;
-    if (!b.finishedAt) return -1;
-    return b?.finishedAt.localeCompare(a?.finishedAt);
-  });
-};
+const initialTableSort = (data) => data.sort((a, b) => {
+  if (!a.finishedAt) return -1;
+  if (!b.finishedAt) return -1;
+  return b?.finishedAt.localeCompare(a?.finishedAt);
+});
 
 export default initialTableSort;

--- a/src/Analysis/GWASResults/Views/Home/HomeTable/tableDataProcessing/tableDataProcessing.js
+++ b/src/Analysis/GWASResults/Views/Home/HomeTable/tableDataProcessing/tableDataProcessing.js
@@ -1,0 +1,4 @@
+import filterTableData from './filterTableData';
+import initialTableSort from './initialTableSort';
+
+export { filterTableData, initialTableSort };

--- a/src/CoreMetadata/CoreMetadataHeader.jsx
+++ b/src/CoreMetadata/CoreMetadataHeader.jsx
@@ -95,7 +95,7 @@ class CoreMetadataHeader extends Component {
         } else {
           // set to empty so it wont check again
           this.setState({
-            downloadButton: (<React.Fragment />),
+            downloadButton: (<p className='h3-typo' id='no-permission'>You do not have access to download this data.</p>),
           });
         }
       });

--- a/src/CoreMetadata/CoreMetadataHeader.jsx
+++ b/src/CoreMetadata/CoreMetadataHeader.jsx
@@ -95,7 +95,7 @@ class CoreMetadataHeader extends Component {
         } else {
           // set to empty so it wont check again
           this.setState({
-            downloadButton: (<p className='h3-typo' id='no-permission'>You do not have access to download this data.</p>),
+            downloadButton: (<React.Fragment />),
           });
         }
       });


### PR DESCRIPTION
Jira Ticket: [VADC-632](https://ctds-planx.atlassian.net/browse/VADC-632)

### Bug Fixes
This ticket addresses 3 bug fixes related to the home table date sorting: 

1.) When a user reran a workflow, and then submitted a new workflow, in some instances the order of the table would show them out of order in terms of date finished. This is addressed now by providing the data to the table with an initial sort based on the date finished before the data is rendered. 
2.) When a user reran a workflow and tried to sort based on date finished, the application would crash because the date finished value was null and the sorting function didn't handle null values. This is addressed by adding logic to sort null values as coming before anything else. 
3.) When a user tried to sort a date range consisting of only one date, in some cases the selected date would not render any results even if there were workflows that were submitting or finished on that day. This was due to the date range filtering function being too granular and including filtering based on time of day. The filtering function has been made less granular and now only accounts for the date, and not the time of day. 

Note that the functions associated with the home table data processing have been moved into a separate folder and can all be imported using tableDataProcessing.js
### Implementation
#### Bugs 1 & 2: 
![output](https://github.com/uc-cdis/data-portal/assets/113449836/0593324a-64a9-47f4-b103-26228ddb6737)
#### Bugs 3: 
![output](https://github.com/uc-cdis/data-portal/assets/113449836/748c32bb-aff2-4a42-adca-49c2aa9865e8)


[VADC-632]: https://ctds-planx.atlassian.net/browse/VADC-632?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ