### PR TITLE
Fix/hiccup hometable

### DIFF
--- a/src/Analysis/GWASResults/Views/Home/HomeTable/tableDataProcessing/initialTableSort.js
+++ b/src/Analysis/GWASResults/Views/Home/HomeTable/tableDataProcessing/initialTableSort.js
@@ -1,7 +1,14 @@
 const initialTableSort = (data) => data.sort((a, b) => {
-  if (!a.finishedAt) return -1;
-  if (!b.finishedAt) return -1;
-  return b?.finishedAt.localeCompare(a?.finishedAt);
+  if (a.finishedAt === null && b.finishedAt === null) {
+    return 0;
+  } else if (a.finishedAt === null) {
+    return -1; // a comes first as it has finishedAt null
+  } else if (b.finishedAt === null) {
+    return 1; // b comes first as it has finishedAt null
+  } else {
+    // Sort by finishedAt in descending order
+    return new Date(b.finishedAt) - new Date(a.finishedAt);
+  }
 });
 
 export default initialTableSort;

--- a/src/Analysis/GWASResults/Views/Home/HomeTable/tableDataProcessing/initialTableSort.js
+++ b/src/Analysis/GWASResults/Views/Home/HomeTable/tableDataProcessing/initialTableSort.js
@@ -1,14 +1,12 @@
 const initialTableSort = (data) => data.sort((a, b) => {
   if (a.finishedAt === null && b.finishedAt === null) {
     return 0;
-  } else if (a.finishedAt === null) {
-    return -1; // a comes first as it has finishedAt null
-  } else if (b.finishedAt === null) {
-    return 1; // b comes first as it has finishedAt null
-  } else {
-    // Sort by finishedAt in descending order
-    return new Date(b.finishedAt) - new Date(a.finishedAt);
+  } if (a.finishedAt === null) {
+    return -1;
+  } if (b.finishedAt === null) {
+    return 1;
   }
+  return new Date(b.finishedAt) - new Date(a.finishedAt);
 });
 
 export default initialTableSort;

--- a/src/Analysis/GWASResults/Views/Home/HomeTable/tableDataProcessing/initialTableSort.test.js
+++ b/src/Analysis/GWASResults/Views/Home/HomeTable/tableDataProcessing/initialTableSort.test.js
@@ -1,6 +1,5 @@
 import initialTableSort from './initialTableSort';
 
-
 describe('sortObjectsByFinishedAt', () => {
   it('should sort objects correctly', () => {
     const input = [
@@ -42,9 +41,7 @@ describe('sortObjectsByFinishedAt', () => {
 
   it('should return the same array if array is empty', () => {
     const input = [];
-
     const sortedArray = initialTableSort(input);
-
     expect(sortedArray).toEqual(input);
   });
 });

--- a/src/Analysis/GWASResults/Views/Home/HomeTable/tableDataProcessing/initialTableSort.test.js
+++ b/src/Analysis/GWASResults/Views/Home/HomeTable/tableDataProcessing/initialTableSort.test.js
@@ -1,0 +1,50 @@
+import initialTableSort from './initialTableSort';
+
+
+describe('sortObjectsByFinishedAt', () => {
+  it('should sort objects correctly', () => {
+    const input = [
+      { finishedAt: '2023-08-01T12:00:00Z' },
+      { finishedAt: null },
+      { finishedAt: '2023-08-03T08:00:00Z' },
+      { finishedAt: '2023-08-02T15:30:00Z' },
+      { finishedAt: null },
+    ];
+
+    const expectedOutput = [
+      { finishedAt: null },
+      { finishedAt: null },
+      { finishedAt: '2023-08-03T08:00:00Z' },
+      { finishedAt: '2023-08-02T15:30:00Z' },
+      { finishedAt: '2023-08-01T12:00:00Z' },
+    ];
+
+    const sortedArray = initialTableSort(input);
+    expect(sortedArray).toEqual(expectedOutput);
+  });
+
+  it('should return the same array if all finishedAt are null', () => {
+    const input = [
+      { finishedAt: null },
+      { finishedAt: null },
+      { finishedAt: null },
+    ];
+
+    const expectedOutput = [
+      { finishedAt: null },
+      { finishedAt: null },
+      { finishedAt: null },
+    ];
+
+    const sortedArray = initialTableSort(input);
+    expect(sortedArray).toEqual(expectedOutput);
+  });
+
+  it('should return the same array if array is empty', () => {
+    const input = [];
+
+    const sortedArray = initialTableSort(input);
+
+    expect(sortedArray).toEqual(input);
+  });
+});


### PR DESCRIPTION
Jira Ticket: [VADC-646](https://ctds-planx.atlassian.net/browse/VADC-646)
### Bug Fixes
This resolves odd UI behavior that was the result of an incorrectly implemented sort function. This function rendered ```-1``` for two different situations, resulting in unpredictable browser behavior in Chrome (but not in Firefox). 


### Improvements
Unit test written to validate initial sort function. 

### Before


### After

