### PR TITLE
Fix: adjust subtractDates to deal with empty end date

### DIFF
--- a/src/Analysis/GWASResults/Views/Execution/ExecutionTable/ExecutionTable.jsx
+++ b/src/Analysis/GWASResults/Views/Execution/ExecutionTable/ExecutionTable.jsx
@@ -4,10 +4,10 @@ import SharedContext from '../../../Utils/SharedContext';
 import DateForTable from '../../../Components/DateForTable/DateForTable';
 
 const subtractDates = (endDate, startDate) => {
-  let timestampEnd = Date.now();
-  if (endDate) {
-    timestampEnd = Date.parse(endDate);
+  if (!endDate) {
+    return '--';
   }
+  const timestampEnd = Date.parse(endDate);
   const timestampStart = Date.parse(startDate);
   const diffInMs = timestampEnd - timestampStart;
   // See here for more info:

--- a/src/Analysis/GWASResults/Views/Execution/ExecutionTable/ExecutionTable.jsx
+++ b/src/Analysis/GWASResults/Views/Execution/ExecutionTable/ExecutionTable.jsx
@@ -3,10 +3,13 @@ import moment from 'moment';
 import SharedContext from '../../../Utils/SharedContext';
 import DateForTable from '../../../Components/DateForTable/DateForTable';
 
-const subtractDates = (date1, date2) => {
-  const timestamp1 = Date.parse(date1);
-  const timestamp2 = Date.parse(date2);
-  const diffInMs = timestamp1 - timestamp2;
+const subtractDates = (endDate, startDate) => {
+  let timestampEnd = Date.now();
+  if (endDate) {
+    timestampEnd = Date.parse(endDate);
+  }
+  const timestampStart = Date.parse(startDate);
+  const diffInMs = timestampEnd - timestampStart;
   // See here for more info:
   // https://momentjscom.readthedocs.io/en/latest/moment/08-durations/03-humanize/
   return moment.duration(diffInMs).humanize();


### PR DESCRIPTION
Jira Ticket: [VADC-650](https://ctds-planx.atlassian.net/browse/VADC-650)


### Bug Fixes
- GWAS Results app: Run Duration shows correct duration instead of “Invalid date” in Execution view


[VADC-650]: https://ctds-planx.atlassian.net/browse/VADC-650?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ