### PR TITLE
(PXP-11041): Discovery page: remove empty “Tags by category” component

### DIFF
--- a/src/Discovery/Discovery.tsx
+++ b/src/Discovery/Discovery.tsx
@@ -711,7 +711,7 @@ const Discovery: React.FunctionComponent<Props> = (props: Props) => {
               </Collapse>
             </Space>
           </div>
-        ) : (
+        ) : (config.tagCategories && config.tagCategories.length > 0) && (
           <DiscoveryTagViewer
             config={config}
             studies={props.studies}


### PR DESCRIPTION
Jira Ticket: [PXP-11041](https://ctds-planx.atlassian.net/browse/PXP-11041)


### Bug Fixes
- Discovery page: remove empty “Tags by category” component
