### PR TITLE
Fix discovery page pop-up spaces

### DIFF
--- a/src/Discovery/Discovery.tsx
+++ b/src/Discovery/Discovery.tsx
@@ -602,7 +602,7 @@ const Discovery: React.FunctionComponent<Props> = (props: Props) => {
               title={'You have access to this data.'}
               content={(
                 <div className='discovery-popover__text'>
-                  <React.Fragment>You have <code>{ARBORIST_READ_PRIV}</code> access to</React.Fragment>
+                  <React.Fragment>You have <code>{ARBORIST_READ_PRIV}</code> access to </React.Fragment>
                   <React.Fragment><code>{record[config.minimalFieldMapping.authzField]}</code>.</React.Fragment>
                 </div>
               )}
@@ -625,7 +625,7 @@ const Discovery: React.FunctionComponent<Props> = (props: Props) => {
               title={'You do not have access to this data.'}
               content={(
                 <div className='discovery-popover__text'>
-                  <React.Fragment>You don&apos;t have <code>{ARBORIST_READ_PRIV}</code> access to</React.Fragment>
+                  <React.Fragment>You don&apos;t have <code>{ARBORIST_READ_PRIV}</code> access to </React.Fragment>
                   <React.Fragment><code>{record[config.minimalFieldMapping.authzField]}</code>.</React.Fragment>
                 </div>
               )}


### PR DESCRIPTION
Missing a space before the resource path:
<img width="215" alt="Screenshot 2023-08-22 at 12 03 31 PM" src="https://github.com/uc-cdis/data-portal/assets/4224001/50db2096-6bca-41fc-bdaf-a3c3ec223025">

### Improvements
- Fix the discovery page pop-up text to add spaces where needed
