### PR TITLE
feat(storybookCommandUpdate): Updated storybook command

### DIFF
--- a/package.json
+++ b/package.json
@@ -197,7 +197,7 @@
     "eslint": "./node_modules/.bin/eslint --ext js --ext jsx --ext ts --ext tsx --ignore-pattern '**/__generated__/**' --ignore-pattern '**/*.min.js' --ignore-pattern '**/setupJest.js' --ignore-pattern '**/gqlHelper.js' --ignore-pattern '**/formHooks.jsx' --ignore-pattern '**/*.stories.jsx' --fix src data",
     "eslint-new": "./node_modules/.bin/eslint  --no-error-on-unmatched-pattern  --ext js --ext jsx --ext ts --ext tsx --ignore-pattern '**/__generated__/**' --ignore-pattern '**/*.ejs' --ignore-pattern '**/*.min.js' --ignore-pattern '**/setupJest.js' --ignore-pattern '**/gqlHelper.js' --ignore-pattern '**/formHooks.jsx'  --ignore-pattern '**/*.json'   --ignore-pattern '**/Dockerfile'  --ignore-pattern '**/*.png'  --ignore-pattern '**/*.ico' --ignore-pattern '**/*.stories.jsx' --ignore-pattern '**/*.css'  --ignore-pattern '**/*.md'  --ignore-pattern '**/*.yml' --ignore-pattern '**/*.conf' --quiet --fix $(git diff --name-only master | xargs)",
     "elint": "./node_modules/.bin/eslint --ext js --ext jsx --ext ts --ext tsx --ignore-pattern '**/__generated__/**' --ignore-pattern '**/*.min.js' --ignore-pattern '**/setupJest.js'",
-    "storybook": "start-storybook -p 6006 -s .storybook/public",
+    "storybook": "npm run params && start-storybook -p 6006 -s .storybook/public",
     "stylelint": "stylelint 'src/**/*.less' 'src/**/*.css' --config .stylelintrc.js --fix",
     "sanity-check": "node ./sanity-check"
   },


### PR DESCRIPTION
Jira Ticket: [VADC-652](https://ctds-planx.atlassian.net/browse/VADC-652)


Adds ```npm run params``` to npm run storybook and execute before command to start storybook. Tested by git cloning and npm installing a new instance of the application, this prevents the errors: ```ERR_INVALID_ARG_TYPE```, ```Field 'browser' doesn't contain a valid alias configuration``` and others. 

As a result, developers can now git clone the repo for data portal, and run storybook and have it work without needing to run the hostname command


### New Features
* Updates the storybook npm command so that it works without needing to run additional commands first


[VADC-652]: https://ctds-planx.atlassian.net/browse/VADC-652?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ