### PR TITLE
HP-1177 fix disco deatils page logic and styling

### DIFF
--- a/src/Discovery/Discovery.css
+++ b/src/Discovery/Discovery.css
@@ -574,8 +574,11 @@
 .discovery-modal__field {
   display: flex;
   white-space: pre-wrap;
-  justify-content: space-between;
   padding: 2px 0;
+}
+
+.discovery-modal__field--with_label {
+  justify-content: space-between;
 }
 
 .discovery-modal__fieldlabel {

--- a/src/Discovery/Discovery.css
+++ b/src/Discovery/Discovery.css
@@ -581,9 +581,17 @@
   justify-content: space-between;
 }
 
+.discovery-modal__field--block {
+  text-align: justify;
+}
+
 .discovery-modal__fieldlabel {
   padding-right: 10px;
   flex-basis: 40%;
+}
+
+.discovery-modal__fieldtext {
+  text-align: end;
 }
 
 .discovery-modal__subheading {

--- a/src/Discovery/Discovery.css
+++ b/src/Discovery/Discovery.css
@@ -580,6 +580,7 @@
 
 .discovery-modal__fieldlabel {
   padding-right: 10px;
+  flex-basis: 40%;
 }
 
 .discovery-modal__subheading {

--- a/src/Discovery/DiscoveryDetails.tsx
+++ b/src/Discovery/DiscoveryDetails.tsx
@@ -94,39 +94,40 @@ const labeledSingleLinkField = (labelText: string, linkObject: LinkItem|string) 
   }
   return (<div {...getFieldCls(labelText)}>{label(labelText)} {linkField(linkObject.link, linkObject.title)}</div>);
 };
-const labeledMultipleLinkField = (labelText: string, linkObjects: LinkItem[]|string[]) => {
-  if (!linkObjects.length) {
+const labeledMultipleLinkField = (labelText: string, links: LinkItem[]|string[]) => {
+  if (!links.length) {
     return <React.Fragment />;
   }
-  if (typeof linkObjects === 'string') {
+  if (typeof links === 'string') {
     return (
-      <div {...getFieldCls(labelText)}>{label(labelText)} {linkField(linkObjects, linkObjects)}</div>
+      <div {...getFieldCls(labelText)}>{label(labelText)} {linkField(links, links)}</div>
     );
   }
-  if (typeof linkObjects[0] === 'string') {
+  if (typeof links[0] === 'string') {
     return (
       <div>
         {
           [
             // labeled first field
-            <div {...getFieldCls(labelText)} key='root'>{label(labelText)} {linkField(linkObjects[0], linkObjects[0])}</div>,
+            <div {...getFieldCls(labelText)} key='root'>{label(labelText)} {linkField(links[0], links[0])}</div>,
             // unlabeled subsequent fields
-            ...linkObjects.slice(1).map(
-              (linkObject, i) => <div {...getFieldCls(labelText)} key={i}><div /> {linkField(linkObject)}</div>,
+            ...links.slice(1).map(
+              (linkText, i) => <div {...getFieldCls(labelText)} key={i}><div /> {linkField(linkText)}</div>,
             ),
           ]
         }
       </div>
     );
   }
+  // if links is an array of objects in the format of { link: aaa, title: bbb }
   return (
     <div>
       {
         [
           // labeled first field
-          <div {...getFieldCls(labelText)} key='root'>{label(labelText)} {linkField(linkObjects[0].link, linkObjects[0].title)}</div>,
+          <div {...getFieldCls(labelText)} key='root'>{label(labelText)} {linkField(links[0].link, links[0].title)}</div>,
           // unlabeled subsequent fields
-          ...linkObjects.slice(1)?.map(
+          ...links.slice(1)?.map(
             (linkObject, i) => <div {...getFieldCls(labelText)} key={i}><div /> {linkField(linkObject.link, linkObject.title)}</div>,
           ),
         ]
@@ -221,7 +222,7 @@ const fieldGrouping = (group: TabFieldGroup, discoveryConfig: DiscoveryConfig, r
   // at least one field from this group is either populated in the resource, or isn't configured to pull from a field (e.g. tags)
   const groupHasContent = group.fields.some(
     (field) => {
-      // Foe special fields (tags, access descriptors, etc...)
+      // For special fields (tags, access descriptors, etc...)
       if (!field.sourceField) {
         return true;
       }

--- a/src/Discovery/DiscoveryDetails.tsx
+++ b/src/Discovery/DiscoveryDetails.tsx
@@ -51,17 +51,19 @@ interface User {
 
 const fieldCls = { className: 'discovery-modal__field' };
 const withLabelFieldCls = { className: 'discovery-modal__field discovery-modal__field--with_label' };
+const blockFieldCls = { className: 'discovery-modal__field discovery-modal__field--block' };
 const subHeadingCls = { className: 'discovery-modal__subheading' };
 const fieldGroupingClass = { className: 'discovery-modal__fieldgroup' };
 const labelCls = { className: 'discovery-modal__fieldlabel' };
+const textCls = { className: 'discovery-modal__fieldtext' };
 const tagsCls = { className: 'discovery-modal__tagsfield' };
 const tabLabelCls = { className: 'discovery-modal__tablabel' };
 
 const getFieldCls = (label?: string) => ((label) ? withLabelFieldCls : fieldCls);
 
-const blockTextField = (text: string) => <div {...getFieldCls()}>{text}</div>;
+const blockTextField = (text: string) => <div {...blockFieldCls}>{text}</div>;
 const label = (text: string) => ((text) ? (<b {...labelCls}>{text}</b>) : (<div />));
-const textField = (text: string) => <span>{text}</span>;
+const textField = (text: string) => <span {...textCls}>{text}</span>;
 const linkField = (text: string, title?: string) => <a href={text} target='_blank' rel='noreferrer'>{title || text}</a>;
 
 const subHeading = (text: string) => <h3 {...subHeadingCls}>{text}</h3>;

--- a/src/Discovery/DiscoveryDetails.tsx
+++ b/src/Discovery/DiscoveryDetails.tsx
@@ -86,7 +86,7 @@ const labeledMultipleTextField = (labelText: string, fieldsText: string[]) => (
         }
       </div>
     )
-    : <React.Fragment />
+    : null
 );
 const labeledSingleLinkField = (labelText: string, linkObject: LinkItem|string) => {
   if (typeof linkObject === 'string') {
@@ -96,7 +96,7 @@ const labeledSingleLinkField = (labelText: string, linkObject: LinkItem|string) 
 };
 const labeledMultipleLinkField = (labelText: string, links: LinkItem[]|string[]) => {
   if (!links.length) {
-    return <React.Fragment />;
+    return null;
   }
   if (typeof links === 'string') {
     return (
@@ -109,10 +109,16 @@ const labeledMultipleLinkField = (labelText: string, links: LinkItem[]|string[])
         {
           [
             // labeled first field
-            <div {...getFieldCls(labelText)} key='root'>{label(labelText)} {linkField(links[0], links[0])}</div>,
+            <div {...getFieldCls(labelText)} key='root'>
+              {label(labelText)} {linkField(links[0], links[0])}
+            </div>,
             // unlabeled subsequent fields
             ...links.slice(1).map(
-              (linkText, i) => <div {...getFieldCls(labelText)} key={i}><div /> {linkField(linkText)}</div>,
+              (linkText, i) => (
+                <div {...getFieldCls(labelText)} key={i}>
+                  <div /> {linkField(linkText)}
+                </div>
+              ),
             ),
           ]
         }
@@ -125,10 +131,16 @@ const labeledMultipleLinkField = (labelText: string, links: LinkItem[]|string[])
       {
         [
           // labeled first field
-          <div {...getFieldCls(labelText)} key='root'>{label(labelText)} {linkField(links[0].link, links[0].title)}</div>,
+          <div {...getFieldCls(labelText)} key='root'>
+            {label(labelText)} {linkField(links[0].link, links[0].title)}
+          </div>,
           // unlabeled subsequent fields
           ...links.slice(1)?.map(
-            (linkObject, i) => <div {...getFieldCls(labelText)} key={i}><div /> {linkField(linkObject.link, linkObject.title)}</div>,
+            (linkObject, i) => (
+              <div {...getFieldCls(labelText)} key={i}>
+                <div /> {linkField(linkObject.link, linkObject.title)}
+              </div>
+            ),
           ),
         ]
       }
@@ -167,7 +179,7 @@ const accessDescriptor = (resource: DiscoveryResource) => {
 type TabFieldConfig = TabFieldGroup['fields'][0]
 type TabFieldGroup = DiscoveryConfig['detailView']['tabs'][0]['groups'][0];
 
-const formatResourceValuesWhenNestedArray = (resourceFieldValue) => {
+const formatResourceValuesWhenNestedArray = (resourceFieldValue: string|any[]) => {
   if (
     Array.isArray(resourceFieldValue)
   ) {
@@ -179,7 +191,7 @@ const formatResourceValuesWhenNestedArray = (resourceFieldValue) => {
   return resourceFieldValue;
 };
 
-const tabField = (fieldConfig: TabFieldConfig, discoveryConfig: DiscoveryConfig, resource: DiscoveryResource): JSX.Element => {
+const tabField = (fieldConfig: TabFieldConfig, discoveryConfig: DiscoveryConfig, resource: DiscoveryResource): JSX.Element|null => {
   // Setup special fields first
   if (fieldConfig.type === 'accessDescriptor') {
     return accessDescriptor(resource);
@@ -215,7 +227,7 @@ const tabField = (fieldConfig: TabFieldConfig, discoveryConfig: DiscoveryConfig,
       return blockTextField(resourceFieldValue);
     }
   }
-  return <React.Fragment />;
+  return null;
 };
 
 const fieldGrouping = (group: TabFieldGroup, discoveryConfig: DiscoveryConfig, resource: DiscoveryResource) => {

--- a/src/Discovery/DiscoveryDetails.tsx
+++ b/src/Discovery/DiscoveryDetails.tsx
@@ -50,19 +50,24 @@ interface User {
 }
 
 const fieldCls = { className: 'discovery-modal__field' };
+const withLabelFieldCls = { className: 'discovery-modal__field discovery-modal__field--with_label' };
 const subHeadingCls = { className: 'discovery-modal__subheading' };
 const fieldGroupingClass = { className: 'discovery-modal__fieldgroup' };
 const labelCls = { className: 'discovery-modal__fieldlabel' };
 const tagsCls = { className: 'discovery-modal__tagsfield' };
 const tabLabelCls = { className: 'discovery-modal__tablabel' };
 
-const blockTextField = (text: string) => <div {...fieldCls}>{text}</div>;
+const getFieldCls = (label?: string) => ((label) ? withLabelFieldCls : fieldCls);
+
+const blockTextField = (text: string) => <div {...getFieldCls()}>{text}</div>;
 const label = (text: string) => ((text) ? (<b {...labelCls}>{text}</b>) : (<div />));
 const textField = (text: string) => <span>{text}</span>;
 const linkField = (text: string, title?: string) => <a href={text} target='_blank' rel='noreferrer'>{title || text}</a>;
 
 const subHeading = (text: string) => <h3 {...subHeadingCls}>{text}</h3>;
-const labeledSingleTextField = (labelText: string, fieldText: string) => <div {...fieldCls}>{label(labelText)} {textField(fieldText)}</div>;
+const labeledSingleTextField = (labelText: string, fieldText: string) => (
+  <div {...getFieldCls(labelText)}>{label(labelText)} {textField(fieldText)}</div>
+);
 const labeledMultipleTextField = (labelText: string, fieldsText: string[]) => (
   fieldsText.length
     ? (
@@ -70,10 +75,10 @@ const labeledMultipleTextField = (labelText: string, fieldsText: string[]) => (
         {
           [
             // labeled first field
-            <div {...fieldCls} key='root'>{label(labelText)} {textField(fieldsText[0])}</div>,
+            <div {...getFieldCls(labelText)} key='root'>{label(labelText)} {textField(fieldsText[0])}</div>,
             // unlabeled subsequent fields
             ...fieldsText.slice(1).map(
-              (text, i) => <div {...fieldCls} key={i}><div /> {textField(text)}</div>,
+              (text, i) => <div {...getFieldCls(labelText)} key={i}><div /> {textField(text)}</div>,
             ),
           ]
         }
@@ -83,9 +88,9 @@ const labeledMultipleTextField = (labelText: string, fieldsText: string[]) => (
 );
 const labeledSingleLinkField = (labelText: string, linkObject: LinkItem|string) => {
   if (typeof linkObject === 'string') {
-    return (<div {...fieldCls}>{label(labelText)} {linkField(linkObject, linkObject)}</div>);
+    return (<div {...getFieldCls(labelText)}>{label(labelText)} {linkField(linkObject, linkObject)}</div>);
   }
-  return (<div {...fieldCls}>{label(labelText)} {linkField(linkObject.link, linkObject.title)}</div>);
+  return (<div {...getFieldCls(labelText)}>{label(labelText)} {linkField(linkObject.link, linkObject.title)}</div>);
 };
 const labeledMultipleLinkField = (labelText: string, linkObjects: LinkItem[]|string[]) => {
   if (!linkObjects.length) {
@@ -93,7 +98,7 @@ const labeledMultipleLinkField = (labelText: string, linkObjects: LinkItem[]|str
   }
   if (typeof linkObjects === 'string') {
     return (
-      <div {...fieldCls}>{label(labelText)} {linkField(linkObjects, linkObjects)}</div>
+      <div {...getFieldCls(labelText)}>{label(labelText)} {linkField(linkObjects, linkObjects)}</div>
     );
   }
   if (typeof linkObjects[0] === 'string') {
@@ -102,10 +107,10 @@ const labeledMultipleLinkField = (labelText: string, linkObjects: LinkItem[]|str
         {
           [
             // labeled first field
-            <div {...fieldCls} key='root'>{label(labelText)} {linkField(linkObjects[0], linkObjects[0])}</div>,
+            <div {...getFieldCls(labelText)} key='root'>{label(labelText)} {linkField(linkObjects[0], linkObjects[0])}</div>,
             // unlabeled subsequent fields
             ...linkObjects.slice(1).map(
-              (linkObject, i) => <div {...fieldCls} key={i}><div /> {linkField(linkObject)}</div>,
+              (linkObject, i) => <div {...getFieldCls(labelText)} key={i}><div /> {linkField(linkObject)}</div>,
             ),
           ]
         }
@@ -117,10 +122,10 @@ const labeledMultipleLinkField = (labelText: string, linkObjects: LinkItem[]|str
       {
         [
           // labeled first field
-          <div {...fieldCls} key='root'>{label(labelText)} {linkField(linkObjects[0].link, linkObjects[0].title)}</div>,
+          <div {...getFieldCls(labelText)} key='root'>{label(labelText)} {linkField(linkObjects[0].link, linkObjects[0].title)}</div>,
           // unlabeled subsequent fields
           ...linkObjects.slice(1)?.map(
-            (linkObject, i) => <div {...fieldCls} key={i}><div /> {linkField(linkObject.link, linkObject.title)}</div>,
+            (linkObject, i) => <div {...getFieldCls(labelText)} key={i}><div /> {linkField(linkObject.link, linkObject.title)}</div>,
           ),
         ]
       }


### PR DESCRIPTION
Jira Ticket: [HP-1177](https://ctds-planx.atlassian.net/browse/HP-1177)

Deployed in https://qa-heal.planx-pla.net/portal/discovery

### New Features
- Discovery: `link` and `linkList` typed field now support customize titles for hyperlinks (Note: to have customized titles, each link has to be an object in the format of `{ "link": "http://i.am.a.link.example", "title": "I am a Link Title" }`)

### Bug Fixes
- Discovery: tags and access descriptors can be rendered correctly in tabbed view details page

### Improvements
- Discovery: better styling for fields with no label from config



[HP-1177]: https://ctds-planx.atlassian.net/browse/HP-1177?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ