### PR TITLE
Feat/results button disable

### DIFF
--- a/src/Analysis/GWASResults/TestData/TableData.js
+++ b/src/Analysis/GWASResults/TestData/TableData.js
@@ -17,6 +17,15 @@ const TableData = [
     phase: 'Running',
     submittedAt: '2022-02-16T10:30:00Z',
   },
+  {
+    uid: '789',
+    wf_name: 'User Added WF Name 3',
+    name: 'Workflow 3',
+    startedAt: '2023-02-16T10:00:00Z',
+    finishedAt: '2023-02-16T10:00:00Z',
+    phase: 'Succeeded',
+    submittedAt: '2023-02-16T10:30:00Z',
+  },
 ];
 
 export default TableData;

--- a/src/Analysis/GWASResults/Views/Home/HomeTable/ActionsDropdown/ActionsDropdown.jsx
+++ b/src/Analysis/GWASResults/Views/Home/HomeTable/ActionsDropdown/ActionsDropdown.jsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Space, Dropdown, Button, notification } from 'antd';
+import {
+  Space, Dropdown, Button, notification,
+} from 'antd';
 import { EllipsisOutlined } from '@ant-design/icons';
 import {
   fetchPresignedUrlForWorkflowArtifact,
@@ -28,7 +30,7 @@ const ActionsDropdown = ({ record }) => {
             fetchPresignedUrlForWorkflowArtifact(
               record.name,
               record.uid,
-              'gwas_archive_index'
+              'gwas_archive_index',
             )
               .then((res) => {
                 window.open(res, '_blank');

--- a/src/Analysis/GWASResults/Views/Home/HomeTable/ActionsDropdown/ActionsDropdown.jsx
+++ b/src/Analysis/GWASResults/Views/Home/HomeTable/ActionsDropdown/ActionsDropdown.jsx
@@ -1,11 +1,10 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import {
-  Space, Dropdown, Button, notification,
-} from 'antd';
+import { Space, Dropdown, Button, notification } from 'antd';
 import { EllipsisOutlined } from '@ant-design/icons';
 import {
-  fetchPresignedUrlForWorkflowArtifact, retryWorkflow,
+  fetchPresignedUrlForWorkflowArtifact,
+  retryWorkflow,
 } from '../../../../Utils/gwasWorkflowApi';
 import PHASES from '../../../../Utils/PhasesEnumeration';
 
@@ -29,18 +28,20 @@ const ActionsDropdown = ({ record }) => {
             fetchPresignedUrlForWorkflowArtifact(
               record.name,
               record.uid,
-              'gwas_archive_index',
-            ).then((res) => {
-              window.open(res, '_blank');
-            }).catch((error) => {
-              openNotification(`❌ Could not download. \n\n${error}`);
-            });
+              'gwas_archive_index'
+            )
+              .then((res) => {
+                window.open(res, '_blank');
+              })
+              .catch((error) => {
+                openNotification(`❌ Could not download. \n\n${error}`);
+              });
           }}
         >
           Download
         </a>
       ),
-      disabled: false,
+      disabled: record.phase !== PHASES.Succeeded,
     },
     {
       key: '2',
@@ -49,14 +50,13 @@ const ActionsDropdown = ({ record }) => {
           href=''
           onClick={(e) => {
             e.preventDefault();
-            retryWorkflow(
-              record.name,
-              record.uid,
-            ).then(() => {
-              openNotification('Workflow successfully restarted.');
-            }).catch(() => {
-              openNotification('❌ Retry request failed.');
-            });
+            retryWorkflow(record.name, record.uid)
+              .then(() => {
+                openNotification('Workflow successfully restarted.');
+              })
+              .catch(() => {
+                openNotification('❌ Retry request failed.');
+              });
           }}
         >
           Retry

--- a/src/Analysis/GWASResults/Views/Home/HomeTable/ActionsDropdown/ActionsDropdown.test.jsx
+++ b/src/Analysis/GWASResults/Views/Home/HomeTable/ActionsDropdown/ActionsDropdown.test.jsx
@@ -8,7 +8,7 @@ describe('ActionsDropdown', () => {
   it('should open the dropdown menu when the button is clicked and Retry option should be disabled for the Phase "running"', () => {
     const record = { phase: PHASES.Running };
     const { getByRole, getByText } = render(
-      <ActionsDropdown record={record} />
+      <ActionsDropdown record={record} />,
     );
     const dropdownButton = getByRole('button');
     waitFor(() => {
@@ -17,13 +17,13 @@ describe('ActionsDropdown', () => {
     expect(getByText('Download')).toBeInTheDocument();
     expect(getByText('Retry')).toBeInTheDocument();
     expect(getByText('Retry').parentElement.parentElement).toHaveClass(
-      'ant-dropdown-menu-item-disabled'
+      'ant-dropdown-menu-item-disabled',
     );
   });
   it('should open the dropdown menu when the button is clicked and Retry option should be enabled for the Phase "failed"', () => {
     const record = { phase: PHASES.Failed };
     const { getByRole, getByText } = render(
-      <ActionsDropdown record={record} />
+      <ActionsDropdown record={record} />,
     );
     const dropdownButton = getByRole('button');
     waitFor(() => {
@@ -32,14 +32,14 @@ describe('ActionsDropdown', () => {
     expect(getByText('Download')).toBeInTheDocument();
     expect(getByText('Retry')).toBeInTheDocument();
     expect(getByText('Retry').parentElement.parentElement).not.toHaveClass(
-      'ant-dropdown-menu-item-disabled'
+      'ant-dropdown-menu-item-disabled',
     );
   });
 
   it('should disabled Download option for the Phase "failed"', () => {
     const record = { phase: PHASES.Failed };
     const { getByRole, getByText } = render(
-      <ActionsDropdown record={record} />
+      <ActionsDropdown record={record} />,
     );
     const dropdownButton = getByRole('button');
     waitFor(() => {
@@ -48,13 +48,13 @@ describe('ActionsDropdown', () => {
     expect(getByText('Download')).toBeInTheDocument();
     expect(getByText('Retry')).toBeInTheDocument();
     expect(getByText('Download').parentElement.parentElement).toHaveClass(
-      'ant-dropdown-menu-item-disabled'
+      'ant-dropdown-menu-item-disabled',
     );
   });
   it('should enabled Download option for the Phase "Succeeded"', () => {
     const record = { phase: PHASES.Succeeded };
     const { getByRole, getByText } = render(
-      <ActionsDropdown record={record} />
+      <ActionsDropdown record={record} />,
     );
     const dropdownButton = getByRole('button');
     waitFor(() => {
@@ -63,7 +63,7 @@ describe('ActionsDropdown', () => {
     expect(getByText('Download')).toBeInTheDocument();
     expect(getByText('Retry')).toBeInTheDocument();
     expect(getByText('Download').parentElement.parentElement).not.toHaveClass(
-      'ant-dropdown-menu-item-disabled'
+      'ant-dropdown-menu-item-disabled',
     );
   });
 });

--- a/src/Analysis/GWASResults/Views/Home/HomeTable/ActionsDropdown/ActionsDropdown.test.jsx
+++ b/src/Analysis/GWASResults/Views/Home/HomeTable/ActionsDropdown/ActionsDropdown.test.jsx
@@ -7,24 +7,63 @@ import PHASES from '../../../../Utils/PhasesEnumeration';
 describe('ActionsDropdown', () => {
   it('should open the dropdown menu when the button is clicked and Retry option should be disabled for the Phase "running"', () => {
     const record = { phase: PHASES.Running };
-    const { getByRole, getByText } = render(<ActionsDropdown record={record} />);
+    const { getByRole, getByText } = render(
+      <ActionsDropdown record={record} />
+    );
     const dropdownButton = getByRole('button');
     waitFor(() => {
       fireEvent.click(dropdownButton);
     });
     expect(getByText('Download')).toBeInTheDocument();
     expect(getByText('Retry')).toBeInTheDocument();
-    expect(getByText('Retry').parentElement.parentElement).toHaveClass('ant-dropdown-menu-item-disabled');
+    expect(getByText('Retry').parentElement.parentElement).toHaveClass(
+      'ant-dropdown-menu-item-disabled'
+    );
   });
   it('should open the dropdown menu when the button is clicked and Retry option should be enabled for the Phase "failed"', () => {
     const record = { phase: PHASES.Failed };
-    const { getByRole, getByText } = render(<ActionsDropdown record={record} />);
+    const { getByRole, getByText } = render(
+      <ActionsDropdown record={record} />
+    );
     const dropdownButton = getByRole('button');
     waitFor(() => {
       fireEvent.click(dropdownButton);
     });
     expect(getByText('Download')).toBeInTheDocument();
     expect(getByText('Retry')).toBeInTheDocument();
-    expect(getByText('Retry').parentElement.parentElement).not.toHaveClass('ant-dropdown-menu-item-disabled');
+    expect(getByText('Retry').parentElement.parentElement).not.toHaveClass(
+      'ant-dropdown-menu-item-disabled'
+    );
+  });
+
+  it('should disabled Download option for the Phase "failed"', () => {
+    const record = { phase: PHASES.Failed };
+    const { getByRole, getByText } = render(
+      <ActionsDropdown record={record} />
+    );
+    const dropdownButton = getByRole('button');
+    waitFor(() => {
+      fireEvent.click(dropdownButton);
+    });
+    expect(getByText('Download')).toBeInTheDocument();
+    expect(getByText('Retry')).toBeInTheDocument();
+    expect(getByText('Download').parentElement.parentElement).toHaveClass(
+      'ant-dropdown-menu-item-disabled'
+    );
+  });
+  it('should enabled Download option for the Phase "Succeeded"', () => {
+    const record = { phase: PHASES.Succeeded };
+    const { getByRole, getByText } = render(
+      <ActionsDropdown record={record} />
+    );
+    const dropdownButton = getByRole('button');
+    waitFor(() => {
+      fireEvent.click(dropdownButton);
+    });
+    expect(getByText('Download')).toBeInTheDocument();
+    expect(getByText('Retry')).toBeInTheDocument();
+    expect(getByText('Download').parentElement.parentElement).not.toHaveClass(
+      'ant-dropdown-menu-item-disabled'
+    );
   });
 });

--- a/src/Analysis/GWASResults/Views/Home/HomeTable/HomeTable.jsx
+++ b/src/Analysis/GWASResults/Views/Home/HomeTable/HomeTable.jsx
@@ -1,7 +1,5 @@
 import React, { useContext, useEffect, useState } from 'react';
-import {
-  Button, Table, Space, Input, DatePicker, Select,
-} from 'antd';
+import { Button, Table, Space, Input, DatePicker, Select } from 'antd';
 import { SearchOutlined } from '@ant-design/icons';
 import PropTypes from 'prop-types';
 import moment from 'moment';
@@ -109,7 +107,8 @@ const HomeTable = ({ data }) => {
   };
 
   const jobStatusDropdownOptions = [];
-  Object.values(PHASES).forEach((phase) => jobStatusDropdownOptions.push({ value: phase, label: phase }),
+  Object.values(PHASES).forEach((phase) =>
+    jobStatusDropdownOptions.push({ value: phase, label: phase })
   );
 
   const columns = [
@@ -120,8 +119,8 @@ const HomeTable = ({ data }) => {
       show: homeTableState.columnManagement.showRunId,
       sorter: (a, b) => a.name.localeCompare(b.name),
       sortOrder:
-        homeTableState.sortInfo?.columnKey === 'name'
-        && homeTableState.sortInfo.order,
+        homeTableState.sortInfo?.columnKey === 'name' &&
+        homeTableState.sortInfo.order,
       children: [
         {
           title: (
@@ -143,8 +142,8 @@ const HomeTable = ({ data }) => {
       show: homeTableState.columnManagement.showWorkflowName,
       sorter: (a, b) => a.wf_name.localeCompare(b.wf_name),
       sortOrder:
-        homeTableState.sortInfo?.columnKey === 'wf_name'
-        && homeTableState.sortInfo.order,
+        homeTableState.sortInfo?.columnKey === 'wf_name' &&
+        homeTableState.sortInfo.order,
       children: [
         {
           title: (
@@ -166,8 +165,8 @@ const HomeTable = ({ data }) => {
       show: homeTableState.columnManagement.showDateSubmitted,
       sorter: (a, b) => a.submittedAt.localeCompare(b.submittedAt),
       sortOrder:
-        homeTableState.sortInfo?.columnKey === 'submittedAt'
-        && homeTableState.sortInfo.order,
+        homeTableState.sortInfo?.columnKey === 'submittedAt' &&
+        homeTableState.sortInfo.order,
       children: [
         {
           title: (
@@ -191,8 +190,8 @@ const HomeTable = ({ data }) => {
       key: 'phase',
       show: homeTableState.columnManagement.showJobStatus,
       sortOrder:
-        homeTableState.sortInfo?.columnKey === 'phase'
-        && homeTableState.sortInfo.order,
+        homeTableState.sortInfo?.columnKey === 'phase' &&
+        homeTableState.sortInfo.order,
       children: [
         {
           title: (
@@ -231,8 +230,8 @@ const HomeTable = ({ data }) => {
         return a?.finishedAt.localeCompare(b?.finishedAt);
       },
       sortOrder:
-        homeTableState.sortInfo?.columnKey === 'finishedAt'
-        && homeTableState.sortInfo.order,
+        homeTableState.sortInfo?.columnKey === 'finishedAt' &&
+        homeTableState.sortInfo.order,
       dataIndex: 'finishedAt',
       children: [
         {
@@ -247,7 +246,8 @@ const HomeTable = ({ data }) => {
             />
           ),
           dataIndex: 'finishedAt',
-          render: (value) => (value ? <DateForTable utcFormattedDate={value} /> : '—/—/----'),
+          render: (value) =>
+            value ? <DateForTable utcFormattedDate={value} /> : '—/—/----',
         },
       ],
     },
@@ -278,7 +278,6 @@ const HomeTable = ({ data }) => {
               </Button>
               <Button
                 onClick={() => {
-                  console.log('RECORD:', record);
                   setSelectedRowData(record);
                   setCurrentView(VIEWS.results);
                 }}
@@ -310,7 +309,8 @@ const HomeTable = ({ data }) => {
     setFilteredData(filterTableData(initiallySortedData, homeTableState));
   }, [homeTableState, data]);
 
-  const checkForShownColumn = () => Object.values(homeTableState.columnManagement).includes(true);
+  const checkForShownColumn = () =>
+    Object.values(homeTableState.columnManagement).includes(true);
 
   return (
     <div className='home-table'>
@@ -319,7 +319,9 @@ const HomeTable = ({ data }) => {
           dataSource={isIterable(filteredData) && [...filteredData]}
           columns={columns}
           rowKey={(record) => record.uid}
-          rowClassName={(record) => record.uid === selectedRowData?.uid && 'selected-row'}
+          rowClassName={(record) =>
+            record.uid === selectedRowData?.uid && 'selected-row'
+          }
           onRow={(record) => ({
             onClick: () => {
               setSelectedRowData(record);

--- a/src/Analysis/GWASResults/Views/Home/HomeTable/HomeTable.jsx
+++ b/src/Analysis/GWASResults/Views/Home/HomeTable/HomeTable.jsx
@@ -278,9 +278,11 @@ const HomeTable = ({ data }) => {
               </Button>
               <Button
                 onClick={() => {
+                  console.log('RECORD:', record);
                   setSelectedRowData(record);
                   setCurrentView(VIEWS.results);
                 }}
+                disabled={record.phase !== PHASES.Succeeded}
               >
                 Results
               </Button>

--- a/src/Analysis/GWASResults/Views/Home/HomeTable/HomeTable.jsx
+++ b/src/Analysis/GWASResults/Views/Home/HomeTable/HomeTable.jsx
@@ -1,5 +1,7 @@
 import React, { useContext, useEffect, useState } from 'react';
-import { Button, Table, Space, Input, DatePicker, Select } from 'antd';
+import {
+  Button, Table, Space, Input, DatePicker, Select,
+} from 'antd';
 import { SearchOutlined } from '@ant-design/icons';
 import PropTypes from 'prop-types';
 import moment from 'moment';
@@ -107,8 +109,7 @@ const HomeTable = ({ data }) => {
   };
 
   const jobStatusDropdownOptions = [];
-  Object.values(PHASES).forEach((phase) =>
-    jobStatusDropdownOptions.push({ value: phase, label: phase })
+  Object.values(PHASES).forEach((phase) => jobStatusDropdownOptions.push({ value: phase, label: phase }),
   );
 
   const columns = [
@@ -119,8 +120,8 @@ const HomeTable = ({ data }) => {
       show: homeTableState.columnManagement.showRunId,
       sorter: (a, b) => a.name.localeCompare(b.name),
       sortOrder:
-        homeTableState.sortInfo?.columnKey === 'name' &&
-        homeTableState.sortInfo.order,
+        homeTableState.sortInfo?.columnKey === 'name'
+        && homeTableState.sortInfo.order,
       children: [
         {
           title: (
@@ -142,8 +143,8 @@ const HomeTable = ({ data }) => {
       show: homeTableState.columnManagement.showWorkflowName,
       sorter: (a, b) => a.wf_name.localeCompare(b.wf_name),
       sortOrder:
-        homeTableState.sortInfo?.columnKey === 'wf_name' &&
-        homeTableState.sortInfo.order,
+        homeTableState.sortInfo?.columnKey === 'wf_name'
+        && homeTableState.sortInfo.order,
       children: [
         {
           title: (
@@ -165,8 +166,8 @@ const HomeTable = ({ data }) => {
       show: homeTableState.columnManagement.showDateSubmitted,
       sorter: (a, b) => a.submittedAt.localeCompare(b.submittedAt),
       sortOrder:
-        homeTableState.sortInfo?.columnKey === 'submittedAt' &&
-        homeTableState.sortInfo.order,
+        homeTableState.sortInfo?.columnKey === 'submittedAt'
+        && homeTableState.sortInfo.order,
       children: [
         {
           title: (
@@ -190,8 +191,8 @@ const HomeTable = ({ data }) => {
       key: 'phase',
       show: homeTableState.columnManagement.showJobStatus,
       sortOrder:
-        homeTableState.sortInfo?.columnKey === 'phase' &&
-        homeTableState.sortInfo.order,
+        homeTableState.sortInfo?.columnKey === 'phase'
+        && homeTableState.sortInfo.order,
       children: [
         {
           title: (
@@ -230,8 +231,8 @@ const HomeTable = ({ data }) => {
         return a?.finishedAt.localeCompare(b?.finishedAt);
       },
       sortOrder:
-        homeTableState.sortInfo?.columnKey === 'finishedAt' &&
-        homeTableState.sortInfo.order,
+        homeTableState.sortInfo?.columnKey === 'finishedAt'
+        && homeTableState.sortInfo.order,
       dataIndex: 'finishedAt',
       children: [
         {
@@ -246,8 +247,7 @@ const HomeTable = ({ data }) => {
             />
           ),
           dataIndex: 'finishedAt',
-          render: (value) =>
-            value ? <DateForTable utcFormattedDate={value} /> : '—/—/----',
+          render: (value) => (value ? <DateForTable utcFormattedDate={value} /> : '—/—/----'),
         },
       ],
     },
@@ -309,8 +309,7 @@ const HomeTable = ({ data }) => {
     setFilteredData(filterTableData(initiallySortedData, homeTableState));
   }, [homeTableState, data]);
 
-  const checkForShownColumn = () =>
-    Object.values(homeTableState.columnManagement).includes(true);
+  const checkForShownColumn = () => Object.values(homeTableState.columnManagement).includes(true);
 
   return (
     <div className='home-table'>
@@ -319,9 +318,7 @@ const HomeTable = ({ data }) => {
           dataSource={isIterable(filteredData) && [...filteredData]}
           columns={columns}
           rowKey={(record) => record.uid}
-          rowClassName={(record) =>
-            record.uid === selectedRowData?.uid && 'selected-row'
-          }
+          rowClassName={(record) => record.uid === selectedRowData?.uid && 'selected-row'}
           onRow={(record) => ({
             onClick: () => {
               setSelectedRowData(record);

--- a/src/Analysis/GWASResults/Views/Home/HomeTable/HomeTable.test.jsx
+++ b/src/Analysis/GWASResults/Views/Home/HomeTable/HomeTable.test.jsx
@@ -41,6 +41,9 @@ describe('HomeTable component', () => {
       ).toBeInTheDocument();
 
       // Check that the execution and results buttons render for each row
+      const inputButton = screen.getAllByText('Input');
+      expect(inputButton[iterator]).toBeInTheDocument();
+
       const executionButton = screen.getAllByText('Execution');
       expect(executionButton[iterator]).toBeInTheDocument();
 

--- a/src/Analysis/GWASResults/Views/Home/HomeTable/HomeTable.test.jsx
+++ b/src/Analysis/GWASResults/Views/Home/HomeTable/HomeTable.test.jsx
@@ -5,6 +5,7 @@ import HomeTable from './HomeTable';
 import SharedContext from '../../../Utils/SharedContext';
 import TableData from '../../../TestData/TableData';
 import InitialHomeTableState from '../HomeTableState/InitialHomeTableState';
+import PHASES from '../../../Utils/PhasesEnumeration';
 
 describe('HomeTable component', () => {
   const data = TableData;
@@ -23,7 +24,7 @@ describe('HomeTable component', () => {
     );
 
     // Check that each of the values from data that needed to be shown appear in the dom
-    data.forEach((item) => {
+    data.forEach((item, iterator) => {
       const finishedTestDate = new Date(item.finishedAt);
       const formattedFinishedTestDate = finishedTestDate.toLocaleDateString();
       const submittedTestDate = new Date(item.submittedAt);
@@ -38,15 +39,31 @@ describe('HomeTable component', () => {
       expect(
         screen.getAllByText(formattedSubmittedTestDate)[0],
       ).toBeInTheDocument();
+
+      // Check that the execution and results buttons render for each row
+      const executionButton = screen.getAllByText('Execution');
+      expect(executionButton[iterator]).toBeInTheDocument();
+
+      const resultsButton = screen.getAllByText('Results');
+      expect(resultsButton[iterator]).toBeInTheDocument();
     });
+  });
 
-    // Check that the execution and results buttons render for each row
-    const executionButton = screen.getAllByText('Execution');
-    expect(executionButton[0]).toBeInTheDocument();
-    expect(executionButton[1]).toBeInTheDocument();
+  it('should render disable results button only if not Succeeded', () => {
+    render(
+      <SharedContext.Provider value={mockContext}>
+        <HomeTable data={data} />
+      </SharedContext.Provider>,
+    );
 
-    const resultsButton = screen.getAllByText('Results');
-    expect(resultsButton[0]).toBeInTheDocument();
-    expect(resultsButton[1]).toBeInTheDocument();
+    data.forEach((item, iterator) => {
+      const resultsButton = screen.getAllByText('Results');
+      const currentResultsButton = resultsButton[iterator].closest('button');
+      if (item.phase === PHASES.Succeeded) {
+        expect(currentResultsButton).not.toBeDisabled();
+      } else {
+        expect(currentResultsButton).toBeDisabled();
+      }
+    });
   });
 });

--- a/src/Analysis/GWASResults/Views/Home/HomeTable/HomeTable.test.jsx
+++ b/src/Analysis/GWASResults/Views/Home/HomeTable/HomeTable.test.jsx
@@ -20,7 +20,7 @@ describe('HomeTable component', () => {
     render(
       <SharedContext.Provider value={mockContext}>
         <HomeTable data={data} />
-      </SharedContext.Provider>
+      </SharedContext.Provider>,
     );
 
     // Check that each of the values from data that needed to be shown appear in the dom
@@ -33,11 +33,11 @@ describe('HomeTable component', () => {
       expect(screen.getAllByText(item.name)[0]).toBeInTheDocument();
       expect(screen.getAllByText(item.wf_name)[0]).toBeInTheDocument();
       expect(
-        screen.getAllByText(formattedFinishedTestDate)[0]
+        screen.getAllByText(formattedFinishedTestDate)[0],
       ).toBeInTheDocument();
       expect(screen.getAllByText(item.phase)[0]).toBeInTheDocument();
       expect(
-        screen.getAllByText(formattedSubmittedTestDate)[0]
+        screen.getAllByText(formattedSubmittedTestDate)[0],
       ).toBeInTheDocument();
 
       // Check that the execution and results buttons render for each row
@@ -53,7 +53,7 @@ describe('HomeTable component', () => {
     render(
       <SharedContext.Provider value={mockContext}>
         <HomeTable data={data} />
-      </SharedContext.Provider>
+      </SharedContext.Provider>,
     );
 
     data.forEach((item, iterator) => {

--- a/src/Analysis/GWASResults/Views/Home/HomeTable/HomeTable.test.jsx
+++ b/src/Analysis/GWASResults/Views/Home/HomeTable/HomeTable.test.jsx
@@ -20,7 +20,7 @@ describe('HomeTable component', () => {
     render(
       <SharedContext.Provider value={mockContext}>
         <HomeTable data={data} />
-      </SharedContext.Provider>,
+      </SharedContext.Provider>
     );
 
     // Check that each of the values from data that needed to be shown appear in the dom
@@ -33,11 +33,11 @@ describe('HomeTable component', () => {
       expect(screen.getAllByText(item.name)[0]).toBeInTheDocument();
       expect(screen.getAllByText(item.wf_name)[0]).toBeInTheDocument();
       expect(
-        screen.getAllByText(formattedFinishedTestDate)[0],
+        screen.getAllByText(formattedFinishedTestDate)[0]
       ).toBeInTheDocument();
       expect(screen.getAllByText(item.phase)[0]).toBeInTheDocument();
       expect(
-        screen.getAllByText(formattedSubmittedTestDate)[0],
+        screen.getAllByText(formattedSubmittedTestDate)[0]
       ).toBeInTheDocument();
 
       // Check that the execution and results buttons render for each row
@@ -53,7 +53,7 @@ describe('HomeTable component', () => {
     render(
       <SharedContext.Provider value={mockContext}>
         <HomeTable data={data} />
-      </SharedContext.Provider>,
+      </SharedContext.Provider>
     );
 
     data.forEach((item, iterator) => {


### PR DESCRIPTION
Jira Ticket: [VADC-739](https://ctds-planx.atlassian.net/browse/VADC-739)

Disables results button when phase associated with hometable row is not succeeded in Results App and updates test for hometable and action dropdown to test this functionality
<img width="793" alt="image" src="https://github.com/uc-cdis/data-portal/assets/113449836/6d6b7225-9ab5-40d5-9b9e-bcb3ae3fce23">
Disables download
<img width="1449" alt="image" src="https://github.com/uc-cdis/data-portal/assets/113449836/e2323e57-e331-4986-9811-5f4dabee2bbe">


### New Features

* Enable Results button and download action only for succeeded workflows

### Improvements
* Updates test for hometable in results app



[VADC-739]: https://ctds-planx.atlassian.net/browse/VADC-739?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ