### PR TITLE
HP-1266 fix: system popup take precedence over discovery popup

### DIFF
--- a/src/Discovery/DiscoveryActionBar.tsx
+++ b/src/Discovery/DiscoveryActionBar.tsx
@@ -54,6 +54,7 @@ interface Props {
     actionToResume: 'download'|'export'|'manifest';
     selectedResources: any[];
   };
+  systemPopupActivated: boolean;
   onActionResumed: () => any
 }
 
@@ -572,7 +573,7 @@ const DiscoveryActionBar = (props: Props) => {
         </Popover>
         <Modal
           closable={false}
-          open={downloadStatus.message.active}
+          open={downloadStatus.message.active && !props.systemPopupActivated}
           title={downloadStatus.message.title}
           footer={(
             <Button

--- a/src/Discovery/reduxer.js
+++ b/src/Discovery/reduxer.js
@@ -6,6 +6,7 @@ export const ReduxDiscoveryActionBar = (() => {
   const mapStateToProps = (state) => ({
     user: state.user,
     discovery: state.discovery,
+    systemPopupActivated: !!state.popups?.systemUseWarnPopup,
   });
 
   const mapDispatchToProps = (dispatch) => ({


### PR DESCRIPTION
Jira Ticket: [HP-1266](https://ctds-planx.atlassian.net/browse/HP-1266)


### Bug Fixes
- Discovery: system popups (e.g.: DUA/TOU) will now takes precendes to display over Discovery page popups (file download/export, etc.)

[HP-1266]: https://ctds-planx.atlassian.net/browse/HP-1266?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ