### PR TITLE
Feat/add team project header to analysis apps

### DIFF
--- a/src/Analysis/Analysis.jsx
+++ b/src/Analysis/Analysis.jsx
@@ -23,7 +23,7 @@ class Analysis extends React.Component {
           {CheckForTeamProjectApplication(analysisApps) && (
             <Col flex='1 0 auto'>
               <QueryClientProvider client={new QueryClient()} contextSharing>
-                <TeamProjectHeader showButton />
+                <TeamProjectHeader isEditable />
               </QueryClientProvider>
             </Col>
           )}

--- a/src/Analysis/AnalysisApp.jsx
+++ b/src/Analysis/AnalysisApp.jsx
@@ -69,8 +69,8 @@ class AnalysisApp extends React.Component {
     // ONLY process messages coming from the same domain as the app AND
     // which contain the message "refresh token!":
     if (
-      event.origin === applicationBaseUrl &&
-      event.data === 'refresh token!'
+      event.origin === applicationBaseUrl
+      && event.data === 'refresh token!'
     ) {
       // Call function to refresh session:
       sessionMonitor.updateUserActivity();
@@ -79,81 +79,81 @@ class AnalysisApp extends React.Component {
 
   getAppContent = (app) => {
     switch (app) {
-      case 'vaGWAS':
-        return (
-          <React.Fragment>
-            <Select
-              value={this.state.jobInput}
-              placeholder='Select your organ'
-              options={analysisApps[app].options}
-              onChange={this.selectChange}
-            />
-            <Button
-              label='Run Analysis'
-              buttonType='primary'
-              onClick={this.onSubmitJob}
-              isPending={this.isJobRunning()}
-            />
-          </React.Fragment>
-        );
-      case 'ndhHIV':
-        return <HIVCohortFilter />;
-      case 'ndhVirus':
-        return (
-          <React.Fragment>
-            <input
-              className='text-input'
-              type='text'
-              placeholder='input data'
-              name='input'
-            />
-            <Button
-              label='Run'
-              buttonType='primary'
-              onClick={this.onSubmitJob}
-              isPending={this.isJobRunning()}
-            />
-          </React.Fragment>
-        );
-      case 'GWASResults':
-        return (
-          <div className='analysis-app_flex_row'>
-            <GWASResultsContainer />
+    case 'vaGWAS':
+      return (
+        <React.Fragment>
+          <Select
+            value={this.state.jobInput}
+            placeholder='Select your organ'
+            options={analysisApps[app].options}
+            onChange={this.selectChange}
+          />
+          <Button
+            label='Run Analysis'
+            buttonType='primary'
+            onClick={this.onSubmitJob}
+            isPending={this.isJobRunning()}
+          />
+        </React.Fragment>
+      );
+    case 'ndhHIV':
+      return <HIVCohortFilter />;
+    case 'ndhVirus':
+      return (
+        <React.Fragment>
+          <input
+            className='text-input'
+            type='text'
+            placeholder='input data'
+            name='input'
+          />
+          <Button
+            label='Run'
+            buttonType='primary'
+            onClick={this.onSubmitJob}
+            isPending={this.isJobRunning()}
+          />
+        </React.Fragment>
+      );
+    case 'GWASResults':
+      return (
+        <div className='analysis-app_flex_row'>
+          <GWASResultsContainer />
+        </div>
+      );
+    case 'GWASUIApp': {
+      return (
+        <TourProvider
+          afterOpen={disableBody}
+          beforeClose={enableBody}
+          disableInteraction
+          onClickClose={({ setCurrentStep, setIsOpen }) => {
+            setIsOpen(false);
+            setCurrentStep(0);
+          }}
+        >
+          <div>
+            <GWASContainer refreshWorkflows={this.refreshWorkflows} />
           </div>
-        );
-      case 'GWASUIApp': {
-        return (
-          <TourProvider
-            afterOpen={disableBody}
-            beforeClose={enableBody}
-            disableInteraction
-            onClickClose={({ setCurrentStep, setIsOpen }) => {
-              setIsOpen(false);
-              setCurrentStep(0);
-            }}
-          >
-            <div>
-              <GWASContainer refreshWorkflows={this.refreshWorkflows} />
-            </div>
-          </TourProvider>
-        );
-      }
-      default:
-        // this will ensure the main window will process the app messages (if any):
-        window.addEventListener('message', this.processAppMessages);
-        return (
-          <React.Fragment>
-            <div className='analysis-app__iframe-wrapper'>
-              <iframe
-                className='analysis-app__iframe'
-                title='Analysis App'
-                frameBorder='0'
-                src={`${this.state.app.applicationUrl}`}
-                onLoad={this.handleIframeApp}
-              />
-            </div>
-          </React.Fragment>
-        );
+        </TourProvider>
+      );
+    }
+    default:
+      // this will ensure the main window will process the app messages (if any):
+      window.addEventListener('message', this.processAppMessages);
+      return (
+        <React.Fragment>
+          <div className='analysis-app__iframe-wrapper'>
+            <iframe
+              className='analysis-app__iframe'
+              title='Analysis App'
+              frameBorder='0'
+              src={`${this.state.app.applicationUrl}`}
+              onLoad={this.handleIframeApp}
+            />
+          </div>
+        </React.Fragment>
+      );
     }
   };
 
@@ -169,7 +169,7 @@ class AnalysisApp extends React.Component {
         if (option === null || this.props.job) {
           this.props.resetJobState();
         }
-      }
+      },
     );
   };
 

--- a/src/Analysis/AnalysisApp.jsx
+++ b/src/Analysis/AnalysisApp.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types'; // see https://github.com/facebook/prop-types#prop-types
 import Select from 'react-select';
-import { Spin } from 'antd';
+import { Spin, Row, Col } from 'antd';
 import Button from '@gen3/ui-component/dist/components/Button';
 import { QueryClient, QueryClientProvider } from 'react-query';
 import { TourProvider } from '@reactour/tour';
@@ -9,10 +9,12 @@ import { disableBodyScroll, enableBodyScroll } from 'body-scroll-lock';
 import BackLink from '../components/BackLink';
 import HIVCohortFilter from '../HIVCohortFilter/HIVCohortFilter';
 import { analysisApps } from '../localconf';
-import './AnalysisApp.css';
 import sessionMonitor from '../SessionMonitor';
 import GWASContainer from './GWASApp/GWASContainer';
 import GWASResultsContainer from './GWASResults/GWASResultsContainer';
+import CheckForTeamProjectApplication from './SharedUtils/TeamProject/Utils/CheckForTeamProjectApplication';
+import TeamProjectHeader from './SharedUtils/TeamProject/TeamProjectHeader/TeamProjectHeader';
+import './AnalysisApp.css';
 
 const queryClient = new QueryClient();
 
@@ -67,8 +69,8 @@ class AnalysisApp extends React.Component {
     // ONLY process messages coming from the same domain as the app AND
     // which contain the message "refresh token!":
     if (
-      event.origin === applicationBaseUrl
-      && event.data === 'refresh token!'
+      event.origin === applicationBaseUrl &&
+      event.data === 'refresh token!'
     ) {
       // Call function to refresh session:
       sessionMonitor.updateUserActivity();
@@ -77,81 +79,81 @@ class AnalysisApp extends React.Component {
 
   getAppContent = (app) => {
     switch (app) {
-    case 'vaGWAS':
-      return (
-        <React.Fragment>
-          <Select
-            value={this.state.jobInput}
-            placeholder='Select your organ'
-            options={analysisApps[app].options}
-            onChange={this.selectChange}
-          />
-          <Button
-            label='Run Analysis'
-            buttonType='primary'
-            onClick={this.onSubmitJob}
-            isPending={this.isJobRunning()}
-          />
-        </React.Fragment>
-      );
-    case 'ndhHIV':
-      return <HIVCohortFilter />;
-    case 'ndhVirus':
-      return (
-        <React.Fragment>
-          <input
-            className='text-input'
-            type='text'
-            placeholder='input data'
-            name='input'
-          />
-          <Button
-            label='Run'
-            buttonType='primary'
-            onClick={this.onSubmitJob}
-            isPending={this.isJobRunning()}
-          />
-        </React.Fragment>
-      );
-    case 'GWASResults':
-      return (
-        <div className='analysis-app_flex_row'>
-          <GWASResultsContainer />
-        </div>
-      );
-    case 'GWASUIApp': {
-      return (
-        <TourProvider
-          afterOpen={disableBody}
-          beforeClose={enableBody}
-          disableInteraction
-          onClickClose={({ setCurrentStep, setIsOpen }) => {
-            setIsOpen(false);
-            setCurrentStep(0);
-          }}
-        >
-          <div>
-            <GWASContainer refreshWorkflows={this.refreshWorkflows} />
-          </div>
-        </TourProvider>
-      );
-    }
-    default:
-      // this will ensure the main window will process the app messages (if any):
-      window.addEventListener('message', this.processAppMessages);
-      return (
-        <React.Fragment>
-          <div className='analysis-app__iframe-wrapper'>
-            <iframe
-              className='analysis-app__iframe'
-              title='Analysis App'
-              frameBorder='0'
-              src={`${this.state.app.applicationUrl}`}
-              onLoad={this.handleIframeApp}
+      case 'vaGWAS':
+        return (
+          <React.Fragment>
+            <Select
+              value={this.state.jobInput}
+              placeholder='Select your organ'
+              options={analysisApps[app].options}
+              onChange={this.selectChange}
             />
+            <Button
+              label='Run Analysis'
+              buttonType='primary'
+              onClick={this.onSubmitJob}
+              isPending={this.isJobRunning()}
+            />
+          </React.Fragment>
+        );
+      case 'ndhHIV':
+        return <HIVCohortFilter />;
+      case 'ndhVirus':
+        return (
+          <React.Fragment>
+            <input
+              className='text-input'
+              type='text'
+              placeholder='input data'
+              name='input'
+            />
+            <Button
+              label='Run'
+              buttonType='primary'
+              onClick={this.onSubmitJob}
+              isPending={this.isJobRunning()}
+            />
+          </React.Fragment>
+        );
+      case 'GWASResults':
+        return (
+          <div className='analysis-app_flex_row'>
+            <GWASResultsContainer />
           </div>
-        </React.Fragment>
-      );
+        );
+      case 'GWASUIApp': {
+        return (
+          <TourProvider
+            afterOpen={disableBody}
+            beforeClose={enableBody}
+            disableInteraction
+            onClickClose={({ setCurrentStep, setIsOpen }) => {
+              setIsOpen(false);
+              setCurrentStep(0);
+            }}
+          >
+            <div>
+              <GWASContainer refreshWorkflows={this.refreshWorkflows} />
+            </div>
+          </TourProvider>
+        );
+      }
+      default:
+        // this will ensure the main window will process the app messages (if any):
+        window.addEventListener('message', this.processAppMessages);
+        return (
+          <React.Fragment>
+            <div className='analysis-app__iframe-wrapper'>
+              <iframe
+                className='analysis-app__iframe'
+                title='Analysis App'
+                frameBorder='0'
+                src={`${this.state.app.applicationUrl}`}
+                onLoad={this.handleIframeApp}
+              />
+            </div>
+          </React.Fragment>
+        );
     }
   };
 
@@ -167,7 +169,7 @@ class AnalysisApp extends React.Component {
         if (option === null || this.props.job) {
           this.props.resetJobState();
         }
-      },
+      }
     );
   };
 
@@ -227,7 +229,22 @@ class AnalysisApp extends React.Component {
         <BackLink url='/analysis' label='Back to Apps' />
         {loaded ? (
           <div className='analysis-app'>
-            <h2 className='analysis-app__title'>{app.title}</h2>
+            <Row>
+              <Col flex='1 0 auto'>
+                <h2>{app.title}</h2>
+              </Col>
+              {CheckForTeamProjectApplication(analysisApps) && (
+                <Col flex='1 0 auto'>
+                  <QueryClientProvider
+                    client={new QueryClient()}
+                    contextSharing
+                  >
+                    <TeamProjectHeader showButton={false} />
+                  </QueryClientProvider>
+                </Col>
+              )}
+            </Row>
+
             <p className='analysis-app__description'>{app.description}</p>
             <div
               className={`${

--- a/src/Analysis/AnalysisApp.jsx
+++ b/src/Analysis/AnalysisApp.jsx
@@ -239,7 +239,7 @@ class AnalysisApp extends React.Component {
                     client={new QueryClient()}
                     contextSharing
                   >
-                    <TeamProjectHeader showButton={false} />
+                    <TeamProjectHeader isEditable={false} />
                   </QueryClientProvider>
                 </Col>
               )}

--- a/src/Analysis/SharedUtils/TeamProject/TeamProjectHeader/TeamProjectHeader.css
+++ b/src/Analysis/SharedUtils/TeamProject/TeamProjectHeader/TeamProjectHeader.css
@@ -6,6 +6,7 @@
   text-align: right;
   color: #2e77b8;
   font-size: 20px;
+  margin-top: 2px;
 }
 
 .team-project-header_modal-button {

--- a/src/Analysis/SharedUtils/TeamProject/TeamProjectHeader/TeamProjectHeader.css
+++ b/src/Analysis/SharedUtils/TeamProject/TeamProjectHeader/TeamProjectHeader.css
@@ -1,8 +1,11 @@
+.analysis .team-project-header {
+  line-height: 80px;
+}
+
 .team-project-header {
   text-align: right;
   color: #2e77b8;
   font-size: 20px;
-  line-height: 80px;
 }
 
 .team-project-header_modal-button {

--- a/src/Analysis/SharedUtils/TeamProject/TeamProjectHeader/TeamProjectHeader.jsx
+++ b/src/Analysis/SharedUtils/TeamProject/TeamProjectHeader/TeamProjectHeader.jsx
@@ -24,7 +24,7 @@ const TeamProjectHeader = ({ showButton }) => {
       // non-editable view should redirect to app selection if user doesn't have a storedTeamProject
       history.push('/analysis');
     }
-  }, []);
+  }, [history, showButton]);
 
   return (
     <React.Fragment>

--- a/src/Analysis/SharedUtils/TeamProject/TeamProjectHeader/TeamProjectHeader.jsx
+++ b/src/Analysis/SharedUtils/TeamProject/TeamProjectHeader/TeamProjectHeader.jsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
+import { useHistory } from 'react-router-dom';
 import EditIcon from './Icons/EditIcon';
 import isEnterOrSpace from '../../IsEnterOrSpace';
 import TeamProjectModal from '../TeamProjectModal/TeamProjectModal';
@@ -11,13 +12,17 @@ const TeamProjectHeader = ({ showButton }) => {
   const showModal = () => {
     setIsModalOpen(true);
   };
+  const history = useHistory();
 
   useEffect(() => {
     const storedTeamProject = localStorage.getItem('teamProject');
     if (storedTeamProject) {
       setBannerText(storedTeamProject);
-    } else {
+    } else if (showButton) {
       showModal();
+    } else if (!showButton && !storedTeamProject) {
+      // non-editable view should redirect to app selection if user doesn't have a storedTeamProject
+      history.push('/analysis');
     }
   }, []);
 

--- a/src/Analysis/SharedUtils/TeamProject/TeamProjectHeader/TeamProjectHeader.jsx
+++ b/src/Analysis/SharedUtils/TeamProject/TeamProjectHeader/TeamProjectHeader.jsx
@@ -6,7 +6,7 @@ import isEnterOrSpace from '../../IsEnterOrSpace';
 import TeamProjectModal from '../TeamProjectModal/TeamProjectModal';
 import './TeamProjectHeader.css';
 
-const TeamProjectHeader = ({ showButton }) => {
+const TeamProjectHeader = ({ isEditable }) => {
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [bannerText, setBannerText] = useState('- -');
   const showModal = () => {
@@ -18,19 +18,19 @@ const TeamProjectHeader = ({ showButton }) => {
     const storedTeamProject = localStorage.getItem('teamProject');
     if (storedTeamProject) {
       setBannerText(storedTeamProject);
-    } else if (showButton) {
+    } else if (isEditable) {
       showModal();
-    } else if (!showButton && !storedTeamProject) {
+    } else if (!isEditable && !storedTeamProject) {
       // non-editable view should redirect to app selection if user doesn't have a storedTeamProject
       history.push('/analysis');
     }
-  }, [history, showButton]);
+  }, [history, isEditable]);
 
   return (
     <React.Fragment>
       <div className='team-project-header'>
         <strong>Team Project</strong> / {bannerText}
-        {showButton && (
+        {isEditable && (
           <span
             className='team-project-header_modal-button'
             tabIndex='0'
@@ -47,7 +47,7 @@ const TeamProjectHeader = ({ showButton }) => {
           </span>
         )}
       </div>
-      {showButton && (
+      {isEditable && (
         <TeamProjectModal
           isModalOpen={isModalOpen}
           setIsModalOpen={setIsModalOpen}
@@ -59,11 +59,11 @@ const TeamProjectHeader = ({ showButton }) => {
 };
 
 TeamProjectHeader.propTypes = {
-  showButton: PropTypes.bool,
+  isEditable: PropTypes.bool,
 };
 
 TeamProjectHeader.defaultProps = {
-  showButton: false,
+  isEditable: false,
 };
 
 export default TeamProjectHeader;

--- a/src/Analysis/SharedUtils/TeamProject/TeamProjectHeader/TeamProjectHeader.jsx
+++ b/src/Analysis/SharedUtils/TeamProject/TeamProjectHeader/TeamProjectHeader.jsx
@@ -28,7 +28,7 @@ const TeamProjectHeader = ({ showButton }) => {
 
   return (
     <React.Fragment>
-      <h3 className='team-project-header'>
+      <div className='team-project-header'>
         <strong>Team Project</strong> / {bannerText}
         {showButton && (
           <span
@@ -46,7 +46,7 @@ const TeamProjectHeader = ({ showButton }) => {
             <EditIcon />
           </span>
         )}
-      </h3>
+      </div>
       {showButton && (
         <TeamProjectModal
           isModalOpen={isModalOpen}

--- a/src/Analysis/SharedUtils/TeamProject/TeamProjectHeader/TeamProjectHeader.stories.jsx
+++ b/src/Analysis/SharedUtils/TeamProject/TeamProjectHeader/TeamProjectHeader.stories.jsx
@@ -15,12 +15,12 @@ const Template = (args) => (
   </div>
 );
 
-export const withButton = Template.bind({});
-withButton.args = {
+export const isEditable = Template.bind({});
+isEditable.args = {
   isEditable: true,
 };
 
-export const withNoButton = Template.bind({});
-withNoButton.args = {
+export const notEditable = Template.bind({});
+notEditable.args = {
   isEditable: false,
 };

--- a/src/Analysis/SharedUtils/TeamProject/TeamProjectHeader/TeamProjectHeader.stories.jsx
+++ b/src/Analysis/SharedUtils/TeamProject/TeamProjectHeader/TeamProjectHeader.stories.jsx
@@ -17,10 +17,10 @@ const Template = (args) => (
 
 export const withButton = Template.bind({});
 withButton.args = {
-  showButton: true,
+  isEditable: true,
 };
 
 export const withNoButton = Template.bind({});
 withNoButton.args = {
-  showButton: false,
+  isEditable: false,
 };

--- a/src/Analysis/SharedUtils/TeamProject/TeamProjectHeader/TeamProjectHeader.test.jsx
+++ b/src/Analysis/SharedUtils/TeamProject/TeamProjectHeader/TeamProjectHeader.test.jsx
@@ -24,7 +24,7 @@ test('renders TeamProjectHeader with default props when showButton is true and n
   render(
     <QueryClientProvider client={new QueryClient()} contextSharing>
       <TeamProjectHeader showButton />
-    </QueryClientProvider>
+    </QueryClientProvider>,
   );
   // Assert that the component renders without crashing without button
   expect(screen.getByText('Team Project')).toBeInTheDocument();
@@ -44,7 +44,7 @@ test(`Calls useHistory for redirect to analysis page when showButton is
       <QueryClientProvider client={new QueryClient()} contextSharing>
         <TeamProjectHeader showButton={false} />
       </QueryClientProvider>
-    </Router>
+    </Router>,
   );
 
   // Check if history.push('/analysis') is called
@@ -56,7 +56,7 @@ test('renders TeamProjectHeader with edit button when showButton is true and can
   render(
     <QueryClientProvider client={new QueryClient()} contextSharing>
       <TeamProjectHeader showButton />
-    </QueryClientProvider>
+    </QueryClientProvider>,
   );
 
   // Assert that the component renders with the edit button
@@ -74,7 +74,7 @@ test('Renders project name based on local storage value', () => {
   render(
     <QueryClientProvider client={new QueryClient()} contextSharing>
       <TeamProjectHeader />
-    </QueryClientProvider>
+    </QueryClientProvider>,
   );
   // Assert that the component renders with the banner text from localStorage
   expect(screen.getByText(`/ ${teamProjectValue}`)).toBeInTheDocument();

--- a/src/Analysis/SharedUtils/TeamProject/TeamProjectHeader/TeamProjectHeader.test.jsx
+++ b/src/Analysis/SharedUtils/TeamProject/TeamProjectHeader/TeamProjectHeader.test.jsx
@@ -1,7 +1,5 @@
 import React from 'react';
-import {
-  render, screen, fireEvent, waitFor,
-} from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { createMemoryHistory } from 'history';
 import { Router } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from 'react-query';
@@ -21,12 +19,12 @@ beforeEach(() => {
   });
 });
 
-test('renders TeamProjectHeader with default props when showButton is true', () => {
+test('renders TeamProjectHeader with default props when showButton is true and no local storage', () => {
   localStorageMock.getItem.mockReturnValueOnce(null);
   render(
     <QueryClientProvider client={new QueryClient()} contextSharing>
       <TeamProjectHeader showButton />
-    </QueryClientProvider>,
+    </QueryClientProvider>
   );
   // Assert that the component renders without crashing without button
   expect(screen.getByText('Team Project')).toBeInTheDocument();
@@ -34,7 +32,7 @@ test('renders TeamProjectHeader with default props when showButton is true', () 
 });
 
 test(`Calls useHistory for redirect to analysis page when showButton is
-  false and teamProject is not set in local storage`, async () => {
+  false and teamProject is not set in local storage`, () => {
   // Mock localStorage
   localStorageMock.getItem.mockReturnValueOnce(null);
   // Create a history object
@@ -46,21 +44,19 @@ test(`Calls useHistory for redirect to analysis page when showButton is
       <QueryClientProvider client={new QueryClient()} contextSharing>
         <TeamProjectHeader showButton={false} />
       </QueryClientProvider>
-    </Router>,
+    </Router>
   );
 
   // Check if history.push('/analysis') is called
-  // screen.debug();
-  await waitFor(() => {
-    expect(history.location.pathname).toBe('/analysis');
-  });
+
+  expect(history.location.pathname).toBe('/analysis');
 });
 
 test('renders TeamProjectHeader with edit button when showButton is true and can open modal', () => {
   render(
     <QueryClientProvider client={new QueryClient()} contextSharing>
       <TeamProjectHeader showButton />
-    </QueryClientProvider>,
+    </QueryClientProvider>
   );
 
   // Assert that the component renders with the edit button
@@ -78,7 +74,7 @@ test('Renders project name based on local storage value', () => {
   render(
     <QueryClientProvider client={new QueryClient()} contextSharing>
       <TeamProjectHeader />
-    </QueryClientProvider>,
+    </QueryClientProvider>
   );
   // Assert that the component renders with the banner text from localStorage
   expect(screen.getByText(`/ ${teamProjectValue}`)).toBeInTheDocument();

--- a/src/Analysis/SharedUtils/TeamProject/TeamProjectHeader/TeamProjectHeader.test.jsx
+++ b/src/Analysis/SharedUtils/TeamProject/TeamProjectHeader/TeamProjectHeader.test.jsx
@@ -24,7 +24,7 @@ test('renders TeamProjectHeader with default props when showButton is true and n
   render(
     <QueryClientProvider client={new QueryClient()} contextSharing>
       <TeamProjectHeader showButton />
-    </QueryClientProvider>,
+    </QueryClientProvider>
   );
   // Assert that the component renders without crashing without button
   expect(screen.getByText('Team Project')).toBeInTheDocument();
@@ -33,21 +33,16 @@ test('renders TeamProjectHeader with default props when showButton is true and n
 
 test(`Calls useHistory for redirect to analysis page when showButton is
   false and teamProject is not set in local storage`, () => {
-  // Mock localStorage
   localStorageMock.getItem.mockReturnValueOnce(null);
-  // Create a history object
   const history = createMemoryHistory();
 
-  // Render the component
   render(
     <Router history={history}>
       <QueryClientProvider client={new QueryClient()} contextSharing>
         <TeamProjectHeader showButton={false} />
       </QueryClientProvider>
-    </Router>,
+    </Router>
   );
-
-  // Check if history.push('/analysis') is called
 
   expect(history.location.pathname).toBe('/analysis');
 });
@@ -56,7 +51,7 @@ test('renders TeamProjectHeader with edit button when showButton is true and can
   render(
     <QueryClientProvider client={new QueryClient()} contextSharing>
       <TeamProjectHeader showButton />
-    </QueryClientProvider>,
+    </QueryClientProvider>
   );
 
   // Assert that the component renders with the edit button
@@ -74,7 +69,7 @@ test('Renders project name based on local storage value', () => {
   render(
     <QueryClientProvider client={new QueryClient()} contextSharing>
       <TeamProjectHeader />
-    </QueryClientProvider>,
+    </QueryClientProvider>
   );
   // Assert that the component renders with the banner text from localStorage
   expect(screen.getByText(`/ ${teamProjectValue}`)).toBeInTheDocument();

--- a/src/Analysis/SharedUtils/TeamProject/TeamProjectHeader/TeamProjectHeader.test.jsx
+++ b/src/Analysis/SharedUtils/TeamProject/TeamProjectHeader/TeamProjectHeader.test.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import { createMemoryHistory } from 'history';
 import { Router } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from 'react-query';

--- a/src/Analysis/SharedUtils/TeamProject/TeamProjectHeader/TeamProjectHeader.test.jsx
+++ b/src/Analysis/SharedUtils/TeamProject/TeamProjectHeader/TeamProjectHeader.test.jsx
@@ -19,11 +19,11 @@ beforeEach(() => {
   });
 });
 
-test('renders TeamProjectHeader with default props when showButton is true and no local storage', () => {
+test('renders TeamProjectHeader with default props when isEditable is true and no local storage', () => {
   localStorageMock.getItem.mockReturnValueOnce(null);
   render(
     <QueryClientProvider client={new QueryClient()} contextSharing>
-      <TeamProjectHeader showButton />
+      <TeamProjectHeader isEditable />
     </QueryClientProvider>,
   );
   // Assert that the component renders without crashing without button
@@ -31,7 +31,7 @@ test('renders TeamProjectHeader with default props when showButton is true and n
   expect(screen.getByText('/ - -')).toBeInTheDocument();
 });
 
-test(`Calls useHistory for redirect to analysis page when showButton is
+test(`Calls useHistory for redirect to analysis page when isEditable is
   false and teamProject is not set in local storage`, () => {
   localStorageMock.getItem.mockReturnValueOnce(null);
   const history = createMemoryHistory();
@@ -39,7 +39,7 @@ test(`Calls useHistory for redirect to analysis page when showButton is
   render(
     <Router history={history}>
       <QueryClientProvider client={new QueryClient()} contextSharing>
-        <TeamProjectHeader showButton={false} />
+        <TeamProjectHeader isEditable={false} />
       </QueryClientProvider>
     </Router>,
   );
@@ -47,10 +47,10 @@ test(`Calls useHistory for redirect to analysis page when showButton is
   expect(history.location.pathname).toBe('/analysis');
 });
 
-test('renders TeamProjectHeader with edit button when showButton is true and can open modal', () => {
+test('renders TeamProjectHeader with edit button when isEditable is true and can open modal', () => {
   render(
     <QueryClientProvider client={new QueryClient()} contextSharing>
-      <TeamProjectHeader showButton />
+      <TeamProjectHeader isEditable />
     </QueryClientProvider>,
   );
 

--- a/src/Analysis/SharedUtils/TeamProject/TeamProjectHeader/TeamProjectHeader.test.jsx
+++ b/src/Analysis/SharedUtils/TeamProject/TeamProjectHeader/TeamProjectHeader.test.jsx
@@ -1,5 +1,7 @@
 import React from 'react';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import {
+  render, screen, fireEvent, waitFor,
+} from '@testing-library/react';
 import { createMemoryHistory } from 'history';
 import { Router } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from 'react-query';
@@ -24,7 +26,7 @@ test('renders TeamProjectHeader with default props when showButton is true', () 
   render(
     <QueryClientProvider client={new QueryClient()} contextSharing>
       <TeamProjectHeader showButton />
-    </QueryClientProvider>
+    </QueryClientProvider>,
   );
   // Assert that the component renders without crashing without button
   expect(screen.getByText('Team Project')).toBeInTheDocument();
@@ -44,7 +46,7 @@ test(`Calls useHistory for redirect to analysis page when showButton is
       <QueryClientProvider client={new QueryClient()} contextSharing>
         <TeamProjectHeader showButton={false} />
       </QueryClientProvider>
-    </Router>
+    </Router>,
   );
 
   // Check if history.push('/analysis') is called
@@ -58,7 +60,7 @@ test('renders TeamProjectHeader with edit button when showButton is true and can
   render(
     <QueryClientProvider client={new QueryClient()} contextSharing>
       <TeamProjectHeader showButton />
-    </QueryClientProvider>
+    </QueryClientProvider>,
   );
 
   // Assert that the component renders with the edit button
@@ -76,7 +78,7 @@ test('Renders project name based on local storage value', () => {
   render(
     <QueryClientProvider client={new QueryClient()} contextSharing>
       <TeamProjectHeader />
-    </QueryClientProvider>
+    </QueryClientProvider>,
   );
   // Assert that the component renders with the banner text from localStorage
   expect(screen.getByText(`/ ${teamProjectValue}`)).toBeInTheDocument();

--- a/src/Analysis/SharedUtils/TeamProject/TeamProjectHeader/TeamProjectHeader.test.jsx
+++ b/src/Analysis/SharedUtils/TeamProject/TeamProjectHeader/TeamProjectHeader.test.jsx
@@ -24,7 +24,7 @@ test('renders TeamProjectHeader with default props when showButton is true and n
   render(
     <QueryClientProvider client={new QueryClient()} contextSharing>
       <TeamProjectHeader showButton />
-    </QueryClientProvider>
+    </QueryClientProvider>,
   );
   // Assert that the component renders without crashing without button
   expect(screen.getByText('Team Project')).toBeInTheDocument();
@@ -41,7 +41,7 @@ test(`Calls useHistory for redirect to analysis page when showButton is
       <QueryClientProvider client={new QueryClient()} contextSharing>
         <TeamProjectHeader showButton={false} />
       </QueryClientProvider>
-    </Router>
+    </Router>,
   );
 
   expect(history.location.pathname).toBe('/analysis');
@@ -51,7 +51,7 @@ test('renders TeamProjectHeader with edit button when showButton is true and can
   render(
     <QueryClientProvider client={new QueryClient()} contextSharing>
       <TeamProjectHeader showButton />
-    </QueryClientProvider>
+    </QueryClientProvider>,
   );
 
   // Assert that the component renders with the edit button
@@ -69,7 +69,7 @@ test('Renders project name based on local storage value', () => {
   render(
     <QueryClientProvider client={new QueryClient()} contextSharing>
       <TeamProjectHeader />
-    </QueryClientProvider>
+    </QueryClientProvider>,
   );
   // Assert that the component renders with the banner text from localStorage
   expect(screen.getByText(`/ ${teamProjectValue}`)).toBeInTheDocument();

--- a/src/Analysis/SharedUtils/TeamProject/TeamProjectHeader/TeamProjectHeader.test.jsx
+++ b/src/Analysis/SharedUtils/TeamProject/TeamProjectHeader/TeamProjectHeader.test.jsx
@@ -1,5 +1,7 @@
 import React from 'react';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { createMemoryHistory } from 'history';
+import { Router } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from 'react-query';
 import '@testing-library/jest-dom';
 import TeamProjectHeader from './TeamProjectHeader';
@@ -17,23 +19,46 @@ beforeEach(() => {
   });
 });
 
-test('renders TeamProjectHeader with default props', () => {
+test('renders TeamProjectHeader with default props when showButton is true', () => {
   localStorageMock.getItem.mockReturnValueOnce(null);
   render(
     <QueryClientProvider client={new QueryClient()} contextSharing>
-      <TeamProjectHeader />
-    </QueryClientProvider>,
+      <TeamProjectHeader showButton />
+    </QueryClientProvider>
   );
   // Assert that the component renders without crashing without button
   expect(screen.getByText('Team Project')).toBeInTheDocument();
   expect(screen.getByText('/ - -')).toBeInTheDocument();
 });
 
+test(`Calls useHistory for redirect to analysis page when showButton is
+  false and teamProject is not set in local storage`, async () => {
+  // Mock localStorage
+  localStorageMock.getItem.mockReturnValueOnce(null);
+  // Create a history object
+  const history = createMemoryHistory();
+
+  // Render the component
+  render(
+    <Router history={history}>
+      <QueryClientProvider client={new QueryClient()} contextSharing>
+        <TeamProjectHeader showButton={false} />
+      </QueryClientProvider>
+    </Router>
+  );
+
+  // Check if history.push('/analysis') is called
+  // screen.debug();
+  await waitFor(() => {
+    expect(history.location.pathname).toBe('/analysis');
+  });
+});
+
 test('renders TeamProjectHeader with edit button when showButton is true and can open modal', () => {
   render(
     <QueryClientProvider client={new QueryClient()} contextSharing>
       <TeamProjectHeader showButton />
-    </QueryClientProvider>,
+    </QueryClientProvider>
   );
 
   // Assert that the component renders with the edit button
@@ -51,7 +76,7 @@ test('Renders project name based on local storage value', () => {
   render(
     <QueryClientProvider client={new QueryClient()} contextSharing>
       <TeamProjectHeader />
-    </QueryClientProvider>,
+    </QueryClientProvider>
   );
   // Assert that the component renders with the banner text from localStorage
   expect(screen.getByText(`/ ${teamProjectValue}`)).toBeInTheDocument();

--- a/src/Analysis/SharedUtils/TeamProject/TeamProjectModal/TeamProjectModal.jsx
+++ b/src/Analysis/SharedUtils/TeamProject/TeamProjectModal/TeamProjectModal.jsx
@@ -1,6 +1,8 @@
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
-import { Button, Modal, Spin, Select } from 'antd';
+import {
+  Button, Modal, Spin, Select,
+} from 'antd';
 import { useQuery } from 'react-query';
 import queryConfig from '../../QueryConfig';
 import LoadingErrorMessage from '../../LoadingErrorMessage/LoadingErrorMessage';
@@ -9,7 +11,7 @@ import './TeamProjectModal.css';
 
 const TeamProjectModal = ({ isModalOpen, setIsModalOpen, setBannerText }) => {
   const [selectedTeamProject, setSelectedTeamProject] = useState(
-    localStorage.getItem('teamProject')
+    localStorage.getItem('teamProject'),
   );
 
   const closeAndUpdateTeamProject = () => {
@@ -21,7 +23,7 @@ const TeamProjectModal = ({ isModalOpen, setIsModalOpen, setBannerText }) => {
   const { data, status } = useQuery(
     'teamprojects',
     fetchArboristTeamProjectRoles,
-    queryConfig
+    queryConfig,
   );
 
   let modalContent = (

--- a/src/Analysis/SharedUtils/TeamProject/TeamProjectModal/TeamProjectModal.test.jsx
+++ b/src/Analysis/SharedUtils/TeamProject/TeamProjectModal/TeamProjectModal.test.jsx
@@ -1,5 +1,7 @@
 import React from 'react';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import {
+  render, screen, fireEvent, waitFor,
+} from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { useQuery } from 'react-query';
 import TeamProjectModal from './TeamProjectModal';
@@ -16,12 +18,12 @@ describe('TeamProjectModal', () => {
         isModalOpen
         setIsModalOpen={() => {}}
         setBannerText={() => {}}
-      />
+      />,
     );
 
     expect(screen.getByText(/Please wait.../i)).toBeInTheDocument();
     expect(
-      screen.getByText(/Retrieving the list of team projects./i)
+      screen.getByText(/Retrieving the list of team projects./i),
     ).toBeInTheDocument();
   });
 
@@ -40,17 +42,17 @@ describe('TeamProjectModal', () => {
         isModalOpen
         setIsModalOpen={setIsModalOpen}
         setBannerText={setBannerText}
-      />
+      />,
     );
 
     await waitFor(() => screen.getByText(/Please select your team./i));
     expect(
-      screen.getByText(/-select one of the team projects below-/i)
+      screen.getByText(/-select one of the team projects below-/i),
     ).toBeInTheDocument();
 
     expect(screen.getByRole('combobox')).toBeInTheDocument();
     expect(screen.getByText('Submit').closest('button')).toHaveAttribute(
-      'disabled'
+      'disabled',
     );
   });
 
@@ -72,19 +74,18 @@ describe('TeamProjectModal', () => {
         isModalOpen
         setIsModalOpen={setIsModalOpen}
         setBannerText={setBannerText}
-      />
+      />,
     );
 
     await waitFor(() => screen.getByText(/Please select your team./i));
 
-    expect(() =>
-      screen.getByText('select one of the team projects below')
+    expect(() => screen.getByText('select one of the team projects below'),
     ).toThrow('Unable to find an element');
     expect(screen.getByText('test string')).toBeInTheDocument();
     expect(screen.getByRole('combobox')).toBeInTheDocument();
     expect(screen.getByText('Submit')).toBeInTheDocument();
     expect(screen.getByText('Submit').closest('button')).not.toHaveAttribute(
-      'disabled'
+      'disabled',
     );
   });
 
@@ -106,7 +107,7 @@ describe('TeamProjectModal', () => {
         isModalOpen
         setIsModalOpen={setIsModalOpen}
         setBannerText={setBannerText}
-      />
+      />,
     );
 
     await waitFor(() => screen.getByText(/Please select your team./i));


### PR DESCRIPTION
Jira Ticket: [VADC-760](https://ctds-planx.atlassian.net/browse/VADC-760)


GWAS APP
<img width="1494" alt="image" src="https://github.com/uc-cdis/data-portal/assets/113449836/c6d8f0fb-cf1d-4e45-a93a-e17da82494a3">

GWAS RESULTS
<img width="1494" alt="image" src="https://github.com/uc-cdis/data-portal/assets/113449836/c63e1ec3-4201-4f19-940e-50d7012aed10">

OHDSI
<img width="1494" alt="image" src="https://github.com/uc-cdis/data-portal/assets/113449836/af52283c-39dc-4775-939a-d9ffba9254bc">

On any app, if the page loads and their is not a teamProject local storage variable set, the app redirects to the Analysis App view so the user can select a team project
![output](https://github.com/uc-cdis/data-portal/assets/113449836/58186f67-18b0-4d1e-aedb-498496920e3b)


### New Features

* Adds selected team project in each of the apps: Atlas, GWAS App and Results App and reroutes user back to Analysis Apps view if they do not have a team project selected

### Improvements
* Lints TeamProjectModal.test.jsx to abide by code formatting style guide

[VADC-760]: https://ctds-planx.atlassian.net/browse/VADC-760?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ