### PR TITLE
HP-1298 fix: system dua popup take over drawer

### DIFF
--- a/src/Discovery/DiscoveryDetails/DiscoveryDetails.tsx
+++ b/src/Discovery/DiscoveryDetails/DiscoveryDetails.tsx
@@ -46,6 +46,7 @@ interface Props {
   permalinkCopied: boolean;
   user: User;
   userAuthMapping: any;
+  systemPopupActivated: boolean;
 }
 
 interface ListItem {
@@ -370,7 +371,8 @@ const DiscoveryDetails = (props: Props) => {
   return (
     <Drawer
       className='discovery-modal'
-      open={props.modalVisible}
+      // if system-level popup is visible, do not show details drawer
+      open={props.modalVisible && !props.systemPopupActivated}
       width={'50vw'}
       closable={false}
       onClose={() => {

--- a/src/Discovery/reduxer.js
+++ b/src/Discovery/reduxer.js
@@ -20,6 +20,7 @@ export const ReduxDiscoveryDetails = (() => {
   const mapStateToProps = (state) => ({
     user: state.user,
     userAuthMapping: state.userAuthMapping,
+    systemPopupActivated: !!state.popups?.systemUseWarnPopup,
   });
 
   return connect(mapStateToProps)(DiscoveryDetails);


### PR DESCRIPTION
Jira Ticket: [HP-1298](https://ctds-planx.atlassian.net/browse/HP-1298)



### Bug Fixes
- Discovery: the display of system-level popup (DUA) will take precedence over the Discovery Details drawer


[HP-1298]: https://ctds-planx.atlassian.net/browse/HP-1298?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ