### PR TITLE
update guppy

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@fortawesome/free-brands-svg-icons": "^5.14.0",
         "@fortawesome/free-solid-svg-icons": "^5.2.0",
         "@fortawesome/react-fontawesome": "^0.2.0",
-        "@gen3/guppy": "^0.18.0",
+        "@gen3/guppy": "git+https://github.com/uc-cdis/guppy.git#fix/search-fields-csrf",
         "@gen3/ui-component": "^0.11.4",
         "@reactour/tour": "^2.12.0",
         "@upsetjs/venn.js": "^1.4.2",
@@ -3761,9 +3761,9 @@
       "dev": true
     },
     "node_modules/@gen3/guppy": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/@gen3/guppy/-/guppy-0.18.0.tgz",
-      "integrity": "sha512-6G7lUn17G08RxxuG3pWDvjI06duBvLVyTVFcVhTq8Jv/nrH7utnfoTswV162+nSOk8z7sFNn79nzCAdKcPfAOg==",
+      "version": "0.18.1",
+      "resolved": "git+ssh://git@github.com/uc-cdis/guppy.git#930f49df56822693854a936f71ac12bce8b24927",
+      "license": "ISC",
       "dependencies": {
         "@apollo/server": "^4.9.4",
         "@elastic/elasticsearch": "~7.13.0",
@@ -40390,9 +40390,8 @@
       "dev": true
     },
     "@gen3/guppy": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/@gen3/guppy/-/guppy-0.18.0.tgz",
-      "integrity": "sha512-6G7lUn17G08RxxuG3pWDvjI06duBvLVyTVFcVhTq8Jv/nrH7utnfoTswV162+nSOk8z7sFNn79nzCAdKcPfAOg==",
+      "version": "git+ssh://git@github.com/uc-cdis/guppy.git#930f49df56822693854a936f71ac12bce8b24927",
+      "from": "@gen3/guppy@git+https://github.com/uc-cdis/guppy.git#fix/search-fields-csrf",
       "requires": {
         "@apollo/server": "^4.9.4",
         "@elastic/elasticsearch": "~7.13.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@fortawesome/free-brands-svg-icons": "^5.14.0",
         "@fortawesome/free-solid-svg-icons": "^5.2.0",
         "@fortawesome/react-fontawesome": "^0.2.0",
-        "@gen3/guppy": "git+https://github.com/uc-cdis/guppy.git#fix/search-fields-csrf",
+        "@gen3/guppy": "^0.18.1",
         "@gen3/ui-component": "^0.11.4",
         "@reactour/tour": "^2.12.0",
         "@upsetjs/venn.js": "^1.4.2",
@@ -3762,8 +3762,8 @@
     },
     "node_modules/@gen3/guppy": {
       "version": "0.18.1",
-      "resolved": "git+ssh://git@github.com/uc-cdis/guppy.git#930f49df56822693854a936f71ac12bce8b24927",
-      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/@gen3/guppy/-/guppy-0.18.1.tgz",
+      "integrity": "sha512-WOGe/qQU2/eS8uDtLOz9tRRrl8xeahUjTojSxZ7B9nCsBMiwmHZ0PGy4+RrdM5AHe7uqQyJdbYCRcpOACUjGQg==",
       "dependencies": {
         "@apollo/server": "^4.9.4",
         "@elastic/elasticsearch": "~7.13.0",
@@ -40390,8 +40390,9 @@
       "dev": true
     },
     "@gen3/guppy": {
-      "version": "git+ssh://git@github.com/uc-cdis/guppy.git#930f49df56822693854a936f71ac12bce8b24927",
-      "from": "@gen3/guppy@git+https://github.com/uc-cdis/guppy.git#fix/search-fields-csrf",
+      "version": "0.18.1",
+      "resolved": "https://registry.npmjs.org/@gen3/guppy/-/guppy-0.18.1.tgz",
+      "integrity": "sha512-WOGe/qQU2/eS8uDtLOz9tRRrl8xeahUjTojSxZ7B9nCsBMiwmHZ0PGy4+RrdM5AHe7uqQyJdbYCRcpOACUjGQg==",
       "requires": {
         "@apollo/server": "^4.9.4",
         "@elastic/elasticsearch": "~7.13.0",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "@fortawesome/free-brands-svg-icons": "^5.14.0",
     "@fortawesome/free-solid-svg-icons": "^5.2.0",
     "@fortawesome/react-fontawesome": "^0.2.0",
-    "@gen3/guppy": "^0.18.0",
+    "@gen3/guppy": "git+https://github.com/uc-cdis/guppy.git#fix/search-fields-csrf",
     "@gen3/ui-component": "^0.11.4",
     "@reactour/tour": "^2.12.0",
     "@upsetjs/venn.js": "^1.4.2",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "@fortawesome/free-brands-svg-icons": "^5.14.0",
     "@fortawesome/free-solid-svg-icons": "^5.2.0",
     "@fortawesome/react-fontawesome": "^0.2.0",
-    "@gen3/guppy": "git+https://github.com/uc-cdis/guppy.git#fix/search-fields-csrf",
+    "@gen3/guppy": "^0.18.1",
     "@gen3/ui-component": "^0.11.4",
     "@reactour/tour": "^2.12.0",
     "@upsetjs/venn.js": "^1.4.2",


### PR DESCRIPTION


### Bug Fixes
- Update Guppy for search box query CSRF fix


### Dependency updates
- Guppy to `0.18.1`

