### PR TITLE
Feat/vadc data dictionary button new tab

### DIFF
--- a/src/Analysis/AnalysisApp.jsx
+++ b/src/Analysis/AnalysisApp.jsx
@@ -16,6 +16,7 @@ import GWASResultsContainer from './GWASResults/GWASResultsContainer';
 import CheckForTeamProjectApplication from './SharedUtils/TeamProject/Utils/CheckForTeamProjectApplication';
 import TeamProjectHeader from './SharedUtils/TeamProject/TeamProjectHeader/TeamProjectHeader';
 import './AnalysisApp.css';
+import AtlasDataDictionaryButton from './AtlasDataDictionary/AtlasDataDictionaryButton/AtlasDataDictionaryButton';
 
 const queryClient = new QueryClient();
 
@@ -164,6 +165,9 @@ class AnalysisApp extends React.Component {
       return (
         <React.Fragment>
           <div className='analysis-app__iframe-wrapper'>
+            {this.state.app.title === 'OHDSI Atlas' && (
+              <AtlasDataDictionaryButton />
+            )}
             <iframe
               className='analysis-app__iframe'
               title='Analysis App'

--- a/src/Analysis/AtlasDataDictionary/AtlasDataDictionaryButton/AtlasDataDictionaryButton.css
+++ b/src/Analysis/AtlasDataDictionary/AtlasDataDictionaryButton/AtlasDataDictionaryButton.css
@@ -1,0 +1,12 @@
+.atlas-data-dictionary-button {
+    float: right;
+    margin-top: -65px;
+  }
+
+  .atlas-data-dictionary-button-modal button:focus {
+   outline: 1px dotted;
+  }
+
+  .analysis-app__iframe-wrapper {
+   margin-bottom: 20px;
+  }

--- a/src/Analysis/AtlasDataDictionary/AtlasDataDictionaryButton/AtlasDataDictionaryButton.test.tsx
+++ b/src/Analysis/AtlasDataDictionary/AtlasDataDictionaryButton/AtlasDataDictionaryButton.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { render } from '@testing-library/react';
 import { BrowserRouter } from 'react-router-dom';
 import '@testing-library/jest-dom/extend-expect';
 import AtlasDataDictionaryButton from './AtlasDataDictionaryButton';
@@ -9,18 +9,18 @@ describe('AtlasDataDictionaryButton', () => {
     const { getByTestId } = render(
       <BrowserRouter>
         <AtlasDataDictionaryButton />
-      </BrowserRouter>
+      </BrowserRouter>,
     );
 
     const expectedPath = '/analysis/AtlasDataDictionary';
     expect(getByTestId('atlas-data-dictionary-button')).toBeInTheDocument();
     expect(getByTestId('atlas-data-dictionary-link')).toHaveAttribute(
       'href',
-      expectedPath
+      expectedPath,
     );
     expect(getByTestId('atlas-data-dictionary-link')).toHaveAttribute(
       'target',
-      '_blank'
+      '_blank',
     );
   });
 });

--- a/src/Analysis/AtlasDataDictionary/AtlasDataDictionaryButton/AtlasDataDictionaryButton.test.tsx
+++ b/src/Analysis/AtlasDataDictionary/AtlasDataDictionaryButton/AtlasDataDictionaryButton.test.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { BrowserRouter } from 'react-router-dom';
+import '@testing-library/jest-dom/extend-expect';
+import AtlasDataDictionaryButton from './AtlasDataDictionaryButton';
+
+describe('AtlasDataDictionaryButton', () => {
+  it('should render the Atlas Data Dictionary button correctly with a link and a secondary button', () => {
+    const { getByTestId } = render(
+      <BrowserRouter>
+        <AtlasDataDictionaryButton />
+      </BrowserRouter>
+    );
+
+    const expectedPath = '/analysis/AtlasDataDictionary';
+    expect(getByTestId('atlas-data-dictionary-button')).toBeInTheDocument();
+    expect(getByTestId('atlas-data-dictionary-link')).toHaveAttribute(
+      'href',
+      expectedPath
+    );
+    expect(getByTestId('atlas-data-dictionary-link')).toHaveAttribute(
+      'target',
+      '_blank'
+    );
+  });
+});

--- a/src/Analysis/AtlasDataDictionary/AtlasDataDictionaryButton/AtlasDataDictionaryButton.tsx
+++ b/src/Analysis/AtlasDataDictionary/AtlasDataDictionaryButton/AtlasDataDictionaryButton.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import Button from '@gen3/ui-component/dist/components/Button';
+import { Link } from 'react-router-dom';
+import './AtlasDataDictionaryButton.css';
+
+const AtlasDataDictionaryButton = () => (
+  <div
+    className='atlas-data-dictionary-button'
+    data-testid='atlas-data-dictionary-button'
+  >
+    <Link
+      to='/analysis/AtlasDataDictionary'
+      target='_blank'
+      rel='noopener noreferrer'
+      data-testid='atlas-data-dictionary-link'
+    >
+      <Button
+        className='analysis-app__button'
+        label='Atlas Data Dictionary'
+        buttonType='secondary'
+        rightIcon='external-link'
+      />
+    </Link>
+  </div>
+);
+
+export default AtlasDataDictionaryButton;


### PR DESCRIPTION
Jira Ticket: [VADC-939](https://ctds-planx.atlassian.net/browse/VADC-939)

![output](https://github.com/uc-cdis/data-portal/assets/113449836/81669fb4-33b1-4b32-b9d7-473bc06e2d34)


### New Features
* Adds button to OHDSI Atlas app to open VADC Data Dictionary App in a new tab


[VADC-939]: https://ctds-planx.atlassian.net/browse/VADC-939?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ