### PR TITLE
fix(updateTooltipsStudyPageButtons): Removed conditional popover comp…

### DIFF
--- a/src/Discovery/DiscoveryDetails/Components/FieldGrouping/TabField/DataDownloadList/ActionButtons/ActionButtons.tsx
+++ b/src/Discovery/DiscoveryDetails/Components/FieldGrouping/TabField/DataDownloadList/ActionButtons/ActionButtons.tsx
@@ -155,20 +155,18 @@ const ActionButtons = ({
         )}
         {showDownloadStudyLevelMetadataButton && (
           <Col>
-            <ConditionalPopover>
-              <Button
-                className='discovery-action-bar-button'
-                disabled={Boolean(noData || downloadStatus.inProgress)}
-                onClick={() => DownloadJsonFile(
-                  'study-level-metadata',
-                  studyMetadataFieldNameReference
+            <Button
+              className='discovery-action-bar-button'
+              disabled={Boolean(noData || downloadStatus.inProgress)}
+              onClick={() => DownloadJsonFile(
+                'study-level-metadata',
+                studyMetadataFieldNameReference
                       && resourceInfo[studyMetadataFieldNameReference],
-                )}
-              >
+              )}
+            >
                 Download <br />
                 Study-Level Metadata
-              </Button>
-            </ConditionalPopover>
+            </Button>
           </Col>
         )}
         {showDownloadFileManifestButtons && (

--- a/src/Discovery/DiscoveryDetails/Components/FieldGrouping/TabField/DataDownloadList/ActionButtons/ActionButtons.tsx
+++ b/src/Discovery/DiscoveryDetails/Components/FieldGrouping/TabField/DataDownloadList/ActionButtons/ActionButtons.tsx
@@ -41,7 +41,6 @@ const ActionButtons = ({
   location,
 }: ActionButtonsProps): JSX.Element => {
   const { HandleRedirectFromDiscoveryDetailsToLoginClick } = UseHandleRedirectToLoginClick();
-
   const studyMetadataFieldNameReference: string | undefined = discoveryConfig?.features.exportToWorkspace.studyMetadataFieldName;
   const manifestFieldName: string = discoveryConfig?.features.exportToWorkspace.manifestFieldName || '';
   let fileManifest: any[] = [];

--- a/src/Discovery/DiscoveryDetails/Components/FieldGrouping/TabField/DataDownloadList/ActionButtons/ActionButtons.tsx
+++ b/src/Discovery/DiscoveryDetails/Components/FieldGrouping/TabField/DataDownloadList/ActionButtons/ActionButtons.tsx
@@ -41,6 +41,7 @@ const ActionButtons = ({
   location,
 }: ActionButtonsProps): JSX.Element => {
   const { HandleRedirectFromDiscoveryDetailsToLoginClick } = UseHandleRedirectToLoginClick();
+
   const studyMetadataFieldNameReference: string | undefined = discoveryConfig?.features.exportToWorkspace.studyMetadataFieldName;
   const manifestFieldName: string = discoveryConfig?.features.exportToWorkspace.manifestFieldName || '';
   let fileManifest: any[] = [];

--- a/src/Discovery/DiscoveryDetails/Components/FieldGrouping/TabField/DataDownloadList/ActionButtons/ActionButtons.tsx
+++ b/src/Discovery/DiscoveryDetails/Components/FieldGrouping/TabField/DataDownloadList/ActionButtons/ActionButtons.tsx
@@ -135,6 +135,7 @@ const ActionButtons = ({
           <Col>
             <Button
               className='discovery-action-bar-button'
+              data-testid='download-variable-level-metadata'
               disabled={Boolean(
                 downloadStatus.inProgress
                   || dataDictionaryInfo.noVariableLevelMetadata,
@@ -157,6 +158,7 @@ const ActionButtons = ({
           <Col>
             <Button
               className='discovery-action-bar-button'
+              data-testid='download-study-level-metadata'
               disabled={Boolean(noData || downloadStatus.inProgress)}
               onClick={() => DownloadJsonFile(
                 'study-level-metadata',
@@ -175,6 +177,7 @@ const ActionButtons = ({
               <ConditionalPopover>
                 <Button
                   className='discovery-action-bar-button'
+                  data-testid='download-manifest'
                   disabled={Boolean(noData || downloadStatus.inProgress || !userHasAccessToDownload)}
                   onClick={() => {
                     HandleDownloadManifestClick(
@@ -192,6 +195,7 @@ const ActionButtons = ({
               <ConditionalPopover>
                 <Button
                   className='discovery-action-bar-button'
+                  data-testid='login-to-download-manifest'
                   disabled={Boolean(noData || downloadStatus.inProgress)}
                   onClick={() => {
                     HandleRedirectFromDiscoveryDetailsToLoginClick(uid);
@@ -210,6 +214,7 @@ const ActionButtons = ({
               <ConditionalPopover>
                 <Button
                   className='discovery-action-bar-button'
+                  data-testid='download-all-files'
                   disabled={Boolean(noData || downloadStatus.inProgress || !userHasAccessToDownload)}
                   loading={downloadStatus.inProgress === 'DownloadDataFiles'}
                   onClick={() => DownloadDataFiles(
@@ -230,6 +235,7 @@ const ActionButtons = ({
               <ConditionalPopover>
                 <Button
                   className='discovery-action-bar-button'
+                  data-testid='login-to-download-all-files'
                   disabled={Boolean(noData || downloadStatus.inProgress)}
                   onClick={() => {
                     HandleRedirectFromDiscoveryDetailsToLoginClick(uid);

--- a/src/Discovery/DiscoveryDetails/Components/FieldGrouping/TabField/DataDownloadList/ActionButtons/ActionsButtons.test.tsx
+++ b/src/Discovery/DiscoveryDetails/Components/FieldGrouping/TabField/DataDownloadList/ActionButtons/ActionsButtons.test.tsx
@@ -1,7 +1,5 @@
 import React from 'react';
-import {
-  render, screen, fireEvent, waitFor,
-} from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import ActionButtons from './ActionButtons';
 import { DiscoveryConfig } from '../../../../../../DiscoveryConfig';
@@ -59,10 +57,7 @@ describe('ActionButtons', () => {
   /* Helper Functions */
   const checkResourceInfoConditional = (buttonText: string) => {
     const { queryByText } = render(
-      <ActionButtons
-        {...testProps}
-        resourceInfo={{} as DiscoveryResource}
-      />,
+      <ActionButtons {...testProps} resourceInfo={{} as DiscoveryResource} />
     );
     // Check that the button is no longer rendered
     expect(queryByText(buttonText)).toBeNull();
@@ -70,12 +65,10 @@ describe('ActionButtons', () => {
 
   const checkExportToWorkspaceConditional = (
     buttonText: string,
-    condition: string,
+    condition: string
   ) => {
     const { getByText, queryByText, rerender } = render(
-      <ActionButtons
-        {...testProps}
-      />,
+      <ActionButtons {...testProps} />
     );
     const targetButton = getByText(buttonText);
     expect(targetButton).toBeInTheDocument();
@@ -86,14 +79,17 @@ describe('ActionButtons', () => {
       <ActionButtons
         {...testProps}
         discoveryConfig={changedConfig as DiscoveryConfig}
-      />,
+      />
     );
     // Check that the button is no longer rendered
     expect(queryByText(buttonText)).toBeNull();
   };
 
-  const hoverOverButtonAndCheckText = async (button: HTMLElement, popoverText:string,
-    popoverShouldRender:boolean) => {
+  const hoverOverButtonAndCheckText = async (
+    button: HTMLElement,
+    popoverText: string,
+    popoverShouldRender: boolean
+  ) => {
     fireEvent.mouseEnter(button);
     const popoverTextNode = screen.queryByText(popoverText);
     if (popoverShouldRender) {
@@ -105,56 +101,58 @@ describe('ActionButtons', () => {
     }
   };
 
-  const checkConditionalPopoverMissingRequiredIdentityProvidersInCommon = async (buttonTestID:string,
-    popoverShouldRender:boolean) => {
-    render(
-      <ActionButtons
-        {...testProps}
-        missingRequiredIdentityProviders={['InCommon']}
-      />,
-    );
-    const popoverText = `This dataset is only accessible to users who have
+  const checkConditionalPopoverMissingRequiredIdentityProvidersInCommon =
+    async (buttonTestID: string, popoverShouldRender: boolean) => {
+      render(
+        <ActionButtons
+          {...testProps}
+          missingRequiredIdentityProviders={['InCommon']}
+        />
+      );
+      const popoverText = `This dataset is only accessible to users who have
     authenticated via InCommon. Please log in using the InCommon option.`;
-    const button = screen.getByTestId(buttonTestID);
-    hoverOverButtonAndCheckText(button, popoverText, popoverShouldRender);
-  };
+      const button = screen.getByTestId(buttonTestID);
+      hoverOverButtonAndCheckText(button, popoverText, popoverShouldRender);
+    };
 
-  const checkConditionalPopoverMissingRequiredIdentityProvidersMultiple = async (buttonTestID: string, popoverShouldRender:boolean) => {
-    const missingRequiredIdentityProviders = ['InCommon', 'Google'];
-    render(
-      <ActionButtons
-        {...testProps}
-        missingRequiredIdentityProviders={missingRequiredIdentityProviders}
-      />,
-    );
-    const popoverText = `Data selection requires [${missingRequiredIdentityProviders.join(', ')}]
+  const checkConditionalPopoverMissingRequiredIdentityProvidersMultiple =
+    async (buttonTestID: string, popoverShouldRender: boolean) => {
+      const missingRequiredIdentityProviders = ['InCommon', 'Google'];
+      render(
+        <ActionButtons
+          {...testProps}
+          missingRequiredIdentityProviders={missingRequiredIdentityProviders}
+        />
+      );
+      const popoverText = `Data selection requires [${missingRequiredIdentityProviders.join(
+        ', '
+      )}]
     credentials to access. Please change selection to only need one set of credentials
     and log in using appropriate credentials`;
-    const button = screen.getByTestId(buttonTestID);
-    hoverOverButtonAndCheckText(button, popoverText, popoverShouldRender);
-  };
+      const button = screen.getByTestId(buttonTestID);
+      hoverOverButtonAndCheckText(button, popoverText, popoverShouldRender);
+    };
 
-  const checkConditionalPopoverUserDoesNotHaveAccess = async (buttonTestID: string,
-    popoverShouldRender:boolean) => {
+  const checkConditionalPopoverUserDoesNotHaveAccess = async (
+    buttonTestID: string,
+    popoverShouldRender: boolean
+  ) => {
     render(
       <ActionButtons
         {...testProps}
         missingRequiredIdentityProviders={['InCommon']}
         userHasAccessToDownload={false}
-      />,
+      />
     );
-    const popoverText = 'You don\'t have access to this data';
+    const popoverText = "You don't have access to this data";
     const button = screen.getByTestId(buttonTestID);
     hoverOverButtonAndCheckText(button, popoverText, popoverShouldRender);
   };
-  const checkConditionalPopoverNoData = async (buttonTestID: string, popoverShouldRender: boolean) => {
-    render(
-      <ActionButtons
-        {...testProps}
-        isUserLoggedIn={false}
-        noData
-      />,
-    );
+  const checkConditionalPopoverNoData = async (
+    buttonTestID: string,
+    popoverShouldRender: boolean
+  ) => {
+    render(<ActionButtons {...testProps} isUserLoggedIn={false} noData />);
     const popoverText = 'This file is not available for the selected study';
     const button = screen.getByTestId(buttonTestID);
     hoverOverButtonAndCheckText(button, popoverText, popoverShouldRender);
@@ -162,20 +160,11 @@ describe('ActionButtons', () => {
 
   /* Tests */
   test('Renders test id for ActionButtons', () => {
-    render(
-      <ActionButtons
-        {...testProps}
-      />,
-    );
+    render(<ActionButtons {...testProps} />);
     expect(screen.queryByTestId('actionButtons')).toBeInTheDocument();
   });
   test('ActionButtons should have "Login to" text when not logged in', () => {
-    render(
-      <ActionButtons
-        {...testProps}
-        isUserLoggedIn={false}
-      />,
-    );
+    render(<ActionButtons {...testProps} isUserLoggedIn={false} />);
     const loginText = screen.getAllByText(/Login to/i);
     expect(loginText[0]).toBeInTheDocument();
     expect(loginText[1]).toBeInTheDocument();
@@ -185,7 +174,7 @@ describe('ActionButtons', () => {
     const buttonText = 'Study-Level Metadata';
     checkExportToWorkspaceConditional(
       buttonText,
-      'enableDownloadStudyMetadata',
+      'enableDownloadStudyMetadata'
     );
     checkExportToWorkspaceConditional(buttonText, 'studyMetadataFieldName');
     checkResourceInfoConditional(buttonText);
@@ -193,13 +182,13 @@ describe('ActionButtons', () => {
   test('renders Download Manifest button based on conditionals', () => {
     checkExportToWorkspaceConditional(
       'Download Manifest',
-      'enableDownloadManifest',
+      'enableDownloadManifest'
     );
   });
   test('renders Download All Files button based on conditionals', () => {
     checkExportToWorkspaceConditional(
       'Download All Files',
-      'enableDownloadZip',
+      'enableDownloadZip'
     );
   });
 
@@ -224,26 +213,41 @@ describe('ActionButtons', () => {
   ];
 
   buttonIDsAndShowsPopover.forEach((button) => {
-    test(`Popover ${button.showsPopover ? 'renders' : 'does not render'} when hovered over
-      ${button.id} button when missing required identity providers is InCommon`, async () => {
+    test(`Popover ${
+      button.showsPopover ? 'renders' : 'does not render'
+    } when hovered over
+      ${
+        button.id
+      } button when missing required identity providers is InCommon`, async () => {
       checkConditionalPopoverMissingRequiredIdentityProvidersInCommon(
         button.id,
-        button.showsPopover,
+        button.showsPopover
       );
     });
-    test(`Popover ${button.showsPopover ? 'renders' : 'does not render'} when hovered over
-      ${button.id} button when missing required identity providers is multiple`, async () => {
+    test(`Popover ${
+      button.showsPopover ? 'renders' : 'does not render'
+    } when hovered over
+      ${
+        button.id
+      } button when missing required identity providers is multiple`, async () => {
       checkConditionalPopoverMissingRequiredIdentityProvidersMultiple(
         button.id,
-        button.showsPopover,
+        button.showsPopover
       );
     });
-    test(`Popover ${button.showsPopover ? 'renders' : 'does not render'} when hovered over
+    test(`Popover ${
+      button.showsPopover ? 'renders' : 'does not render'
+    } when hovered over
       ${button.id} button when user does not have access`, async () => {
-      checkConditionalPopoverUserDoesNotHaveAccess(button.id, button.showsPopover);
+      checkConditionalPopoverUserDoesNotHaveAccess(
+        button.id,
+        button.showsPopover
+      );
     });
 
-    test(`Popover ${button.showsPopover ? 'renders' : 'does not render'} when hovered over
+    test(`Popover ${
+      button.showsPopover ? 'renders' : 'does not render'
+    } when hovered over
       ${button.id} button when study has no data`, async () => {
       checkConditionalPopoverNoData(button.id, button.showsPopover);
     });

--- a/src/Discovery/DiscoveryDetails/Components/FieldGrouping/TabField/DataDownloadList/ActionButtons/ActionsButtons.test.tsx
+++ b/src/Discovery/DiscoveryDetails/Components/FieldGrouping/TabField/DataDownloadList/ActionButtons/ActionsButtons.test.tsx
@@ -222,11 +222,17 @@ describe('ActionButtons', () => {
   buttonIDsAndShowsPopover.forEach((button) => {
     test(`Popover ${button.showsPopover ? 'renders' : 'does not render'} when hovered over
       ${button.id} button when missing required identity providers is InCommon`, async () => {
-      checkConditionalPopoverMissingRequiredIdentityProvidersInCommon(button.id, button.showsPopover);
+      checkConditionalPopoverMissingRequiredIdentityProvidersInCommon(
+        button.id,
+        button.showsPopover,
+      );
     });
     test(`Popover ${button.showsPopover ? 'renders' : 'does not render'} when hovered over
       ${button.id} button when missing required identity providers is multiple`, async () => {
-      checkConditionalPopoverMissingRequiredIdentityProvidersMultiple(button.id, button.showsPopover);
+      checkConditionalPopoverMissingRequiredIdentityProvidersMultiple(
+        button.id,
+        button.showsPopover,
+        );
     });
     test(`Popover ${button.showsPopover ? 'renders' : 'does not render'} when hovered over
       ${button.id} button when user does not have access`, async () => {

--- a/src/Discovery/DiscoveryDetails/Components/FieldGrouping/TabField/DataDownloadList/ActionButtons/ActionsButtons.test.tsx
+++ b/src/Discovery/DiscoveryDetails/Components/FieldGrouping/TabField/DataDownloadList/ActionButtons/ActionsButtons.test.tsx
@@ -92,7 +92,8 @@ describe('ActionButtons', () => {
     expect(queryByText(buttonText)).toBeNull();
   };
 
-  const hoverOverButtonAndCheckText = async (button: HTMLElement, popoverText:string, popoverShouldRender:boolean) => {
+  const hoverOverButtonAndCheckText = async (button: HTMLElement, popoverText:string,
+    popoverShouldRender:boolean) => {
     fireEvent.mouseEnter(button);
     const popoverTextNode = screen.queryByText(popoverText);
     if (popoverShouldRender) {
@@ -104,14 +105,16 @@ describe('ActionButtons', () => {
     }
   };
 
-  const checkConditionalPopoverMissingRequiredIdentityProvidersInCommon = async (buttonTestID:string, popoverShouldRender:boolean) => {
+  const checkConditionalPopoverMissingRequiredIdentityProvidersInCommon = async (buttonTestID:string,
+    popoverShouldRender:boolean) => {
     render(
       <ActionButtons
         {...testProps}
         missingRequiredIdentityProviders={['InCommon']}
       />,
     );
-    const popoverText = 'This dataset is only accessible to users who have authenticated via InCommon. Please log in using the InCommon option.';
+    const popoverText = `This dataset is only accessible to users who have
+    authenticated via InCommon. Please log in using the InCommon option.`;
     const button = screen.getByTestId(buttonTestID);
     hoverOverButtonAndCheckText(button, popoverText, popoverShouldRender);
   };
@@ -131,7 +134,8 @@ describe('ActionButtons', () => {
     hoverOverButtonAndCheckText(button, popoverText, popoverShouldRender);
   };
 
-  const checkConditionalPopoverUserDoesNotHaveAccess = async (buttonTestID: string, popoverShouldRender:boolean) => {
+  const checkConditionalPopoverUserDoesNotHaveAccess = async (buttonTestID: string,
+    popoverShouldRender:boolean) => {
     render(
       <ActionButtons
         {...testProps}
@@ -232,7 +236,7 @@ describe('ActionButtons', () => {
       checkConditionalPopoverMissingRequiredIdentityProvidersMultiple(
         button.id,
         button.showsPopover,
-        );
+      );
     });
     test(`Popover ${button.showsPopover ? 'renders' : 'does not render'} when hovered over
       ${button.id} button when user does not have access`, async () => {

--- a/src/Discovery/DiscoveryDetails/Components/FieldGrouping/TabField/DataDownloadList/ActionButtons/ActionsButtons.test.tsx
+++ b/src/Discovery/DiscoveryDetails/Components/FieldGrouping/TabField/DataDownloadList/ActionButtons/ActionsButtons.test.tsx
@@ -104,19 +104,19 @@ describe('ActionButtons', () => {
 
   const hoverOverButtonAndCheckText = async (button, popOverText, popOverShouldRender) => {
     fireEvent.mouseEnter(button);
+    const popOverTextNode = screen.queryByText(popOverText);
     if (popOverShouldRender) {
       await waitFor(() => {
-        const popOverTextNode = screen.getByText(popOverText);
         expect(popOverTextNode).toBeInTheDocument();
       });
     } else {
-      const popOverTextNode = screen.queryByText(popOverText);
       expect(popOverTextNode).toBeNull();
     }
   };
 
-  const checkConditionalPopoverMissingRequiredIdentityProvidersInCommon = async (buttonTestID, popOverShouldRender) => {
-    const { getByText } = render(
+  const checkConditionalPopoverMissingRequiredIdentityProvidersInCommon =
+  async (buttonTestID:string, popOverShouldRender:boolean) => {
+    render(
       <ActionButtons
         isUserLoggedIn
         userHasAccessToDownload
@@ -135,7 +135,7 @@ describe('ActionButtons', () => {
     hoverOverButtonAndCheckText(button, popOverText, popOverShouldRender);
   };
 
-  const checkConditionalPopoverMissingRequiredIdentityProvidersMultiple = async (buttonTestID, popOverShouldRender) => {
+  const checkConditionalPopoverMissingRequiredIdentityProvidersMultiple = async (buttonTestID: string, popOverShouldRender:boolean) => {
     const missingRequiredIdentityProviders = ['InCommon', 'Google'];
     render(
       <ActionButtons

--- a/src/Discovery/DiscoveryDetails/Components/FieldGrouping/TabField/DataDownloadList/ActionButtons/ActionsButtons.test.tsx
+++ b/src/Discovery/DiscoveryDetails/Components/FieldGrouping/TabField/DataDownloadList/ActionButtons/ActionsButtons.test.tsx
@@ -114,8 +114,7 @@ describe('ActionButtons', () => {
     }
   };
 
-  const checkConditionalPopoverMissingRequiredIdentityProvidersInCommon =
-  async (buttonTestID:string, popOverShouldRender:boolean) => {
+  const checkConditionalPopoverMissingRequiredIdentityProvidersInCommon = async (buttonTestID:string, popOverShouldRender:boolean) => {
     render(
       <ActionButtons
         isUserLoggedIn
@@ -257,6 +256,7 @@ describe('ActionButtons', () => {
       'enableDownloadZip',
     );
   });
+
   /* Testing Conditional popover */
   const buttonIDsAndShowsPopover = [
     {
@@ -279,20 +279,20 @@ describe('ActionButtons', () => {
 
   buttonIDsAndShowsPopover.forEach((button) => {
     test(`Pop over ${button.showsPopover ? 'renders' : 'does not render'} when hovered over
-    ${button.id} button when missing required identity providers is InCommon`, async () => {
+      ${button.id} button when missing required identity providers is InCommon`, async () => {
       checkConditionalPopoverMissingRequiredIdentityProvidersInCommon(button.id, button.showsPopover);
     });
     test(`Pop over ${button.showsPopover ? 'renders' : 'does not render'} when hovered over
-    ${button.id} button when missing required identity providers is multiple`, async () => {
+      ${button.id} button when missing required identity providers is multiple`, async () => {
       checkConditionalPopoverMissingRequiredIdentityProvidersMultiple(button.id, button.showsPopover);
     });
     test(`Pop over ${button.showsPopover ? 'renders' : 'does not render'} when hovered over
-    ${button.id} button when User Does Not Have Access`, async () => {
+      ${button.id} button when User Does Not Have Access`, async () => {
       checkConditionalPopoverUserDoesNotHaveAccess(button.id, button.showsPopover);
     });
 
     test(`Pop over ${button.showsPopover ? 'renders' : 'does not render'} when hovered over
-    ${button.id} button when study has no data`, async () => {
+      ${button.id} button when study has no data`, async () => {
       checkConditionalPopoverNoData(button.id, button.showsPopover);
     });
   });

--- a/src/Discovery/DiscoveryDetails/Components/FieldGrouping/TabField/DataDownloadList/ActionButtons/ActionsButtons.test.tsx
+++ b/src/Discovery/DiscoveryDetails/Components/FieldGrouping/TabField/DataDownloadList/ActionButtons/ActionsButtons.test.tsx
@@ -44,20 +44,25 @@ describe('ActionButtons', () => {
     message: { content: <React.Fragment />, active: true, title: '' },
   };
 
+  const testProps = {
+    isUserLoggedIn: true,
+    userHasAccessToDownload: true,
+    discoveryConfig: mockDiscoveryConfig as DiscoveryConfig,
+    resourceInfo: mockResourceInfo as unknown as DiscoveryResource,
+    missingRequiredIdentityProviders: [],
+    noData: false,
+    downloadStatus: mockDownloadStatus as DownloadStatus,
+    setDownloadStatus: () => {},
+    history: {},
+    location: {},
+  };
+
   /* Helper Functions */
   const checkResourceInfoConditional = (buttonText: string) => {
     const { queryByText } = render(
       <ActionButtons
-        isUserLoggedIn
-        userHasAccessToDownload
-        discoveryConfig={mockDiscoveryConfig as DiscoveryConfig}
+        {...testProps}
         resourceInfo={{} as DiscoveryResource}
-        missingRequiredIdentityProviders={[]}
-        noData={false}
-        downloadStatus={mockDownloadStatus as DownloadStatus}
-        setDownloadStatus={() => {}}
-        history={{}}
-        location={{}}
       />,
     );
     // Check that the button is no longer rendered
@@ -70,16 +75,7 @@ describe('ActionButtons', () => {
   ) => {
     const { getByText, queryByText, rerender } = render(
       <ActionButtons
-        isUserLoggedIn
-        userHasAccessToDownload
-        discoveryConfig={mockDiscoveryConfig as DiscoveryConfig}
-        resourceInfo={mockResourceInfo as unknown as DiscoveryResource}
-        missingRequiredIdentityProviders={[]}
-        noData={false}
-        downloadStatus={mockDownloadStatus as DownloadStatus}
-        setDownloadStatus={() => {}}
-        history={{}}
-        location={{}}
+        {...testProps}
       />,
     );
     const targetButton = getByText(buttonText);
@@ -89,16 +85,8 @@ describe('ActionButtons', () => {
     changedConfig.features.exportToWorkspace[condition] = false;
     rerender(
       <ActionButtons
-        isUserLoggedIn
-        userHasAccessToDownload
+        {...testProps}
         discoveryConfig={changedConfig as DiscoveryConfig}
-        resourceInfo={mockResourceInfo as unknown as DiscoveryResource}
-        missingRequiredIdentityProviders={[]}
-        noData={false}
-        downloadStatus={mockDownloadStatus as DownloadStatus}
-        setDownloadStatus={() => {}}
-        history={{}}
-        location={{}}
       />,
     );
     // Check that the button is no longer rendered
@@ -120,16 +108,8 @@ describe('ActionButtons', () => {
   const checkConditionalPopoverMissingRequiredIdentityProvidersInCommon = async (buttonTestID:string, popoverShouldRender:boolean) => {
     render(
       <ActionButtons
-        isUserLoggedIn
-        userHasAccessToDownload
-        discoveryConfig={mockDiscoveryConfig as DiscoveryConfig}
-        resourceInfo={mockResourceInfo as unknown as DiscoveryResource}
+        {...testProps}
         missingRequiredIdentityProviders={['InCommon']}
-        noData={false}
-        downloadStatus={mockDownloadStatus as DownloadStatus}
-        setDownloadStatus={() => {}}
-        history={{}}
-        location={{}}
       />,
     );
     const popoverText = 'This dataset is only accessible to users who have authenticated via InCommon. Please log in using the InCommon option.';
@@ -141,16 +121,8 @@ describe('ActionButtons', () => {
     const missingRequiredIdentityProviders = ['InCommon', 'Google'];
     render(
       <ActionButtons
-        isUserLoggedIn
-        userHasAccessToDownload
-        discoveryConfig={mockDiscoveryConfig as DiscoveryConfig}
-        resourceInfo={mockResourceInfo as unknown as DiscoveryResource}
+        {...testProps}
         missingRequiredIdentityProviders={missingRequiredIdentityProviders}
-        noData={false}
-        downloadStatus={mockDownloadStatus as DownloadStatus}
-        setDownloadStatus={() => {}}
-        history={{}}
-        location={{}}
       />,
     );
     const popoverText = `Data selection requires [${missingRequiredIdentityProviders.join(', ')}]
@@ -163,16 +135,8 @@ describe('ActionButtons', () => {
   const checkConditionalPopoverUserDoesNotHaveAccess = async (buttonTestID: string, popoverShouldRender:boolean) => {
     render(
       <ActionButtons
-        isUserLoggedIn
-        userHasAccessToDownload={false}
-        discoveryConfig={mockDiscoveryConfig as DiscoveryConfig}
-        resourceInfo={mockResourceInfo as unknown as DiscoveryResource}
+        {...testProps}
         missingRequiredIdentityProviders={['InCommon']}
-        noData={false}
-        downloadStatus={mockDownloadStatus as DownloadStatus}
-        setDownloadStatus={() => {}}
-        history={{}}
-        location={{}}
       />,
     );
     const popoverText = 'You don\'t have access to this data';
@@ -182,16 +146,9 @@ describe('ActionButtons', () => {
   const checkConditionalPopoverNoData = async (buttonTestID: string, popoverShouldRender: boolean) => {
     render(
       <ActionButtons
+        {...testProps}
         isUserLoggedIn={false}
-        userHasAccessToDownload
-        discoveryConfig={mockDiscoveryConfig as DiscoveryConfig}
-        resourceInfo={mockResourceInfo as unknown as DiscoveryResource}
-        missingRequiredIdentityProviders={[]}
         noData
-        downloadStatus={mockDownloadStatus as DownloadStatus}
-        setDownloadStatus={() => {}}
-        history={{}}
-        location={{}}
       />,
     );
     const popoverText = 'This file is not available for the selected study';
@@ -217,19 +174,6 @@ describe('ActionButtons', () => {
     );
     expect(screen.queryByTestId('actionButtons')).toBeInTheDocument();
   });
-
-  const ActionButtonsTestProps = {
-    isUserLoggedIn: false,
-    userHasAccessToDownload: true,
-    discoveryConfig: mockDiscoveryConfig as DiscoveryConfig,
-    resourceInfo: mockResourceInfo as unknown as DiscoveryResource,
-    missingRequiredIdentityProviders: [],
-    noData: false,
-    downloadStatus: mockDownloadStatus as DownloadStatus,
-    setDownloadStatus: () => {},
-    history: {},
-    location: {},
-  };
   test('ActionButtons should have "Login to" text when not logged in', () => {
     render(
       <ActionButtons

--- a/src/Discovery/DiscoveryDetails/Components/FieldGrouping/TabField/DataDownloadList/ActionButtons/ActionsButtons.test.tsx
+++ b/src/Discovery/DiscoveryDetails/Components/FieldGrouping/TabField/DataDownloadList/ActionButtons/ActionsButtons.test.tsx
@@ -136,6 +136,7 @@ describe('ActionButtons', () => {
       <ActionButtons
         {...testProps}
         missingRequiredIdentityProviders={['InCommon']}
+        userHasAccessToDownload={false}
       />,
     );
     const popoverText = 'You don\'t have access to this data';

--- a/src/Discovery/DiscoveryDetails/Components/FieldGrouping/TabField/DataDownloadList/ActionButtons/ActionsButtons.test.tsx
+++ b/src/Discovery/DiscoveryDetails/Components/FieldGrouping/TabField/DataDownloadList/ActionButtons/ActionsButtons.test.tsx
@@ -220,20 +220,20 @@ describe('ActionButtons', () => {
   ];
 
   buttonIDsAndShowsPopover.forEach((button) => {
-    test(`Pop over ${button.showsPopover ? 'renders' : 'does not render'} when hovered over
+    test(`Popover ${button.showsPopover ? 'renders' : 'does not render'} when hovered over
       ${button.id} button when missing required identity providers is InCommon`, async () => {
       checkConditionalPopoverMissingRequiredIdentityProvidersInCommon(button.id, button.showsPopover);
     });
-    test(`Pop over ${button.showsPopover ? 'renders' : 'does not render'} when hovered over
+    test(`Popover ${button.showsPopover ? 'renders' : 'does not render'} when hovered over
       ${button.id} button when missing required identity providers is multiple`, async () => {
       checkConditionalPopoverMissingRequiredIdentityProvidersMultiple(button.id, button.showsPopover);
     });
-    test(`Pop over ${button.showsPopover ? 'renders' : 'does not render'} when hovered over
-      ${button.id} button when User Does Not Have Access`, async () => {
+    test(`Popover ${button.showsPopover ? 'renders' : 'does not render'} when hovered over
+      ${button.id} button when user does not have access`, async () => {
       checkConditionalPopoverUserDoesNotHaveAccess(button.id, button.showsPopover);
     });
 
-    test(`Pop over ${button.showsPopover ? 'renders' : 'does not render'} when hovered over
+    test(`Popover ${button.showsPopover ? 'renders' : 'does not render'} when hovered over
       ${button.id} button when study has no data`, async () => {
       checkConditionalPopoverNoData(button.id, button.showsPopover);
     });

--- a/src/Discovery/DiscoveryDetails/Components/FieldGrouping/TabField/DataDownloadList/ActionButtons/ActionsButtons.test.tsx
+++ b/src/Discovery/DiscoveryDetails/Components/FieldGrouping/TabField/DataDownloadList/ActionButtons/ActionsButtons.test.tsx
@@ -3,7 +3,6 @@ import {
   render, screen, fireEvent, waitFor,
 } from '@testing-library/react';
 import '@testing-library/jest-dom';
-import { TestScheduler } from 'jest';
 import ActionButtons from './ActionButtons';
 import { DiscoveryConfig } from '../../../../../../DiscoveryConfig';
 import { DiscoveryResource } from '../../../../../../Discovery';
@@ -160,16 +159,7 @@ describe('ActionButtons', () => {
   test('Renders test id for ActionButtons', () => {
     render(
       <ActionButtons
-        isUserLoggedIn
-        userHasAccessToDownload
-        discoveryConfig={mockDiscoveryConfig as DiscoveryConfig}
-        resourceInfo={mockResourceInfo as unknown as DiscoveryResource}
-        missingRequiredIdentityProviders={[]}
-        noData={false}
-        downloadStatus={mockDownloadStatus as DownloadStatus}
-        setDownloadStatus={() => {}}
-        history={{}}
-        location={{}}
+        {...testProps}
       />,
     );
     expect(screen.queryByTestId('actionButtons')).toBeInTheDocument();
@@ -177,16 +167,8 @@ describe('ActionButtons', () => {
   test('ActionButtons should have "Login to" text when not logged in', () => {
     render(
       <ActionButtons
+        {...testProps}
         isUserLoggedIn={false}
-        userHasAccessToDownload
-        discoveryConfig={mockDiscoveryConfig as DiscoveryConfig}
-        resourceInfo={mockResourceInfo as unknown as DiscoveryResource}
-        missingRequiredIdentityProviders={[]}
-        noData={false}
-        downloadStatus={mockDownloadStatus as DownloadStatus}
-        setDownloadStatus={() => {}}
-        history={{}}
-        location={{}}
       />,
     );
     const loginText = screen.getAllByText(/Login to/i);

--- a/src/Discovery/DiscoveryDetails/Components/FieldGrouping/TabField/DataDownloadList/ActionButtons/ActionsButtons.test.tsx
+++ b/src/Discovery/DiscoveryDetails/Components/FieldGrouping/TabField/DataDownloadList/ActionButtons/ActionsButtons.test.tsx
@@ -5,6 +5,9 @@ import {
 import '@testing-library/jest-dom';
 import { TestScheduler } from 'jest';
 import ActionButtons from './ActionButtons';
+import { DiscoveryConfig } from '../../../../../../DiscoveryConfig';
+import { DiscoveryResource } from '../../../../../../Discovery';
+import DownloadStatus from '../Interfaces/DownloadStatus';
 
 jest.mock('react-router-dom', () => ({
   useHistory: jest.fn().mockReturnValue(0),
@@ -22,7 +25,7 @@ describe('ActionButtons', () => {
         enableDownloadStudyMetadata: true,
         enableDownloadManifest: true,
         enableDownloadZip: true,
-        variableMetadataFieldName: true,
+        variableMetadataFieldName: 'test',
         enableDownloadVariableMetadata: true,
       },
     },
@@ -47,11 +50,11 @@ describe('ActionButtons', () => {
       <ActionButtons
         isUserLoggedIn
         userHasAccessToDownload
-        discoveryConfig={mockDiscoveryConfig}
-        resourceInfo={{}}
+        discoveryConfig={mockDiscoveryConfig as DiscoveryConfig}
+        resourceInfo={{} as DiscoveryResource}
         missingRequiredIdentityProviders={[]}
         noData={false}
-        downloadStatus={mockDownloadStatus}
+        downloadStatus={mockDownloadStatus as DownloadStatus}
         setDownloadStatus={() => {}}
         history={{}}
         location={{}}
@@ -69,11 +72,11 @@ describe('ActionButtons', () => {
       <ActionButtons
         isUserLoggedIn
         userHasAccessToDownload
-        discoveryConfig={mockDiscoveryConfig}
-        resourceInfo={mockResourceInfo}
+        discoveryConfig={mockDiscoveryConfig as DiscoveryConfig}
+        resourceInfo={mockResourceInfo as unknown as DiscoveryResource}
         missingRequiredIdentityProviders={[]}
         noData={false}
-        downloadStatus={mockDownloadStatus}
+        downloadStatus={mockDownloadStatus as DownloadStatus}
         setDownloadStatus={() => {}}
         history={{}}
         location={{}}
@@ -88,11 +91,11 @@ describe('ActionButtons', () => {
       <ActionButtons
         isUserLoggedIn
         userHasAccessToDownload
-        discoveryConfig={changedConfig}
-        resourceInfo={mockResourceInfo}
+        discoveryConfig={changedConfig as DiscoveryConfig}
+        resourceInfo={mockResourceInfo as unknown as DiscoveryResource}
         missingRequiredIdentityProviders={[]}
         noData={false}
-        downloadStatus={mockDownloadStatus}
+        downloadStatus={mockDownloadStatus as DownloadStatus}
         setDownloadStatus={() => {}}
         history={{}}
         location={{}}
@@ -102,98 +105,98 @@ describe('ActionButtons', () => {
     expect(queryByText(buttonText)).toBeNull();
   };
 
-  const hoverOverButtonAndCheckText = async (button, popOverText, popOverShouldRender) => {
+  const hoverOverButtonAndCheckText = async (button: HTMLElement, popoverText:string, popoverShouldRender:boolean) => {
     fireEvent.mouseEnter(button);
-    const popOverTextNode = screen.queryByText(popOverText);
-    if (popOverShouldRender) {
+    const popoverTextNode = screen.queryByText(popoverText);
+    if (popoverShouldRender) {
       await waitFor(() => {
-        expect(popOverTextNode).toBeInTheDocument();
+        expect(popoverTextNode).toBeInTheDocument();
       });
     } else {
-      expect(popOverTextNode).toBeNull();
+      expect(popoverTextNode).toBeNull();
     }
   };
 
-  const checkConditionalPopoverMissingRequiredIdentityProvidersInCommon = async (buttonTestID:string, popOverShouldRender:boolean) => {
+  const checkConditionalPopoverMissingRequiredIdentityProvidersInCommon = async (buttonTestID:string, popoverShouldRender:boolean) => {
     render(
       <ActionButtons
         isUserLoggedIn
         userHasAccessToDownload
-        discoveryConfig={mockDiscoveryConfig}
-        resourceInfo={mockResourceInfo}
+        discoveryConfig={mockDiscoveryConfig as DiscoveryConfig}
+        resourceInfo={mockResourceInfo as unknown as DiscoveryResource}
         missingRequiredIdentityProviders={['InCommon']}
         noData={false}
-        downloadStatus={mockDownloadStatus}
+        downloadStatus={mockDownloadStatus as DownloadStatus}
         setDownloadStatus={() => {}}
         history={{}}
         location={{}}
       />,
     );
-    const popOverText = 'This dataset is only accessible to users who have authenticated via InCommon. Please log in using the InCommon option.';
+    const popoverText = 'This dataset is only accessible to users who have authenticated via InCommon. Please log in using the InCommon option.';
     const button = screen.getByTestId(buttonTestID);
-    hoverOverButtonAndCheckText(button, popOverText, popOverShouldRender);
+    hoverOverButtonAndCheckText(button, popoverText, popoverShouldRender);
   };
 
-  const checkConditionalPopoverMissingRequiredIdentityProvidersMultiple = async (buttonTestID: string, popOverShouldRender:boolean) => {
+  const checkConditionalPopoverMissingRequiredIdentityProvidersMultiple = async (buttonTestID: string, popoverShouldRender:boolean) => {
     const missingRequiredIdentityProviders = ['InCommon', 'Google'];
     render(
       <ActionButtons
         isUserLoggedIn
         userHasAccessToDownload
-        discoveryConfig={mockDiscoveryConfig}
-        resourceInfo={mockResourceInfo}
+        discoveryConfig={mockDiscoveryConfig as DiscoveryConfig}
+        resourceInfo={mockResourceInfo as unknown as DiscoveryResource}
         missingRequiredIdentityProviders={missingRequiredIdentityProviders}
         noData={false}
-        downloadStatus={mockDownloadStatus}
+        downloadStatus={mockDownloadStatus as DownloadStatus}
         setDownloadStatus={() => {}}
         history={{}}
         location={{}}
       />,
     );
-    const popOverText = `Data selection requires [${missingRequiredIdentityProviders.join(', ')}]
+    const popoverText = `Data selection requires [${missingRequiredIdentityProviders.join(', ')}]
     credentials to access. Please change selection to only need one set of credentials
     and log in using appropriate credentials`;
     const button = screen.getByTestId(buttonTestID);
-    hoverOverButtonAndCheckText(button, popOverText, popOverShouldRender);
+    hoverOverButtonAndCheckText(button, popoverText, popoverShouldRender);
   };
 
-  const checkConditionalPopoverUserDoesNotHaveAccess = async (buttonTestID, popOverShouldRender) => {
+  const checkConditionalPopoverUserDoesNotHaveAccess = async (buttonTestID: string, popoverShouldRender:boolean) => {
     render(
       <ActionButtons
         isUserLoggedIn
         userHasAccessToDownload={false}
-        discoveryConfig={mockDiscoveryConfig}
-        resourceInfo={mockResourceInfo}
+        discoveryConfig={mockDiscoveryConfig as DiscoveryConfig}
+        resourceInfo={mockResourceInfo as unknown as DiscoveryResource}
         missingRequiredIdentityProviders={['InCommon']}
         noData={false}
-        downloadStatus={mockDownloadStatus}
+        downloadStatus={mockDownloadStatus as DownloadStatus}
         setDownloadStatus={() => {}}
         history={{}}
         location={{}}
       />,
     );
-    const popOverText = 'You don\'t have access to this data';
+    const popoverText = 'You don\'t have access to this data';
     const button = screen.getByTestId(buttonTestID);
-    hoverOverButtonAndCheckText(button, popOverText, popOverShouldRender);
+    hoverOverButtonAndCheckText(button, popoverText, popoverShouldRender);
   };
-  const checkConditionalPopoverNoData = async (buttonTestID, popOverShouldRender) => {
+  const checkConditionalPopoverNoData = async (buttonTestID: string, popoverShouldRender: boolean) => {
     render(
       <ActionButtons
         isUserLoggedIn={false}
         userHasAccessToDownload
-        discoveryConfig={mockDiscoveryConfig}
-        resourceInfo={mockResourceInfo}
+        discoveryConfig={mockDiscoveryConfig as DiscoveryConfig}
+        resourceInfo={mockResourceInfo as unknown as DiscoveryResource}
         missingRequiredIdentityProviders={[]}
         noData
-        downloadStatus={mockDownloadStatus}
+        downloadStatus={mockDownloadStatus as DownloadStatus}
         setDownloadStatus={() => {}}
         history={{}}
         location={{}}
       />,
     );
-    const popOverText = 'This file is not available for the selected study';
+    const popoverText = 'This file is not available for the selected study';
     const button = screen.getByTestId(buttonTestID);
-    hoverOverButtonAndCheckText(button, popOverText, popOverShouldRender);
+    hoverOverButtonAndCheckText(button, popoverText, popoverShouldRender);
   };
 
   /* Tests */
@@ -202,11 +205,11 @@ describe('ActionButtons', () => {
       <ActionButtons
         isUserLoggedIn
         userHasAccessToDownload
-        discoveryConfig={mockDiscoveryConfig}
-        resourceInfo={mockResourceInfo}
+        discoveryConfig={mockDiscoveryConfig as DiscoveryConfig}
+        resourceInfo={mockResourceInfo as unknown as DiscoveryResource}
         missingRequiredIdentityProviders={[]}
         noData={false}
-        downloadStatus={mockDownloadStatus}
+        downloadStatus={mockDownloadStatus as DownloadStatus}
         setDownloadStatus={() => {}}
         history={{}}
         location={{}}
@@ -215,16 +218,28 @@ describe('ActionButtons', () => {
     expect(screen.queryByTestId('actionButtons')).toBeInTheDocument();
   });
 
+  const ActionButtonsTestProps = {
+    isUserLoggedIn: false,
+    userHasAccessToDownload: true,
+    discoveryConfig: mockDiscoveryConfig as DiscoveryConfig,
+    resourceInfo: mockResourceInfo as unknown as DiscoveryResource,
+    missingRequiredIdentityProviders: [],
+    noData: false,
+    downloadStatus: mockDownloadStatus as DownloadStatus,
+    setDownloadStatus: () => {},
+    history: {},
+    location: {},
+  };
   test('ActionButtons should have "Login to" text when not logged in', () => {
     render(
       <ActionButtons
         isUserLoggedIn={false}
         userHasAccessToDownload
-        discoveryConfig={mockDiscoveryConfig}
-        resourceInfo={mockResourceInfo}
+        discoveryConfig={mockDiscoveryConfig as DiscoveryConfig}
+        resourceInfo={mockResourceInfo as unknown as DiscoveryResource}
         missingRequiredIdentityProviders={[]}
         noData={false}
-        downloadStatus={mockDownloadStatus}
+        downloadStatus={mockDownloadStatus as DownloadStatus}
         setDownloadStatus={() => {}}
         history={{}}
         location={{}}

--- a/src/Discovery/DiscoveryDetails/Components/FieldGrouping/TabField/DataDownloadList/ActionButtons/ActionsButtons.test.tsx
+++ b/src/Discovery/DiscoveryDetails/Components/FieldGrouping/TabField/DataDownloadList/ActionButtons/ActionsButtons.test.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import {
+  render, screen, fireEvent, waitFor,
+} from '@testing-library/react';
 import '@testing-library/jest-dom';
 import ActionButtons from './ActionButtons';
 import { DiscoveryConfig } from '../../../../../../DiscoveryConfig';
@@ -57,7 +59,7 @@ describe('ActionButtons', () => {
   /* Helper Functions */
   const checkResourceInfoConditional = (buttonText: string) => {
     const { queryByText } = render(
-      <ActionButtons {...testProps} resourceInfo={{} as DiscoveryResource} />
+      <ActionButtons {...testProps} resourceInfo={{} as DiscoveryResource} />,
     );
     // Check that the button is no longer rendered
     expect(queryByText(buttonText)).toBeNull();
@@ -65,10 +67,10 @@ describe('ActionButtons', () => {
 
   const checkExportToWorkspaceConditional = (
     buttonText: string,
-    condition: string
+    condition: string,
   ) => {
     const { getByText, queryByText, rerender } = render(
-      <ActionButtons {...testProps} />
+      <ActionButtons {...testProps} />,
     );
     const targetButton = getByText(buttonText);
     expect(targetButton).toBeInTheDocument();
@@ -79,7 +81,7 @@ describe('ActionButtons', () => {
       <ActionButtons
         {...testProps}
         discoveryConfig={changedConfig as DiscoveryConfig}
-      />
+      />,
     );
     // Check that the button is no longer rendered
     expect(queryByText(buttonText)).toBeNull();
@@ -88,7 +90,7 @@ describe('ActionButtons', () => {
   const hoverOverButtonAndCheckText = async (
     button: HTMLElement,
     popoverText: string,
-    popoverShouldRender: boolean
+    popoverShouldRender: boolean,
   ) => {
     fireEvent.mouseEnter(button);
     const popoverTextNode = screen.queryByText(popoverText);
@@ -101,56 +103,54 @@ describe('ActionButtons', () => {
     }
   };
 
-  const checkConditionalPopoverMissingRequiredIdentityProvidersInCommon =
-    async (buttonTestID: string, popoverShouldRender: boolean) => {
-      render(
-        <ActionButtons
-          {...testProps}
-          missingRequiredIdentityProviders={['InCommon']}
-        />
-      );
-      const popoverText = `This dataset is only accessible to users who have
+  const checkConditionalPopoverMissingRequiredIdentityProvidersInCommon = async (buttonTestID: string, popoverShouldRender: boolean) => {
+    render(
+      <ActionButtons
+        {...testProps}
+        missingRequiredIdentityProviders={['InCommon']}
+      />,
+    );
+    const popoverText = `This dataset is only accessible to users who have
     authenticated via InCommon. Please log in using the InCommon option.`;
-      const button = screen.getByTestId(buttonTestID);
-      hoverOverButtonAndCheckText(button, popoverText, popoverShouldRender);
-    };
+    const button = screen.getByTestId(buttonTestID);
+    hoverOverButtonAndCheckText(button, popoverText, popoverShouldRender);
+  };
 
-  const checkConditionalPopoverMissingRequiredIdentityProvidersMultiple =
-    async (buttonTestID: string, popoverShouldRender: boolean) => {
-      const missingRequiredIdentityProviders = ['InCommon', 'Google'];
-      render(
-        <ActionButtons
-          {...testProps}
-          missingRequiredIdentityProviders={missingRequiredIdentityProviders}
-        />
-      );
-      const popoverText = `Data selection requires [${missingRequiredIdentityProviders.join(
-        ', '
-      )}]
+  const checkConditionalPopoverMissingRequiredIdentityProvidersMultiple = async (buttonTestID: string, popoverShouldRender: boolean) => {
+    const missingRequiredIdentityProviders = ['InCommon', 'Google'];
+    render(
+      <ActionButtons
+        {...testProps}
+        missingRequiredIdentityProviders={missingRequiredIdentityProviders}
+      />,
+    );
+    const popoverText = `Data selection requires [${missingRequiredIdentityProviders.join(
+      ', ',
+    )}]
     credentials to access. Please change selection to only need one set of credentials
     and log in using appropriate credentials`;
-      const button = screen.getByTestId(buttonTestID);
-      hoverOverButtonAndCheckText(button, popoverText, popoverShouldRender);
-    };
+    const button = screen.getByTestId(buttonTestID);
+    hoverOverButtonAndCheckText(button, popoverText, popoverShouldRender);
+  };
 
   const checkConditionalPopoverUserDoesNotHaveAccess = async (
     buttonTestID: string,
-    popoverShouldRender: boolean
+    popoverShouldRender: boolean,
   ) => {
     render(
       <ActionButtons
         {...testProps}
         missingRequiredIdentityProviders={['InCommon']}
         userHasAccessToDownload={false}
-      />
+      />,
     );
-    const popoverText = "You don't have access to this data";
+    const popoverText = 'You don\'t have access to this data';
     const button = screen.getByTestId(buttonTestID);
     hoverOverButtonAndCheckText(button, popoverText, popoverShouldRender);
   };
   const checkConditionalPopoverNoData = async (
     buttonTestID: string,
-    popoverShouldRender: boolean
+    popoverShouldRender: boolean,
   ) => {
     render(<ActionButtons {...testProps} isUserLoggedIn={false} noData />);
     const popoverText = 'This file is not available for the selected study';
@@ -174,7 +174,7 @@ describe('ActionButtons', () => {
     const buttonText = 'Study-Level Metadata';
     checkExportToWorkspaceConditional(
       buttonText,
-      'enableDownloadStudyMetadata'
+      'enableDownloadStudyMetadata',
     );
     checkExportToWorkspaceConditional(buttonText, 'studyMetadataFieldName');
     checkResourceInfoConditional(buttonText);
@@ -182,13 +182,13 @@ describe('ActionButtons', () => {
   test('renders Download Manifest button based on conditionals', () => {
     checkExportToWorkspaceConditional(
       'Download Manifest',
-      'enableDownloadManifest'
+      'enableDownloadManifest',
     );
   });
   test('renders Download All Files button based on conditionals', () => {
     checkExportToWorkspaceConditional(
       'Download All Files',
-      'enableDownloadZip'
+      'enableDownloadZip',
     );
   });
 
@@ -217,22 +217,22 @@ describe('ActionButtons', () => {
       button.showsPopover ? 'renders' : 'does not render'
     } when hovered over
       ${
-        button.id
-      } button when missing required identity providers is InCommon`, async () => {
+  button.id
+} button when missing required identity providers is InCommon`, async () => {
       checkConditionalPopoverMissingRequiredIdentityProvidersInCommon(
         button.id,
-        button.showsPopover
+        button.showsPopover,
       );
     });
     test(`Popover ${
       button.showsPopover ? 'renders' : 'does not render'
     } when hovered over
       ${
-        button.id
-      } button when missing required identity providers is multiple`, async () => {
+  button.id
+} button when missing required identity providers is multiple`, async () => {
       checkConditionalPopoverMissingRequiredIdentityProvidersMultiple(
         button.id,
-        button.showsPopover
+        button.showsPopover,
       );
     });
     test(`Popover ${
@@ -241,7 +241,7 @@ describe('ActionButtons', () => {
       ${button.id} button when user does not have access`, async () => {
       checkConditionalPopoverUserDoesNotHaveAccess(
         button.id,
-        button.showsPopover
+        button.showsPopover,
       );
     });
 

--- a/src/Discovery/DiscoveryDetails/Components/FieldGrouping/TabField/DataDownloadList/ActionButtons/ActionsButtons.test.tsx
+++ b/src/Discovery/DiscoveryDetails/Components/FieldGrouping/TabField/DataDownloadList/ActionButtons/ActionsButtons.test.tsx
@@ -180,7 +180,7 @@ describe('ActionButtons', () => {
   const checkConditionalPopoverNoData = async (buttonTestID, popOverShouldRender) => {
     render(
       <ActionButtons
-        isUserLoggedIn
+        isUserLoggedIn={false}
         userHasAccessToDownload
         discoveryConfig={mockDiscoveryConfig}
         resourceInfo={mockResourceInfo}
@@ -198,7 +198,6 @@ describe('ActionButtons', () => {
   };
 
   /* Tests */
-
   test('Renders test id for ActionButtons', () => {
     render(
       <ActionButtons
@@ -291,11 +290,10 @@ describe('ActionButtons', () => {
     ${button.id} button when User Does Not Have Access`, async () => {
       checkConditionalPopoverUserDoesNotHaveAccess(button.id, button.showsPopover);
     });
-    /*
+
     test(`Pop over ${button.showsPopover ? 'renders' : 'does not render'} when hovered over
     ${button.id} button when study has no data`, async () => {
       checkConditionalPopoverNoData(button.id, button.showsPopover);
     });
-    */
   });
 });


### PR DESCRIPTION
Link to JIRA ticket if there is one: 
https://ctds-planx.atlassian.net/browse/HP-1415

**Dev Notes**
* Removed the ``` ConditionalPopover``` from only the Study level meta data button, the variable level meta data button did not have one wrapping it.  
* Adds unit tests for conditional wrapper logic and updated unit test to use test props

##### Before
<img width="722" alt="image" src="https://github.com/uc-cdis/data-portal/assets/113449836/ee22d4cd-613f-411a-a898-19a5df8635af">

##### After
![output](https://github.com/uc-cdis/data-portal/assets/113449836/bdca4ed3-53aa-4715-aed0-863f958570bf)


### New Features
* Updates the Download Study Level Metadata button to not render a popover

### Improvements
* Refactored Actions Buttons Test to increase coverage and concision 