### PR TITLE
Fix/slmd button not clickable

### DIFF
--- a/src/Discovery/DiscoveryDetails/Components/FieldGrouping/TabField/DataDownloadList/ActionButtons/ActionButtons.tsx
+++ b/src/Discovery/DiscoveryDetails/Components/FieldGrouping/TabField/DataDownloadList/ActionButtons/ActionButtons.tsx
@@ -48,6 +48,9 @@ const ActionButtons = ({
   if (manifestFieldName) {
     fileManifest = resourceInfo?.[manifestFieldName] || [];
   }
+
+  // Study level metabutton should show only if the downloading study level metadata value is enabled
+  // and resourceInfo includes the study metadata field name reference from the discovery config
   const showDownloadStudyLevelMetadataButton = Boolean(
     discoveryConfig?.features.exportToWorkspace.enableDownloadStudyMetadata
       && studyMetadataFieldNameReference
@@ -159,7 +162,7 @@ const ActionButtons = ({
             <Button
               className='discovery-action-bar-button'
               data-testid='download-study-level-metadata'
-              disabled={Boolean(noData || downloadStatus.inProgress)}
+              disabled={Boolean(downloadStatus.inProgress)}
               onClick={() => DownloadJsonFile(
                 'study-level-metadata',
                 studyMetadataFieldNameReference

--- a/src/Discovery/DiscoveryDetails/Components/FieldGrouping/TabField/DataDownloadList/ActionButtons/ActionsButtons.test.tsx
+++ b/src/Discovery/DiscoveryDetails/Components/FieldGrouping/TabField/DataDownloadList/ActionButtons/ActionsButtons.test.tsx
@@ -175,7 +175,12 @@ describe('ActionButtons', () => {
       study_id: 'mockStudyId',
       // study_metadata: true, <-- deliberately commented out for testing
     };
-    render(<ActionButtons {...testProps} resourceInfo={resourceInfoWithoutStudyMetadataKey as unknown as DiscoveryResource} />);
+    render(
+    <ActionButtons
+      {...testProps}
+      resourceInfo={resourceInfoWithoutStudyMetadataKey as unknown as DiscoveryResource}
+    />
+    );
     expect(screen.queryByTestId('download-study-level-metadata')).toBeNull();
   });
   test('renders Download Study-Level Metadata button based on conditionals', () => {

--- a/src/Discovery/DiscoveryDetails/Components/FieldGrouping/TabField/DataDownloadList/ActionButtons/ActionsButtons.test.tsx
+++ b/src/Discovery/DiscoveryDetails/Components/FieldGrouping/TabField/DataDownloadList/ActionButtons/ActionsButtons.test.tsx
@@ -170,6 +170,16 @@ describe('ActionButtons', () => {
     expect(loginText[1]).toBeInTheDocument();
   });
 
+  test(`Study Level metadata button should not render when
+   the resourceInfo does not includes the study metadata field name
+   reference from the discovery config`, () => {
+    const resourceInfoWithoutStudyMetadataKey = {
+      study_id: 'mockStudyId',
+      // study_metadata: true, <-- deliberately commented out for testing
+    };
+    render(<ActionButtons {...testProps} resourceInfo={resourceInfoWithoutStudyMetadataKey as unknown as DiscoveryResource} />);
+    expect(screen.queryByTestId('download-study-level-metadata')).toBeNull();
+  });
   test('renders Download Study-Level Metadata button based on conditionals', () => {
     const buttonText = 'Study-Level Metadata';
     checkExportToWorkspaceConditional(

--- a/src/Discovery/DiscoveryDetails/Components/FieldGrouping/TabField/DataDownloadList/ActionButtons/ActionsButtons.test.tsx
+++ b/src/Discovery/DiscoveryDetails/Components/FieldGrouping/TabField/DataDownloadList/ActionButtons/ActionsButtons.test.tsx
@@ -169,10 +169,8 @@ describe('ActionButtons', () => {
     expect(loginText[0]).toBeInTheDocument();
     expect(loginText[1]).toBeInTheDocument();
   });
-
-  test(`Study Level metadata button should not render when
-   the resourceInfo does not includes the study metadata field name
-   reference from the discovery config`, () => {
+  test(`Study Level metadata button should not render when the resourceInfo does not include
+    the study metadata field name reference from the discovery config`, () => {
     const resourceInfoWithoutStudyMetadataKey = {
       study_id: 'mockStudyId',
       // study_metadata: true, <-- deliberately commented out for testing


### PR DESCRIPTION
Link to JIRA ticket if there is one: 
https://ctds-planx.atlassian.net/browse/HP-1454

**Screen Shots**
Before:
<img width="1495" alt="image" src="https://github.com/uc-cdis/data-portal/assets/113449836/31fbfcef-e131-421c-bea3-201544844300">

After: 
<img width="1495" alt="image" src="https://github.com/uc-cdis/data-portal/assets/113449836/cf0cf45e-dd37-4f3b-8f02-df4f172544d6">


### Bug Fixes
* Updates the logic for the study level metadata button so it is not disabled even when there is noData 

### Improvements
* Adds unit test to ensure study level metadata button does not render when the resourceInfo does not include
    the study metadata field name reference from the discovery config
