### PR TITLE
Feat/input validation heal data dictionary field

### DIFF
--- a/src/Discovery/DiscoveryDetails/Components/FieldGrouping/TabField/DataDownloadList/ActionButtons/DownloadUtils/DownloadVariableMetadata/SanitizeFileName.test.ts
+++ b/src/Discovery/DiscoveryDetails/Components/FieldGrouping/TabField/DataDownloadList/ActionButtons/DownloadUtils/DownloadVariableMetadata/SanitizeFileName.test.ts
@@ -1,9 +1,7 @@
 import SanitizeFileName from './SanitizeFileName';
 import { validFileNameChecks } from '../../../../../../../../../utils';
 
-const {
-  invalidWindowsFileNames,
-} = validFileNameChecks;
+const { invalidWindowsFileNames } = validFileNameChecks;
 
 describe('SanitizeFileName', () => {
   it(`should sanitize a file name with valid characters and return the

--- a/src/Discovery/DiscoveryDetails/Components/FieldGrouping/TabField/DataDownloadList/ActionButtons/DownloadUtils/DownloadVariableMetadata/SanitizeFileName.ts
+++ b/src/Discovery/DiscoveryDetails/Components/FieldGrouping/TabField/DataDownloadList/ActionButtons/DownloadUtils/DownloadVariableMetadata/SanitizeFileName.ts
@@ -1,6 +1,5 @@
 import { validFileNameChecks } from '../../../../../../../../../utils';
 
-
 const SanitizeFileName = (unSanitizedfileName: string) => {
   let fileName = unSanitizedfileName;
   const fileExtension = '.json';

--- a/src/Discovery/DiscoveryDetails/Components/FieldGrouping/TabField/DataDownloadList/ActionButtons/DownloadUtils/DownloadVariableMetadata/SanitizeFileName.ts
+++ b/src/Discovery/DiscoveryDetails/Components/FieldGrouping/TabField/DataDownloadList/ActionButtons/DownloadUtils/DownloadVariableMetadata/SanitizeFileName.ts
@@ -1,20 +1,15 @@
 import { validFileNameChecks } from '../../../../../../../../../utils';
 
-const {
-  fileNameCharactersCheckRegex,
-  invalidWindowsFileNames,
-  maximumAllowedFileNameLength,
-} = validFileNameChecks;
 
 const SanitizeFileName = (unSanitizedfileName: string) => {
   let fileName = unSanitizedfileName;
   const fileExtension = '.json';
   // Replace all invalid file name characters
-  fileName = fileName.replace(fileNameCharactersCheckRegex, '');
+  fileName = fileName.replace(validFileNameChecks.fileNameCharactersCheckRegex, '');
   // Trim excessive filename characters
-  fileName = fileName.substring(0, maximumAllowedFileNameLength - fileExtension.length);
+  fileName = fileName.substring(0, validFileNameChecks.maximumAllowedFileNameLength - fileExtension.length);
   // Ensure file name is not an invalid Window's file name
-  invalidWindowsFileNames.forEach((invalidName) => {
+  validFileNameChecks.invalidWindowsFileNames.forEach((invalidName) => {
     if (invalidName === fileName) {
       fileName += '_';
     }

--- a/src/Discovery/DiscoveryDetails/Components/FieldGrouping/TabField/DataDownloadList/ActionButtons/DownloadUtils/DownloadVariableMetadata/SanitizeFileName.ts
+++ b/src/Discovery/DiscoveryDetails/Components/FieldGrouping/TabField/DataDownloadList/ActionButtons/DownloadUtils/DownloadVariableMetadata/SanitizeFileName.ts
@@ -1,8 +1,13 @@
-import { fileNameCharactersCheckRegex, invalidWindowsFileNames } from '../../../../../../../../../utils';
+import { validFileNameChecks } from '../../../../../../../../../utils';
+
+const {
+  fileNameCharactersCheckRegex,
+  invalidWindowsFileNames,
+  maximumAllowedFileNameLength,
+} = validFileNameChecks;
 
 const SanitizeFileName = (unSanitizedfileName: string) => {
   let fileName = unSanitizedfileName;
-  const maximumAllowedFileNameLength = 250;
   const fileExtension = '.json';
   // Replace all invalid file name characters
   fileName = fileName.replace(fileNameCharactersCheckRegex, '');

--- a/src/StudyRegistration/DataDictionarySubmission.tsx
+++ b/src/StudyRegistration/DataDictionarySubmission.tsx
@@ -342,12 +342,13 @@ const DataDictionarySubmission: React.FunctionComponent<StudyRegistrationProps> 
           <Form.Item
             name='Data Dictionary Name'
             label='Data Dictionary Name'
-            rules={[{ required: true },
+            initialValue=''
+            rules={[
               {
                 validator: handleDataDictionaryNameValidation,
-                validateTrigger: 'onChange',
-              }]}
-            extra={'Supported file types: CSV, TSV, JSON; Maximum file size: 10MB'}
+              },
+              { required: true },
+            ]}
           >
             <Input />
           </Form.Item>

--- a/src/StudyRegistration/DataDictionarySubmission.tsx
+++ b/src/StudyRegistration/DataDictionarySubmission.tsx
@@ -26,7 +26,7 @@ import { Link, useLocation } from 'react-router-dom';
 import {
   hostname, kayakoConfig, studyRegistrationConfig, useArboristUI,
 } from '../localconf';
-import { cleanUpFileRecord, generatePresignedURL } from './utils';
+import { cleanUpFileRecord, generatePresignedURL, handleDataDictionaryNameValidation } from './utils';
 import { createKayakoTicket } from '../utils';
 import { userHasMethodForServiceOnResource } from '../authMappingUtils';
 import { StudyRegistrationProps } from './StudyRegistration';
@@ -342,7 +342,12 @@ const DataDictionarySubmission: React.FunctionComponent<StudyRegistrationProps> 
           <Form.Item
             name='Data Dictionary Name'
             label='Data Dictionary Name'
-            rules={[{ required: true }]}
+            rules={[{ required: true },
+              {
+                validator: handleDataDictionaryNameValidation,
+                validateTrigger: 'onChange',
+              }]}
+            extra={'Supported file types: CSV, TSV, JSON; Maximum file size: 10MB'}
           >
             <Input />
           </Form.Item>

--- a/src/StudyRegistration/DataDictionarySubmission.tsx
+++ b/src/StudyRegistration/DataDictionarySubmission.tsx
@@ -342,7 +342,6 @@ const DataDictionarySubmission: React.FunctionComponent<StudyRegistrationProps> 
           <Form.Item
             name='Data Dictionary Name'
             label='Data Dictionary Name'
-            initialValue=''
             rules={[
               {
                 validator: handleDataDictionaryNameValidation,

--- a/src/StudyRegistration/utils.test.ts
+++ b/src/StudyRegistration/utils.test.ts
@@ -11,12 +11,11 @@ describe('Tests for handleDataDictionaryNameValidation', () => {
     const numberOfFileNameTests = 500;
     for (let i = 0; i < numberOfFileNameTests; i += 1) {
       const randomAlphaNumericString = Math.random().toString(36).slice(2);
-      const otherAllowedCharacters = '_-()[]'.split('');
+      const otherAllowedCharacters = '_-()[].'.split('');
       const randomAllowedCharter = otherAllowedCharacters[
         Math.floor(Math.random() * (otherAllowedCharacters.length))
       ];
       const testFileName = randomAlphaNumericString + randomAllowedCharter;
-      console.log(testFileName)
       await expect(handleDataDictionaryNameValidation({}, testFileName)).resolves.toBe(true);
     }
   });

--- a/src/StudyRegistration/utils.test.ts
+++ b/src/StudyRegistration/utils.test.ts
@@ -1,18 +1,26 @@
-import SanitizeFileName from './SanitizeFileName';
-import { validFileNameChecks } from '../../../../../../../../../utils';
+/* eslint-disable no-await-in-loop */
+import { handleDataDictionaryNameValidation } from './utils';
+import { validFileNameChecks } from '../utils';
 
-const {
-  invalidWindowsFileNames,
-} = validFileNameChecks;
-
-describe('SanitizeFileName', () => {
-  it(`should sanitize a file name with valid characters and return the
-      original name if it is within the maximum length and not an invalid name`, () => {
-    const unSanitizedValidFileName = 'myFile-with_valid_characters123';
-    const expectedSanitizedFileName = `${unSanitizedValidFileName}.json`;
-    expect(SanitizeFileName(unSanitizedValidFileName)).toBe(expectedSanitizedFileName);
+describe('Tests for handleDataDictionaryNameValidation', () => {
+  it('should accept a file name with valid characters', async () => {
+    const validFileName = 'myFile-with_valid_characters123[]()_ .';
+    await expect(handleDataDictionaryNameValidation({}, validFileName)).resolves.toBe(true);
+  });
+  it('should reject file names that use a reserved filename', async () => {
+    for (let i = 0; i < validFileNameChecks.invalidWindowsFileNames.length; i += 1) {
+      const invalidFileName = validFileNameChecks.invalidWindowsFileNames[i];
+      await expect(handleDataDictionaryNameValidation({}, invalidFileName)).rejects.toBe(
+        'Data Dictionary name is a reserved file name, please pick a different name.');
+    }
+  });
+  it('should reject a file name with greater than the allowed number of characters', async () => {
+    const invalidFileName = 'a'.repeat(251);
+    await expect(handleDataDictionaryNameValidation({}, invalidFileName)).rejects.toBe(
+      'File name length is greater than 250 characters');
   });
 
+  /*
   it(`should sanitize a file name with a single invalid character and
     return a sanitized name`, () => {
     const unSanitizedFileName = 'Staff participants: Baseline measures';
@@ -41,11 +49,12 @@ describe('SanitizeFileName', () => {
     });
   });
 
-  it('should truncate file name if it exceeds the maximum allowed length', () => {
+  it('should reject file name if it exceeds the maximum allowed length', () => {
     const unSanitizedFileName = `${'a'.repeat(251)}.json`;
     const expectedSanitizedFileName = `${'a'.repeat(245)}.json`;
     expect(SanitizeFileName(unSanitizedFileName)).toBe(
       expectedSanitizedFileName,
     );
   });
+  */
 });

--- a/src/StudyRegistration/utils.test.ts
+++ b/src/StudyRegistration/utils.test.ts
@@ -7,11 +7,24 @@ describe('Tests for handleDataDictionaryNameValidation', () => {
     const validFileName = 'myFile-with_valid_characters123[]()_ .';
     await expect(handleDataDictionaryNameValidation({}, validFileName)).resolves.toBe(true);
   });
-  it('should reject a file name with invalid characters', async () => {
-    const badCharacters = '/:\\*?"<>|:;@#༺$$صباح﷽ㅏ€҉܏܏܏܏܏܏Ɯ܏܏␀😨😧😦😱😫😩🐔🐓ㅑㅕㅛㅠㅡㅣㄷㅍㅎ%^&*:!‮'.split('');
-    for (let i = 0; i < validFileNameChecks.invalidWindowsFileNames.length; i += 1) {
+  it('should accept a variety of file names with valid characters', async () => {
+    const numberOfFileNameTests = 500;
+    for (let i = 0; i < numberOfFileNameTests; i += 1) {
       const randomAlphaNumericString = Math.random().toString(36).slice(2);
-      const invalidFileName = randomAlphaNumericString + badCharacters[i];
+      const otherAllowedCharacters = '_-()[]'.split('');
+      const randomAllowedCharter = otherAllowedCharacters[
+        Math.floor(Math.random() * (otherAllowedCharacters.length))
+      ];
+      const testFileName = randomAlphaNumericString + randomAllowedCharter;
+      await expect(handleDataDictionaryNameValidation({}, testFileName)).resolves.toBe(true);
+    }
+  });
+  it('should reject a file name with invalid characters', async () => {
+    const badCharacters = '/:\\*?"<>|:;@#༺$$صباح﷽ㅏ€҉܏܏܏܏܏܏Ɯ܏܏␀😨😧😦😱😫😩🐔🐓ㅑㅕㅛㅠㅡㅣㄷㅍㅎ%^&*:!‮';
+    const badCharactersArray = badCharacters.split('');
+    for (let i = 0; i < badCharactersArray.length; i += 1) {
+      const randomAlphaNumericString = Math.random().toString(36).slice(2);
+      const invalidFileName = randomAlphaNumericString + badCharactersArray[i];
       await expect(handleDataDictionaryNameValidation({}, invalidFileName)).rejects.toBe(
         'Data Dictionary name can only use alphabetic and numeric characters, and []() ._-');
     }
@@ -24,46 +37,8 @@ describe('Tests for handleDataDictionaryNameValidation', () => {
     }
   });
   it('should reject a file name with greater than the allowed number of characters', async () => {
-    const invalidFileName = 'a'.repeat(251);
+    const invalidFileName = 'a'.repeat(validFileNameChecks.maximumAllowedFileNameLength + 1);
     await expect(handleDataDictionaryNameValidation({}, invalidFileName)).rejects.toBe(
       'Data Dictionary name length is greater than 250 characters');
   });
-
-  /*
-  it(`should sanitize a file name with a single invalid character and
-    return a sanitized name`, () => {
-    const unSanitizedFileName = 'Staff participants: Baseline measures';
-    const expectedSanitizedFileName = 'Staff participants Baseline measures.json';
-    expect(SanitizeFileName(unSanitizedFileName)).toBe(
-      expectedSanitizedFileName,
-    );
-  });
-
-  it(`should sanitize a file name with many invalid characters and return the
-      sanitized name`, () => {
-    const unSanitizedFileName = '/:\\*?"<>|My :;@#༺$$صباح﷽ㅏ€҉܏܏܏܏܏܏Ɯ܏܏␀😨😧😦😱😫😩🐔🐓ㅑㅕㅛㅠㅡㅣㄷㅍㅎ%^&*F:il!e‮';
-    const expectedSanitizedFileName = 'My File.json';
-    expect(SanitizeFileName(unSanitizedFileName)).toBe(
-      expectedSanitizedFileName,
-    );
-  });
-
-  it(`should sanitize invalid Window's file names and return a
-      sanitized name with a underscore appended before the file extension`, () => {
-    invalidWindowsFileNames.forEach((invalidName) => {
-      const expectedSanitizedFileName = `${invalidName}_.json`;
-      expect(SanitizeFileName(invalidName)).toBe(
-        expectedSanitizedFileName,
-      );
-    });
-  });
-
-  it('should reject file name if it exceeds the maximum allowed length', () => {
-    const unSanitizedFileName = `${'a'.repeat(251)}.json`;
-    const expectedSanitizedFileName = `${'a'.repeat(245)}.json`;
-    expect(SanitizeFileName(unSanitizedFileName)).toBe(
-      expectedSanitizedFileName,
-    );
-  });
-  */
 });

--- a/src/StudyRegistration/utils.test.ts
+++ b/src/StudyRegistration/utils.test.ts
@@ -7,6 +7,15 @@ describe('Tests for handleDataDictionaryNameValidation', () => {
     const validFileName = 'myFile-with_valid_characters123[]()_ .';
     await expect(handleDataDictionaryNameValidation({}, validFileName)).resolves.toBe(true);
   });
+  it('should reject a file name with invalid characters', async () => {
+    const badCharacters = '/:\\*?"<>|:;@#༺$$صباح﷽ㅏ€҉܏܏܏܏܏܏Ɯ܏܏␀😨😧😦😱😫😩🐔🐓ㅑㅕㅛㅠㅡㅣㄷㅍㅎ%^&*:!‮'.split('');
+    for (let i = 0; i < validFileNameChecks.invalidWindowsFileNames.length; i += 1) {
+      const randomAlphaNumericString = Math.random().toString(36).slice(2);
+      const invalidFileName = randomAlphaNumericString + badCharacters[i];
+      await expect(handleDataDictionaryNameValidation({}, invalidFileName)).rejects.toBe(
+        'Data Dictionary name can only use alphabetic and numeric characters, and []() ._-');
+    }
+  });
   it('should reject file names that use a reserved filename', async () => {
     for (let i = 0; i < validFileNameChecks.invalidWindowsFileNames.length; i += 1) {
       const invalidFileName = validFileNameChecks.invalidWindowsFileNames[i];
@@ -17,7 +26,7 @@ describe('Tests for handleDataDictionaryNameValidation', () => {
   it('should reject a file name with greater than the allowed number of characters', async () => {
     const invalidFileName = 'a'.repeat(251);
     await expect(handleDataDictionaryNameValidation({}, invalidFileName)).rejects.toBe(
-      'File name length is greater than 250 characters');
+      'Data Dictionary name length is greater than 250 characters');
   });
 
   /*

--- a/src/StudyRegistration/utils.test.ts
+++ b/src/StudyRegistration/utils.test.ts
@@ -16,6 +16,7 @@ describe('Tests for handleDataDictionaryNameValidation', () => {
         Math.floor(Math.random() * (otherAllowedCharacters.length))
       ];
       const testFileName = randomAlphaNumericString + randomAllowedCharter;
+      console.log(testFileName)
       await expect(handleDataDictionaryNameValidation({}, testFileName)).resolves.toBe(true);
     }
   });

--- a/src/StudyRegistration/utils.tsx
+++ b/src/StudyRegistration/utils.tsx
@@ -2,6 +2,7 @@ import {
   studyRegistrationConfig, discoveryConfig, mdsURL, cedarWrapperURL, userAPIPath, requestorPath,
 } from '../localconf';
 import { fetchWithCreds } from '../actions';
+import { validFileNameChecks } from '../utils';
 
 const STUDY_DATA_FIELD = 'gen3_discovery'; // field in the MDS response that contains the study data
 
@@ -42,12 +43,12 @@ export const preprocessStudyRegistrationMetadata = async (username, metadataID, 
         repository_study_ID: studyId,
       }));
     } else if (updatedValues.repository) {
-        tempStudyIDObj = [{
-          repository_name: updatedValues.repository,
-          repository_study_ID: '',
-          repository_study_link: '',
-          repository_persistent_ID: '',
-      }]
+      tempStudyIDObj = [{
+        repository_name: updatedValues.repository,
+        repository_study_ID: '',
+        repository_study_link: '',
+        repository_persistent_ID: '',
+      }];
     }
     metadataToUpdate[STUDY_DATA_FIELD].study_metadata.metadata_location.data_repositories = tempStudyIDObj;
 
@@ -171,4 +172,25 @@ export const doesUserHaveRequestPending = async (
     throw new Error(`Encountered error while checking for existing request: ${JSON.stringify(res)}`);
   }
   return !!res.data?.length;
+};
+
+
+
+export const handleDataDictionaryNameValidation = (_:object, userInput:string): Promise<boolean|void> => {
+  // console.log('here:', userInput);
+  const {
+    fileNameCharactersCheckRegex,
+    invalidWindowsFileNames,
+    maximumAllowedFileNameLength,
+  } = validFileNameChecks;
+  if (userInput.length > maximumAllowedFileNameLength) {
+    return Promise.reject(`File name length is greater than ${maximumAllowedFileNameLength} characters`);
+  }
+  if (invalidWindowsFileNames.includes(userInput)) {
+    return Promise.reject('Data Dictionary name is a reserved file name, please pick a different name.');
+  }
+  if (userInput.includes('@')) {
+    return Promise.reject('Data Dictionary name can only use alphabetic and numeric characters, and []() ._-');
+  }
+  return Promise.resolve(true);
 };

--- a/src/StudyRegistration/utils.tsx
+++ b/src/StudyRegistration/utils.tsx
@@ -177,7 +177,7 @@ export const doesUserHaveRequestPending = async (
 export const handleDataDictionaryNameValidation = (_:object, userInput:string): Promise<boolean|void> => {
   if (userInput.length > validFileNameChecks.maximumAllowedFileNameLength) {
     return Promise.reject(
-      `Data Dictionary name length is greater than ${validFileNameChecks.maximumAllowedFileNameLength} characters`
+      `Data Dictionary name length is greater than ${validFileNameChecks.maximumAllowedFileNameLength} characters`,
     );
   }
   if (validFileNameChecks.invalidWindowsFileNames.includes(userInput)) {

--- a/src/StudyRegistration/utils.tsx
+++ b/src/StudyRegistration/utils.tsx
@@ -175,7 +175,6 @@ export const doesUserHaveRequestPending = async (
 };
 
 export const handleDataDictionaryNameValidation = (_:object, userInput:string): Promise<boolean|void> => {
-  // console.log('here:', userInput);
   const {
     invalidWindowsFileNames,
     maximumAllowedFileNameLength,
@@ -187,9 +186,7 @@ export const handleDataDictionaryNameValidation = (_:object, userInput:string): 
     return Promise.reject('Data Dictionary name is a reserved file name, please pick a different name.');
   }
   if (userInput.match(validFileNameChecks.fileNameCharactersCheckRegex)) {
-    console.log('trigged rejection');
     return Promise.reject('Data Dictionary name can only use alphabetic and numeric characters, and []() ._-');
   }
-
   return Promise.resolve(true);
 };

--- a/src/StudyRegistration/utils.tsx
+++ b/src/StudyRegistration/utils.tsx
@@ -175,14 +175,12 @@ export const doesUserHaveRequestPending = async (
 };
 
 export const handleDataDictionaryNameValidation = (_:object, userInput:string): Promise<boolean|void> => {
-  const {
-    invalidWindowsFileNames,
-    maximumAllowedFileNameLength,
-  } = validFileNameChecks;
-  if (userInput.length > maximumAllowedFileNameLength) {
-    return Promise.reject(`Data Dictionary name length is greater than ${maximumAllowedFileNameLength} characters`);
+  if (userInput.length > validFileNameChecks.maximumAllowedFileNameLength) {
+    return Promise.reject(
+      `Data Dictionary name length is greater than ${validFileNameChecks.maximumAllowedFileNameLength} characters`
+    );
   }
-  if (invalidWindowsFileNames.includes(userInput)) {
+  if (validFileNameChecks.invalidWindowsFileNames.includes(userInput)) {
     return Promise.reject('Data Dictionary name is a reserved file name, please pick a different name.');
   }
   if (userInput.match(validFileNameChecks.fileNameCharactersCheckRegex)) {

--- a/src/StudyRegistration/utils.tsx
+++ b/src/StudyRegistration/utils.tsx
@@ -174,23 +174,26 @@ export const doesUserHaveRequestPending = async (
   return !!res.data?.length;
 };
 
-
-
 export const handleDataDictionaryNameValidation = (_:object, userInput:string): Promise<boolean|void> => {
   // console.log('here:', userInput);
   const {
-    fileNameCharactersCheckRegex,
     invalidWindowsFileNames,
     maximumAllowedFileNameLength,
   } = validFileNameChecks;
+  console.log('userInput', userInput);
+  if (userInput.length > maximumAllowedFileNameLength) {
+    return Promise.reject('File name contains invalid characters');
+  }
   if (userInput.length > maximumAllowedFileNameLength) {
     return Promise.reject(`File name length is greater than ${maximumAllowedFileNameLength} characters`);
   }
   if (invalidWindowsFileNames.includes(userInput)) {
     return Promise.reject('Data Dictionary name is a reserved file name, please pick a different name.');
   }
-  if (userInput.includes('@')) {
+  if (userInput.match(validFileNameChecks.fileNameCharactersCheckRegex)) {
+    console.log('trigged rejection');
     return Promise.reject('Data Dictionary name can only use alphabetic and numeric characters, and []() ._-');
   }
+
   return Promise.resolve(true);
 };

--- a/src/StudyRegistration/utils.tsx
+++ b/src/StudyRegistration/utils.tsx
@@ -180,12 +180,8 @@ export const handleDataDictionaryNameValidation = (_:object, userInput:string): 
     invalidWindowsFileNames,
     maximumAllowedFileNameLength,
   } = validFileNameChecks;
-  console.log('userInput', userInput);
   if (userInput.length > maximumAllowedFileNameLength) {
-    return Promise.reject('File name contains invalid characters');
-  }
-  if (userInput.length > maximumAllowedFileNameLength) {
-    return Promise.reject(`File name length is greater than ${maximumAllowedFileNameLength} characters`);
+    return Promise.reject(`Data Dictionary name length is greater than ${maximumAllowedFileNameLength} characters`);
   }
   if (invalidWindowsFileNames.includes(userInput)) {
     return Promise.reject('Data Dictionary name is a reserved file name, please pick a different name.');

--- a/src/utils.js
+++ b/src/utils.js
@@ -254,7 +254,10 @@ export const createKayakoTicket = async (subject, fullName, email, contents, dep
   }
 };
 
-export const fileNameCharactersCheckRegex = /[^a-zA-Z0-9[\]() ._-]+/g;
-export const invalidWindowsFileNames = ['CON', 'PRN', 'AUX', 'NUL', 'COM0',
+export const validFileNameChecks = {
+  fileNameCharactersCheckRegex: /[^a-zA-Z0-9[\]() ._-]+/g,
+  invalidWindowsFileNames: ['CON', 'PRN', 'AUX', 'NUL', 'COM0',
   'COM1', 'COM2', 'COM3', 'COM4', 'COM5', 'COM6', 'COM7', 'COM8', 'COM9', 'LPT0',
-  'LPT1', 'LPT2', 'LPT3', 'LPT4', 'LPT5', 'LPT6', 'LPT7', 'LPT8', 'LPT9'];
+  'LPT1', 'LPT2', 'LPT3', 'LPT4', 'LPT5', 'LPT6', 'LPT7', 'LPT8', 'LPT9'],
+  maximumAllowedFileNameLength: 250,
+}

--- a/src/utils.js
+++ b/src/utils.js
@@ -257,7 +257,7 @@ export const createKayakoTicket = async (subject, fullName, email, contents, dep
 export const validFileNameChecks = {
   fileNameCharactersCheckRegex: /[^a-zA-Z0-9[\]() ._-]+/g,
   invalidWindowsFileNames: ['CON', 'PRN', 'AUX', 'NUL', 'COM0',
-  'COM1', 'COM2', 'COM3', 'COM4', 'COM5', 'COM6', 'COM7', 'COM8', 'COM9', 'LPT0',
-  'LPT1', 'LPT2', 'LPT3', 'LPT4', 'LPT5', 'LPT6', 'LPT7', 'LPT8', 'LPT9'],
+    'COM1', 'COM2', 'COM3', 'COM4', 'COM5', 'COM6', 'COM7', 'COM8', 'COM9', 'LPT0',
+    'LPT1', 'LPT2', 'LPT3', 'LPT4', 'LPT5', 'LPT6', 'LPT7', 'LPT8', 'LPT9'],
   maximumAllowedFileNameLength: 250,
-}
+};


### PR DESCRIPTION
Link to JIRA ticket if there is one: 
https://ctds-planx.atlassian.net/browse/HP-1414

**Dev Notes**
* Replaces individual variable declarations in ```src/utils.js``` with a single ```validFileNameChecks``` object
* Adds unit test for new functionality in utils.js

**Screen shots**
![output](https://github.com/uc-cdis/data-portal/assets/113449836/6d499e96-9843-4b33-b8ae-e42c26df7640)


### New Features
* Adds rules for Data Dictionary Name form field to enforce valid file names

