### PR TITLE
Feat/atlas data dictionary sort numbers and strings

### DIFF
--- a/src/Analysis/AtlasDataDictionary/AtlasDataDictionaryTable/Utils/ColumnItems.tsx
+++ b/src/Analysis/AtlasDataDictionary/AtlasDataDictionaryTable/Utils/ColumnItems.tsx
@@ -1,11 +1,6 @@
 import React from 'react';
 
-interface IColumnsItems {
-  headerKey: string;
-  jsx: React.ReactNode;
-}
-
-const ColumnsItems: IColumnsItems[] = [
+const ColumnsItems = [
   {
     headerKey: 'vocabularyID',
     jsx: (

--- a/src/Analysis/AtlasDataDictionary/AtlasDataDictionaryTable/Utils/ColumnItems.tsx
+++ b/src/Analysis/AtlasDataDictionary/AtlasDataDictionaryTable/Utils/ColumnItems.tsx
@@ -1,16 +1,13 @@
 import React from 'react';
 
-type sortType = 'string' | 'number' | 'notAvailable';
 interface IColumnsItems {
   headerKey: string;
-  sortType: sortType;
   jsx: React.ReactNode;
 }
 
 const ColumnsItems: IColumnsItems[] = [
   {
     headerKey: 'vocabularyID',
-    sortType: 'string',
     jsx: (
       <span>
         Vocabulary
@@ -21,12 +18,10 @@ const ColumnsItems: IColumnsItems[] = [
   },
   {
     headerKey: 'conceptID',
-    sortType: 'number',
     jsx: <span className='extra-wide-header'>Concept ID</span>,
   },
   {
     headerKey: 'conceptCode',
-    sortType: 'string',
     jsx: (
       <span>
         Concept
@@ -59,7 +54,6 @@ const ColumnsItems: IColumnsItems[] = [
   },
   {
     headerKey: 'numberOfPeopleWithVariable',
-    sortType: 'number',
     jsx: (
       <span>
         #&nbsp;/&nbsp;%&nbsp;of&nbsp;People
@@ -70,7 +64,6 @@ const ColumnsItems: IColumnsItems[] = [
   },
   {
     headerKey: 'numberOfPeopleWhereValueIsFilled',
-    sortType: 'number',
     jsx: (
       <span>
         #&nbsp;/&nbsp;%&nbsp;of&nbsp;People
@@ -81,7 +74,6 @@ const ColumnsItems: IColumnsItems[] = [
   },
   {
     headerKey: 'numberOfPeopleWhereValueIsNull',
-    sortType: 'number',
     jsx: (
       <span>
         #&nbsp;/&nbsp;%&nbsp;of&nbsp;People
@@ -92,7 +84,6 @@ const ColumnsItems: IColumnsItems[] = [
   },
   {
     headerKey: 'valueStoredAs',
-    sortType: 'string',
     jsx: (
       <span>
         Value
@@ -103,7 +94,6 @@ const ColumnsItems: IColumnsItems[] = [
   },
   {
     headerKey: 'valueSummary',
-    sortType: 'notAvailable',
     jsx: <span>Value&nbsp;Summary</span>,
   },
 ];

--- a/src/Analysis/AtlasDataDictionary/AtlasDataDictionaryTable/Utils/ColumnItems.tsx
+++ b/src/Analysis/AtlasDataDictionary/AtlasDataDictionaryTable/Utils/ColumnItems.tsx
@@ -32,7 +32,6 @@ const ColumnsItems: IColumnsItems[] = [
   },
   {
     headerKey: 'conceptName',
-    sortType: 'string',
     jsx: (
       <span>
         Concept
@@ -43,7 +42,6 @@ const ColumnsItems: IColumnsItems[] = [
   },
   {
     headerKey: 'conceptClassID',
-    sortType: 'string',
     jsx: (
       <span>
         Concept

--- a/src/Analysis/AtlasDataDictionary/AtlasDataDictionaryTable/Utils/ColumnItems.tsx
+++ b/src/Analysis/AtlasDataDictionary/AtlasDataDictionaryTable/Utils/ColumnItems.tsx
@@ -1,8 +1,16 @@
 import React from 'react';
 
-const ColumnsItems = [
+type sortType = 'string' | 'number' | 'notAvailable';
+interface IColumnsItems {
+  headerKey: string;
+  sortType: sortType;
+  jsx: React.ReactNode;
+}
+
+const ColumnsItems: IColumnsItems[] = [
   {
     headerKey: 'vocabularyID',
+    sortType: 'string',
     jsx: (
       <span>
         Vocabulary
@@ -13,10 +21,12 @@ const ColumnsItems = [
   },
   {
     headerKey: 'conceptID',
+    sortType: 'number',
     jsx: <span className='extra-wide-header'>Concept ID</span>,
   },
   {
     headerKey: 'conceptCode',
+    sortType: 'string',
     jsx: (
       <span>
         Concept
@@ -27,6 +37,7 @@ const ColumnsItems = [
   },
   {
     headerKey: 'conceptName',
+    sortType: 'string',
     jsx: (
       <span>
         Concept
@@ -37,6 +48,7 @@ const ColumnsItems = [
   },
   {
     headerKey: 'conceptClassID',
+    sortType: 'string',
     jsx: (
       <span>
         Concept
@@ -47,6 +59,7 @@ const ColumnsItems = [
   },
   {
     headerKey: 'numberOfPeopleWithVariable',
+    sortType: 'number',
     jsx: (
       <span>
         #&nbsp;/&nbsp;%&nbsp;of&nbsp;People
@@ -57,6 +70,7 @@ const ColumnsItems = [
   },
   {
     headerKey: 'numberOfPeopleWhereValueIsFilled',
+    sortType: 'number',
     jsx: (
       <span>
         #&nbsp;/&nbsp;%&nbsp;of&nbsp;People
@@ -67,6 +81,7 @@ const ColumnsItems = [
   },
   {
     headerKey: 'numberOfPeopleWhereValueIsNull',
+    sortType: 'number',
     jsx: (
       <span>
         #&nbsp;/&nbsp;%&nbsp;of&nbsp;People
@@ -77,6 +92,7 @@ const ColumnsItems = [
   },
   {
     headerKey: 'valueStoredAs',
+    sortType: 'string',
     jsx: (
       <span>
         Value
@@ -87,6 +103,7 @@ const ColumnsItems = [
   },
   {
     headerKey: 'valueSummary',
+    sortType: 'notAvailable',
     jsx: <span>Value&nbsp;Summary</span>,
   },
 ];

--- a/src/Analysis/AtlasDataDictionary/AtlasDataDictionaryTable/Utils/SortUtils.test.ts
+++ b/src/Analysis/AtlasDataDictionary/AtlasDataDictionaryTable/Utils/SortUtils.test.ts
@@ -35,7 +35,8 @@ describe('SortUtils', () => {
     expect(actualErrorMsg).toEqual(expectedErrorMsg);
   });
 
-  it('tests SortDataWithDirection function with ascending and descending directions for string', () => {
+  it(`tests SortDataWithDirection function with ascending and descending
+    directions for string`, () => {
     const sortKeyForString = 'vocabularyID';
     let direction: ISortConfig['direction'] = 'ascending';
     let sortedData = SortDataWithDirection(data, direction, sortKeyForString);

--- a/src/Analysis/AtlasDataDictionary/AtlasDataDictionaryTable/Utils/SortUtils.test.ts
+++ b/src/Analysis/AtlasDataDictionary/AtlasDataDictionaryTable/Utils/SortUtils.test.ts
@@ -1,6 +1,5 @@
 import { DetermineNextSortDirection, SortDataWithDirection } from './SortUtils';
 import { ISortConfig } from '../Interfaces/Interfaces';
-import ColumnsItems from './ColumnItems';
 
 describe('SortUtils', () => {
   it('tests DetermineNextSortDirection function with valid sortKey and direction', () => {
@@ -17,17 +16,15 @@ describe('SortUtils', () => {
     expect(newDirection).toBe('ascending');
   });
 
+  const data = [
+    { conceptID: 1, vocabularyID: 'A' },
+    { conceptID: 2, vocabularyID: 'B' },
+    { conceptID: 3, vocabularyID: 'C' },
+  ];
+
   it('tests that SortDataWithDirection function with invalid sortKey throws expected error', () => {
-    const data = [
-      { name: 'John Doe', exampleKey: 'A' },
-      { name: 'Jane Doe', exampleKey: 'B' },
-      { name: 'Mike Doe', exampleKey: 'C' },
-    ];
-    const sortKey = 'exampleKey';
+    const sortKey = 'thisIsNotAValidKey';
     const direction = 'ascending';
-    // const sortedData = SortDataWithDirection(data, direction, sortKey);
-    // expect(SortDataWithDirection(data, direction, sortKey)).toThrow(
-    //   'Invalid sortType parameter used with SortDataWithDirection');
     let actualErrorMsg = null;
     try {
       SortDataWithDirection(data, direction, sortKey);
@@ -38,23 +35,32 @@ describe('SortUtils', () => {
     expect(actualErrorMsg).toEqual(expectedErrorMsg);
   });
 
-  it('tests SortDataWithDirection function with descending directions for string', () => {
-    const data = [
-      { name: 'John Doe', vocabularyID: 'A' },
-      { name: 'Jane Doe', vocabularyID: 'B' },
-      { name: 'Mike Doe', vocabularyID: 'C' },
-    ];
+  it('tests SortDataWithDirection function with ascending and descending directions for string', () => {
     const sortKeyForString = 'vocabularyID';
-    let direction: 'ascending' | 'descending' | null = 'descending';
+    let direction: ISortConfig['direction'] = 'ascending';
     let sortedData = SortDataWithDirection(data, direction, sortKeyForString);
-    expect(sortedData[0].name).toBe('Mike Doe');
-    expect(sortedData[1].name).toBe('Jane Doe');
-    expect(sortedData[2].name).toBe('John Doe');
+    expect(sortedData[0].vocabularyID).toBe('A');
+    expect(sortedData[1].vocabularyID).toBe('B');
+    expect(sortedData[2].vocabularyID).toBe('C');
 
-    direction = 'ascending';
+    direction = 'descending';
     sortedData = SortDataWithDirection(data, direction, sortKeyForString);
-    expect(sortedData[0].name).toBe('John Doe');
-    expect(sortedData[1].name).toBe('Jane Doe');
-    expect(sortedData[2].name).toBe('Mike Doe');
+    expect(sortedData[0].vocabularyID).toBe('C');
+    expect(sortedData[1].vocabularyID).toBe('B');
+    expect(sortedData[2].vocabularyID).toBe('A');
+  });
+  it('tests SortDataWithDirection function with ascending and descending directions for number', () => {
+    const sortKeyForString = 'conceptID';
+    let direction: ISortConfig['direction'] = 'ascending';
+    let sortedData = SortDataWithDirection(data, direction, sortKeyForString);
+    expect(sortedData[0].conceptID).toBe(1);
+    expect(sortedData[1].conceptID).toBe(2);
+    expect(sortedData[2].conceptID).toBe(3);
+
+    direction = 'descending';
+    sortedData = SortDataWithDirection(data, direction, sortKeyForString);
+    expect(sortedData[0].conceptID).toBe(3);
+    expect(sortedData[1].conceptID).toBe(2);
+    expect(sortedData[2].conceptID).toBe(1);
   });
 });

--- a/src/Analysis/AtlasDataDictionary/AtlasDataDictionaryTable/Utils/SortUtils.test.ts
+++ b/src/Analysis/AtlasDataDictionary/AtlasDataDictionaryTable/Utils/SortUtils.test.ts
@@ -49,7 +49,8 @@ describe('SortUtils', () => {
     expect(sortedData[1].vocabularyID).toBe('B');
     expect(sortedData[2].vocabularyID).toBe('A');
   });
-  it('tests SortDataWithDirection function with ascending and descending directions for number', () => {
+  it(`tests SortDataWithDirection function
+    with ascending and descending directions for number`, () => {
     const sortKeyForString = 'conceptID';
     let direction: ISortConfig['direction'] = 'ascending';
     let sortedData = SortDataWithDirection(data, direction, sortKeyForString);

--- a/src/Analysis/AtlasDataDictionary/AtlasDataDictionaryTable/Utils/SortUtils.test.ts
+++ b/src/Analysis/AtlasDataDictionary/AtlasDataDictionaryTable/Utils/SortUtils.test.ts
@@ -52,15 +52,15 @@ describe('SortUtils', () => {
   });
   it(`tests SortDataWithDirection function
     with ascending and descending directions for number`, () => {
-    const sortKeyForString = 'conceptID';
+    const sortKeyForNumber = 'conceptID';
     let direction: ISortConfig['direction'] = 'ascending';
-    let sortedData = SortDataWithDirection(data, direction, sortKeyForString);
+    let sortedData = SortDataWithDirection(data, direction, sortKeyForNumber);
     expect(sortedData[0].conceptID).toBe(1);
     expect(sortedData[1].conceptID).toBe(2);
     expect(sortedData[2].conceptID).toBe(11);
 
     direction = 'descending';
-    sortedData = SortDataWithDirection(data, direction, sortKeyForString);
+    sortedData = SortDataWithDirection(data, direction, sortKeyForNumber);
     expect(sortedData[0].conceptID).toBe(11);
     expect(sortedData[1].conceptID).toBe(2);
     expect(sortedData[2].conceptID).toBe(1);

--- a/src/Analysis/AtlasDataDictionary/AtlasDataDictionaryTable/Utils/SortUtils.test.ts
+++ b/src/Analysis/AtlasDataDictionary/AtlasDataDictionaryTable/Utils/SortUtils.test.ts
@@ -1,5 +1,6 @@
 import { DetermineNextSortDirection, SortDataWithDirection } from './SortUtils';
 import { ISortConfig } from '../Interfaces/Interfaces';
+import ColumnsItems from './ColumnItems';
 
 describe('SortUtils', () => {
   it('tests DetermineNextSortDirection function with valid sortKey and direction', () => {
@@ -16,7 +17,7 @@ describe('SortUtils', () => {
     expect(newDirection).toBe('ascending');
   });
 
-  it('tests SortDataWithDirection function with ascending direction and valid sortKey', () => {
+  it('tests that SortDataWithDirection function with invalid sortKey throws expected error', () => {
     const data = [
       { name: 'John Doe', exampleKey: 'A' },
       { name: 'Jane Doe', exampleKey: 'B' },
@@ -24,27 +25,36 @@ describe('SortUtils', () => {
     ];
     const sortKey = 'exampleKey';
     const direction = 'ascending';
-
-    const sortedData = SortDataWithDirection(data, direction, sortKey);
-
-    expect(sortedData[0].name).toBe('John Doe');
-    expect(sortedData[1].name).toBe('Jane Doe');
-    expect(sortedData[2].name).toBe('Mike Doe');
+    // const sortedData = SortDataWithDirection(data, direction, sortKey);
+    // expect(SortDataWithDirection(data, direction, sortKey)).toThrow(
+    //   'Invalid sortType parameter used with SortDataWithDirection');
+    let actualErrorMsg = null;
+    try {
+      SortDataWithDirection(data, direction, sortKey);
+    } catch (e) {
+      actualErrorMsg = e.message;
+    }
+    const expectedErrorMsg = 'Invalid sortType parameter used with SortDataWithDirection';
+    expect(actualErrorMsg).toEqual(expectedErrorMsg);
   });
 
-  it('tests SortDataWithDirection function with descending direction and valid sortKey', () => {
+  it('tests SortDataWithDirection function with descending directions for string', () => {
     const data = [
-      { name: 'John Doe', exampleKey: 'A' },
-      { name: 'Jane Doe', exampleKey: 'B' },
-      { name: 'Mike Doe', exampleKey: 'C' },
+      { name: 'John Doe', vocabularyID: 'A' },
+      { name: 'Jane Doe', vocabularyID: 'B' },
+      { name: 'Mike Doe', vocabularyID: 'C' },
     ];
-    const sortKey = 'exampleKey';
-    const direction = 'descending';
-
-    const sortedData = SortDataWithDirection(data, direction, sortKey);
-
+    const sortKeyForString = 'vocabularyID';
+    let direction: 'ascending' | 'descending' | null = 'descending';
+    let sortedData = SortDataWithDirection(data, direction, sortKeyForString);
     expect(sortedData[0].name).toBe('Mike Doe');
     expect(sortedData[1].name).toBe('Jane Doe');
     expect(sortedData[2].name).toBe('John Doe');
+
+    direction = 'ascending';
+    sortedData = SortDataWithDirection(data, direction, sortKeyForString);
+    expect(sortedData[0].name).toBe('John Doe');
+    expect(sortedData[1].name).toBe('Jane Doe');
+    expect(sortedData[2].name).toBe('Mike Doe');
   });
 });

--- a/src/Analysis/AtlasDataDictionary/AtlasDataDictionaryTable/Utils/SortUtils.test.ts
+++ b/src/Analysis/AtlasDataDictionary/AtlasDataDictionaryTable/Utils/SortUtils.test.ts
@@ -19,7 +19,7 @@ describe('SortUtils', () => {
   const data = [
     { conceptID: 1, vocabularyID: 'A' },
     { conceptID: 2, vocabularyID: 'B' },
-    { conceptID: 3, vocabularyID: 'C' },
+    { conceptID: 11, vocabularyID: 'C' },
   ];
 
   it('tests that SortDataWithDirection function with invalid sortKey throws expected error', () => {
@@ -55,11 +55,11 @@ describe('SortUtils', () => {
     let sortedData = SortDataWithDirection(data, direction, sortKeyForString);
     expect(sortedData[0].conceptID).toBe(1);
     expect(sortedData[1].conceptID).toBe(2);
-    expect(sortedData[2].conceptID).toBe(3);
+    expect(sortedData[2].conceptID).toBe(11);
 
     direction = 'descending';
     sortedData = SortDataWithDirection(data, direction, sortKeyForString);
-    expect(sortedData[0].conceptID).toBe(3);
+    expect(sortedData[0].conceptID).toBe(11);
     expect(sortedData[1].conceptID).toBe(2);
     expect(sortedData[2].conceptID).toBe(1);
   });

--- a/src/Analysis/AtlasDataDictionary/AtlasDataDictionaryTable/Utils/SortUtils.test.ts
+++ b/src/Analysis/AtlasDataDictionary/AtlasDataDictionaryTable/Utils/SortUtils.test.ts
@@ -1,5 +1,5 @@
 import { DetermineNextSortDirection, SortDataWithDirection } from './SortUtils';
-import { ISortConfig } from '../Interfaces/Interfaces';
+import { IRowData, ISortConfig } from '../Interfaces/Interfaces';
 
 describe('SortUtils', () => {
   it('tests DetermineNextSortDirection function with valid sortKey and direction', () => {
@@ -20,7 +20,7 @@ describe('SortUtils', () => {
     { conceptID: 1, vocabularyID: 'A' },
     { conceptID: 2, vocabularyID: 'B' },
     { conceptID: 11, vocabularyID: 'C' },
-  ];
+  ] as IRowData[];
 
   it('tests that SortDataWithDirection function with invalid sortKey throws expected error', () => {
     const sortKey = 'thisIsNotAValidKey';

--- a/src/Analysis/AtlasDataDictionary/AtlasDataDictionaryTable/Utils/SortUtils.test.ts
+++ b/src/Analysis/AtlasDataDictionary/AtlasDataDictionaryTable/Utils/SortUtils.test.ts
@@ -31,7 +31,7 @@ describe('SortUtils', () => {
     } catch (e) {
       actualErrorMsg = e.message;
     }
-    const expectedErrorMsg = 'Invalid sortType parameter used with SortDataWithDirection';
+    const expectedErrorMsg = 'Invalid sortType found in SortDataWithDirection';
     expect(actualErrorMsg).toEqual(expectedErrorMsg);
   });
 

--- a/src/Analysis/AtlasDataDictionary/AtlasDataDictionaryTable/Utils/SortUtils.ts
+++ b/src/Analysis/AtlasDataDictionary/AtlasDataDictionaryTable/Utils/SortUtils.ts
@@ -1,5 +1,4 @@
-import { ISortConfig } from '../Interfaces/Interfaces';
-import ColumnsItems from './ColumnItems';
+import { ISortConfig, IRowData } from '../Interfaces/Interfaces';
 
 const DetermineNextSortDirection = (
   sortConfig: ISortConfig,
@@ -18,18 +17,13 @@ const DetermineNextSortDirection = (
   return direction;
 };
 
-const determineSortType = (sortKey: string) => {
-  const objectWithSortKey = ColumnsItems.find(
-    (object) => object.headerKey === sortKey,
-  );
-  return objectWithSortKey?.sortType;
-};
+const determineSortType = (data: IRowData[], sortKey: string) => typeof data[0][sortKey];
 const SortDataWithDirection = (
   data: any,
   direction: ISortConfig['direction'],
   sortKey: string,
 ) => {
-  const sortType = determineSortType(sortKey);
+  const sortType = determineSortType(data, sortKey);
   if (sortType !== 'number' && sortType !== 'string') {
     throw new Error(
       'Invalid sortType parameter used with SortDataWithDirection',

--- a/src/Analysis/AtlasDataDictionary/AtlasDataDictionaryTable/Utils/SortUtils.ts
+++ b/src/Analysis/AtlasDataDictionary/AtlasDataDictionaryTable/Utils/SortUtils.ts
@@ -1,7 +1,11 @@
 import { ISortConfig } from '../Interfaces/Interfaces';
+import ColumnsItems from './ColumnItems';
 
-const DetermineNextSortDirection = (sortConfig: ISortConfig, sortKey: string|null) => {
-  let direction:ISortConfig['direction'] = 'ascending';
+const DetermineNextSortDirection = (
+  sortConfig: ISortConfig,
+  sortKey: string | null
+) => {
+  let direction: ISortConfig['direction'] = 'ascending';
   if (sortConfig.sortKey === sortKey) {
     if (sortConfig.direction === 'ascending') {
       direction = 'descending';
@@ -14,14 +18,35 @@ const DetermineNextSortDirection = (sortConfig: ISortConfig, sortKey: string|nul
   return direction;
 };
 
-const SortDataWithDirection = (data:any, direction:ISortConfig['direction'], sortKey: string) => [...data].sort((a, b) => {
-  if (direction === 'ascending') {
-    return a[sortKey].toString().localeCompare(b[sortKey].toString());
+const determineSortType = (sortKey: string) => {
+  const objectWithSortKey = ColumnsItems.find(
+    (object) => object.headerKey === sortKey
+  );
+  return objectWithSortKey?.sortType;
+};
+const SortDataWithDirection = (
+  data: any,
+  direction: ISortConfig['direction'],
+  sortKey: string
+) => {
+  const sortType = determineSortType(sortKey);
+  if (sortType !== 'number' && sortType !== 'string') {
+    throw new Error('invalid sortType found within SortDataWithDirection');
   }
-  if (direction === 'descending') {
-    return b[sortKey].toString().localeCompare(a[sortKey].toString());
-  }
-  return 0;
-});
+  return () =>
+    [...data].sort((a, b) => {
+      if (direction === 'ascending') {
+        return sortType === 'string'
+          ? a[sortKey].toString().localeCompare(b[sortKey].toString())
+          : a[sortKey] - b[sortKey];
+      }
+      if (direction === 'descending') {
+        return sortType === 'string'
+          ? b[sortKey].toString().localeCompare(a[sortKey].toString())
+          : b[sortKey] - a[sortKey];
+      }
+      return 0;
+    });
+};
 
 export { DetermineNextSortDirection, SortDataWithDirection };

--- a/src/Analysis/AtlasDataDictionary/AtlasDataDictionaryTable/Utils/SortUtils.ts
+++ b/src/Analysis/AtlasDataDictionary/AtlasDataDictionaryTable/Utils/SortUtils.ts
@@ -26,7 +26,7 @@ const SortDataWithDirection = (
   const sortType = determineSortType(data, sortKey);
   if (sortType !== 'number' && sortType !== 'string') {
     throw new Error(
-      'Invalid sortType parameter used with SortDataWithDirection',
+      'Invalid sortType found in SortDataWithDirection',
     );
   }
   return [...data].sort((a, b) => {

--- a/src/Analysis/AtlasDataDictionary/AtlasDataDictionaryTable/Utils/SortUtils.ts
+++ b/src/Analysis/AtlasDataDictionary/AtlasDataDictionaryTable/Utils/SortUtils.ts
@@ -3,7 +3,7 @@ import ColumnsItems from './ColumnItems';
 
 const DetermineNextSortDirection = (
   sortConfig: ISortConfig,
-  sortKey: string | null
+  sortKey: string | null,
 ) => {
   let direction: ISortConfig['direction'] = 'ascending';
   if (sortConfig.sortKey === sortKey) {
@@ -20,33 +20,34 @@ const DetermineNextSortDirection = (
 
 const determineSortType = (sortKey: string) => {
   const objectWithSortKey = ColumnsItems.find(
-    (object) => object.headerKey === sortKey
+    (object) => object.headerKey === sortKey,
   );
   return objectWithSortKey?.sortType;
 };
 const SortDataWithDirection = (
   data: any,
   direction: ISortConfig['direction'],
-  sortKey: string
+  sortKey: string,
 ) => {
   const sortType = determineSortType(sortKey);
   if (sortType !== 'number' && sortType !== 'string') {
-    throw new Error('invalid sortType found within SortDataWithDirection');
+    throw new Error(
+      'Invalid sortType parameter used with SortDataWithDirection',
+    );
   }
-  return () =>
-    [...data].sort((a, b) => {
-      if (direction === 'ascending') {
-        return sortType === 'string'
-          ? a[sortKey].toString().localeCompare(b[sortKey].toString())
-          : a[sortKey] - b[sortKey];
-      }
-      if (direction === 'descending') {
-        return sortType === 'string'
-          ? b[sortKey].toString().localeCompare(a[sortKey].toString())
-          : b[sortKey] - a[sortKey];
-      }
-      return 0;
-    });
+  return [...data].sort((a, b) => {
+    if (direction === 'ascending') {
+      return sortType === 'string'
+        ? a[sortKey].toString().localeCompare(b[sortKey].toString())
+        : a[sortKey] - b[sortKey];
+    }
+    if (direction === 'descending') {
+      return sortType === 'string'
+        ? b[sortKey].toString().localeCompare(a[sortKey].toString())
+        : b[sortKey] - a[sortKey];
+    }
+    return 0;
+  });
 };
 
 export { DetermineNextSortDirection, SortDataWithDirection };

--- a/src/Analysis/AtlasDataDictionary/AtlasDataDictionaryTable/Utils/SortUtils.ts
+++ b/src/Analysis/AtlasDataDictionary/AtlasDataDictionaryTable/Utils/SortUtils.ts
@@ -17,13 +17,12 @@ const DetermineNextSortDirection = (
   return direction;
 };
 
-const determineSortType = (data: IRowData[], sortKey: string) => typeof data[0][sortKey];
 const SortDataWithDirection = (
-  data: any,
+  data: IRowData[],
   direction: ISortConfig['direction'],
   sortKey: string,
 ) => {
-  const sortType = determineSortType(data, sortKey);
+  const sortType = typeof data[0][sortKey];
   if (sortType !== 'number' && sortType !== 'string') {
     throw new Error(
       'Invalid sortType found in SortDataWithDirection',


### PR DESCRIPTION
Link to JIRA ticket if there is one: https://ctds-planx.atlassian.net/browse/VADC-1021

**Dev notes**
Before in the VADC Atlas Data Dictionary all the columns were sorted as though they were strings. This update checks the data type before implementing the sort, so that the data can be sorted either numerically or alphabetically depending on whether the value is a string or number. This avoids issues with numeric data such as
```1, 2, 11 ```
being sorted 
``` 1, 11, 2```


**Before**
![output](https://github.com/uc-cdis/data-portal/assets/113449836/3181bd13-16b2-41f6-9d91-85e676ab3db5)

**After** 
![output](https://github.com/uc-cdis/data-portal/assets/113449836/5c6dc312-006d-48c0-a659-8b77b14e0000)

### Feature
* Updates VADC Atlas Data Dictionary app so that columns are sorted based on their data type, making it easier for users to find the desired row data. 
