### PR TITLE
VADC-1020 Feat/debounce vadc data dictionary search

### DIFF
--- a/src/Analysis/AtlasDataDictionary/AtlasDataDictionaryTable/Components/SearchBar/SearchBar.test.tsx
+++ b/src/Analysis/AtlasDataDictionary/AtlasDataDictionaryTable/Components/SearchBar/SearchBar.test.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
-import { render, fireEvent, screen, waitFor } from '@testing-library/react';
+import {
+  render, fireEvent, screen, waitFor,
+} from '@testing-library/react';
 import SearchBar from './SearchBar';
 
 describe('SearchBar', () => {

--- a/src/Analysis/AtlasDataDictionary/AtlasDataDictionaryTable/Components/SearchBar/SearchBar.test.tsx
+++ b/src/Analysis/AtlasDataDictionary/AtlasDataDictionaryTable/Components/SearchBar/SearchBar.test.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
-import { render, fireEvent, screen } from '@testing-library/react';
+import { render, fireEvent, screen, waitFor } from '@testing-library/react';
 import SearchBar from './SearchBar';
 
 describe('SearchBar', () => {
-  it('should update data based on input value', () => {
+  it('should update data based on input value', async () => {
     const columnsShown = 5;
     const TableData: any = [
       { id: 1, name: 'John Doe', age: 28 },
@@ -33,8 +33,9 @@ describe('SearchBar', () => {
     // Simulate key press event (Enter) to trigger search
     fireEvent.keyPress(input, { key: 'Enter' });
 
-    // Expect set data to be filtered by search term
-    expect(setData).toHaveBeenCalledTimes(1);
+    // Expect set data to be filtered by search term after debouncing
+    await waitFor(() => expect(setData).toHaveBeenCalledTimes(1));
+
     const filteredData = TableData.filter((item) => Object.values(item).some((value) => {
       const valueToString = value?.toString()?.toLowerCase();
       return valueToString && valueToString.includes('doe');

--- a/src/Analysis/AtlasDataDictionary/AtlasDataDictionaryTable/Components/SearchBar/SearchBar.tsx
+++ b/src/Analysis/AtlasDataDictionary/AtlasDataDictionaryTable/Components/SearchBar/SearchBar.tsx
@@ -49,7 +49,9 @@ const SearchBar = ({
   };
   const debounceDelayInMilliseconds = 500;
   useEffect(() => {
-    const debouncedFilter = debounce(() => { filterTableData(); }, debounceDelayInMilliseconds);
+    const debouncedFilter = debounce(() => {
+      filterTableData();
+    }, debounceDelayInMilliseconds);
     debouncedFilter();
   }, [searchTerm]);
 

--- a/src/Analysis/AtlasDataDictionary/AtlasDataDictionaryTable/Components/SearchBar/SearchBar.tsx
+++ b/src/Analysis/AtlasDataDictionary/AtlasDataDictionaryTable/Components/SearchBar/SearchBar.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect } from 'react';
 import { Input } from '@mantine/core';
+import { debounce } from 'lodash';
 import SearchIcon from '../Icons/SearchIcon';
 import { IRowData } from '../../Interfaces/Interfaces';
 
@@ -18,7 +19,7 @@ const SearchBar = ({
   searchTerm,
   handleTableChange,
 }: ISearchBarProps) => {
-  useEffect(() => {
+  const filterTableData = () => {
     const filteredData = TableData.filter((item) => {
       const searchQuery = searchTerm.toLowerCase().trim();
       return Object.values(item).some((value) => {
@@ -45,6 +46,11 @@ const SearchBar = ({
       });
     });
     setData(filteredData);
+  };
+  const debounceDelayInMilliseconds = 500;
+  useEffect(() => {
+    const debouncedFilter = debounce(() => { filterTableData(); }, debounceDelayInMilliseconds);
+    debouncedFilter();
   }, [searchTerm]);
 
   const handleInputChange = (event) => {

--- a/src/Analysis/AtlasDataDictionary/AtlasDataDictionaryTable/Components/TableRow/NonNumericDetailsTable/NonNumericDetailsTable.tsx
+++ b/src/Analysis/AtlasDataDictionary/AtlasDataDictionaryTable/Components/TableRow/NonNumericDetailsTable/NonNumericDetailsTable.tsx
@@ -47,7 +47,7 @@ const NonNumericDetailsTable = ({ rowObject, searchTerm }) => (
                 searchTerm,
               )}
             >
-              {valueSummaryObj.personCount}
+              {valueSummaryObj.personCount.toLocaleString()}
             </td>
           </tr>
         ),

--- a/src/Analysis/AtlasDataDictionary/AtlasDataDictionaryTable/Components/TableRow/NumericDetailsTable/NumericDetailsTable.tsx
+++ b/src/Analysis/AtlasDataDictionary/AtlasDataDictionaryTable/Components/TableRow/NumericDetailsTable/NumericDetailsTable.tsx
@@ -36,7 +36,7 @@ const NumericDetailsTable = ({ rowObject, searchTerm }) => (
             searchTerm,
           )}
         >
-          <div className={'td-container'}>{rowObject.meanValue}</div>
+          <div className={'td-container'}>{rowObject.meanValue.toLocaleString()}</div>
         </td>
         <td
           className={checkIfCellContainsSearchTerm(

--- a/src/Analysis/AtlasDataDictionary/AtlasDataDictionaryTable/Components/TableRow/NumericDetailsTable/NumericDetailsTable.tsx
+++ b/src/Analysis/AtlasDataDictionary/AtlasDataDictionaryTable/Components/TableRow/NumericDetailsTable/NumericDetailsTable.tsx
@@ -20,7 +20,7 @@ const NumericDetailsTable = ({ rowObject, searchTerm }) => (
             searchTerm,
           )}
         >
-          <div className={'td-container'}>{rowObject.minValue}</div>
+          <div className={'td-container'}>{rowObject.minValue.toLocaleString()}</div>
         </td>
         <td
           className={checkIfCellContainsSearchTerm(
@@ -28,7 +28,7 @@ const NumericDetailsTable = ({ rowObject, searchTerm }) => (
             searchTerm,
           )}
         >
-          <div className={'td-container'}>{rowObject.maxValue}</div>
+          <div className={'td-container'}>{rowObject.maxValue.toLocaleString()}</div>
         </td>
         <td
           className={checkIfCellContainsSearchTerm(
@@ -44,7 +44,7 @@ const NumericDetailsTable = ({ rowObject, searchTerm }) => (
             searchTerm,
           )}
         >
-          <div className={'td-container'}>{rowObject.standardDeviation}</div>
+          <div className={'td-container'}>{rowObject.standardDeviation.toLocaleString()}</div>
         </td>
       </tr>
     </tbody>

--- a/src/Analysis/AtlasDataDictionary/AtlasDataDictionaryTable/Components/TableRow/TableRow.tsx
+++ b/src/Analysis/AtlasDataDictionary/AtlasDataDictionaryTable/Components/TableRow/TableRow.tsx
@@ -121,7 +121,7 @@ const TableRow = ({
             }
           >
             <div className='td-container'>
-              {rowObject.numberOfPeopleWithVariable}
+              {rowObject.numberOfPeopleWithVariable.toLocaleString()}
               <br />
               {rowObject.numberOfPeopleWithVariablePercent}%
             </div>
@@ -141,7 +141,7 @@ const TableRow = ({
             } `}
           >
             <div className='td-container'>
-              {rowObject.numberOfPeopleWhereValueIsFilled}
+              {rowObject.numberOfPeopleWhereValueIsFilled.toLocaleString()}
               <br />
               {rowObject.numberOfPeopleWhereValueIsFilledPercent}%
             </div>
@@ -161,7 +161,7 @@ const TableRow = ({
             }
           >
             <div className='td-container'>
-              {rowObject.numberOfPeopleWhereValueIsNull}
+              {rowObject.numberOfPeopleWhereValueIsNull.toLocaleString()}
               <br />
               {rowObject.numberOfPeopleWhereValueIsNullPercent}%
             </div>

--- a/src/Analysis/AtlasDataDictionary/AtlasDataDictionaryTable/Components/TableRow/TableRow.tsx
+++ b/src/Analysis/AtlasDataDictionary/AtlasDataDictionaryTable/Components/TableRow/TableRow.tsx
@@ -123,7 +123,7 @@ const TableRow = ({
             <div className='td-container'>
               {rowObject.numberOfPeopleWithVariable.toLocaleString()}
               <br />
-              {rowObject.numberOfPeopleWithVariablePercent}%
+              {rowObject.numberOfPeopleWithVariablePercent.toLocaleString()}%
             </div>
           </td>
         )}
@@ -143,7 +143,7 @@ const TableRow = ({
             <div className='td-container'>
               {rowObject.numberOfPeopleWhereValueIsFilled.toLocaleString()}
               <br />
-              {rowObject.numberOfPeopleWhereValueIsFilledPercent}%
+              {rowObject.numberOfPeopleWhereValueIsFilledPercent.toLocaleString()}%
             </div>
           </td>
         )}
@@ -163,7 +163,7 @@ const TableRow = ({
             <div className='td-container'>
               {rowObject.numberOfPeopleWhereValueIsNull.toLocaleString()}
               <br />
-              {rowObject.numberOfPeopleWhereValueIsNullPercent}%
+              {rowObject.numberOfPeopleWhereValueIsNullPercent.toLocaleString()}%
             </div>
           </td>
         )}

--- a/src/Analysis/AtlasDataDictionary/AtlasDataDictionaryTable/Utils/ColumnItems.tsx
+++ b/src/Analysis/AtlasDataDictionary/AtlasDataDictionaryTable/Utils/ColumnItems.tsx
@@ -49,9 +49,7 @@ const ColumnsItems = [
     headerKey: 'numberOfPeopleWithVariable',
     jsx: (
       <span>
-        #&nbsp;/&nbsp;%&nbsp;of&nbsp;People
-        <br />
-        with&nbsp;Variable
+        People with<br />Variable
       </span>
     ),
   },
@@ -59,9 +57,7 @@ const ColumnsItems = [
     headerKey: 'numberOfPeopleWhereValueIsFilled',
     jsx: (
       <span>
-        #&nbsp;/&nbsp;%&nbsp;of&nbsp;People
-        <br />
-        where&nbsp;Value&nbsp;is&nbsp;Filled
+        People with <br />Variable where <br />Value is Filled
       </span>
     ),
   },
@@ -69,9 +65,7 @@ const ColumnsItems = [
     headerKey: 'numberOfPeopleWhereValueIsNull',
     jsx: (
       <span>
-        #&nbsp;/&nbsp;%&nbsp;of&nbsp;People
-        <br />
-        where&nbsp;Value&nbsp;is&nbsp;Null
+        People with <br />Variable where <br />Value&nbsp;is&nbsp;Null
       </span>
     ),
   },

--- a/src/Analysis/AtlasDataDictionary/AtlasDataDictionaryTable/Utils/ColumnItems.tsx
+++ b/src/Analysis/AtlasDataDictionary/AtlasDataDictionaryTable/Utils/ColumnItems.tsx
@@ -57,7 +57,7 @@ const ColumnsItems = [
     headerKey: 'numberOfPeopleWhereValueIsFilled',
     jsx: (
       <span>
-        People with <br />Variable where <br />Value is Filled
+        People with <br />Variable where <br />Value&nbsp;is&nbsp;Filled
       </span>
     ),
   },


### PR DESCRIPTION
Link to JIRA ticket if there is one: 
https://ctds-planx.atlassian.net/browse/VADC-1020

**Developer Notes**
* Debouncing impact on UX is more noticeable when TableData size is larger, such as when the TableData has greater than 8k entries, about 25mb. Adding debouncing reduces excessive rerenders of charts and pauses caused by processing when typing. 
* To test: change line 9 in ```data-portal/src/Analysis/AtlasDataDictionary/AtlasDataDictionaryTable/TestData/GenerateTableData.js``` to ```const numberOfEntries = 8000;``` then run ```Node GenerateTableData.js``` in that directory. Then run storybook with ```npm run storybook``` and use the ```mockedValidData``` selection for the story AtlasDataDictionaryLoading to compare and contrast the UX in this branch vs. master when typing in the search bar. 
<img width="171" alt="image" src="https://github.com/uc-cdis/data-portal/assets/113449836/cb1fe415-330f-410f-9354-7659a825d51f">


* Changes to column headers and numeric formatting: 
<img width="1412" alt="image" src="https://github.com/uc-cdis/data-portal/assets/113449836/e3bb0791-5ebf-40d5-85db-c328f5795317">

<img width="1412" alt="image" src="https://github.com/uc-cdis/data-portal/assets/113449836/6d510e09-06e9-4688-b64b-ed4de517121c">





### Improvements
* Adds debouncing for search input on VADC Atlas Data Dictionary application to improve UX when typing searches with large table data sizes 
* Updates column names and formats numbers with commas to improve readability
