### PR TITLE
fix missing tag fields in disco table

### DIFF
--- a/src/Discovery/Discovery.tsx
+++ b/src/Discovery/Discovery.tsx
@@ -386,7 +386,7 @@ const Discovery: React.FunctionComponent<Props> = (props: Props) => {
         width: config.tagColumnWidth || '200px',
         render: (_, record) => (
           <React.Fragment>
-            {record[config.minimalFieldMapping.tagsListFieldName]?.map(({ name, category }) => {
+            {(record[config.minimalFieldMapping.tagsListFieldName] || []).map(({ name, category }) => {
               const isSelected = !!props.selectedTags[name];
               const color = getTagColor(category, config);
               if (typeof name !== 'string') {

--- a/src/Discovery/DiscoveryListView.tsx
+++ b/src/Discovery/DiscoveryListView.tsx
@@ -173,7 +173,7 @@ const DiscoveryListView: React.FunctionComponent<Props> = (props: Props) => {
               { config.features.tagsInDescription?.enabled
                 ? (
                   <div className='discovery-table__row-horizontal-content'>
-                    {record[config.minimalFieldMapping.tagsListFieldName]?.map(({ name, category }) => {
+                    {(record[config.minimalFieldMapping.tagsListFieldName] || []).map(({ name, category }) => {
                       const isSelected = !!props.selectedTags[name];
                       const color = getTagColor(category, config);
                       if (typeof name !== 'string') {


### PR DESCRIPTION


### Bug Fixes
- Discovery: fix another bug cause the page to crash due to incorrectly handling optional tags field
