### PR TITLE
use file manifest for batch download

### DIFF
--- a/src/Discovery/DiscoveryActionBar.tsx
+++ b/src/Discovery/DiscoveryActionBar.tsx
@@ -473,7 +473,9 @@ const DiscoveryActionBar = (props: Props) => {
             console.log(`RequiredIDP does not expect: ${tag?.name}`);
             return; // do not add tag to list
           }
-          requiredIDP.push(tag.name);
+          if (!requiredIDP.includes(tag.name)) {
+            requiredIDP.push(tag.name);
+          }
         }
       }));
       return requiredIDP;

--- a/src/Discovery/DiscoveryActionBar.tsx
+++ b/src/Discovery/DiscoveryActionBar.tsx
@@ -250,6 +250,26 @@ const checkDownloadStatus = (
   );
 };
 
+const assembleFileManifest = (manifestFieldName: string, selectedResources: any[]) => {
+  // combine manifests from all selected studies
+  const manifest:any = [];
+  selectedResources.forEach((study) => {
+    if (study[manifestFieldName]) {
+      if ('commons_url' in study && !(hostname.includes(study.commons_url))) { // PlanX addition to allow hostname based DRS in manifest download clients
+        // like FUSE
+        manifest.push(...study[manifestFieldName].map((x) => ({
+          ...x,
+          commons_url: ('commons_url' in x)
+            ? x.commons_url : study.commons_url,
+        })));
+      } else {
+        manifest.push(...study[manifestFieldName]);
+      }
+    }
+  });
+  return manifest;
+};
+
 const handleDownloadZipClick = async (
   config: DiscoveryConfig,
   selectedResources: any[],
@@ -259,8 +279,8 @@ const handleDownloadZipClick = async (
   location,
   healIDPLoginNeeded,
 ) => {
+  const { manifestFieldName } = config.features.exportToWorkspace;
   if (config.features.exportToWorkspace.verifyExternalLogins) {
-    const { manifestFieldName } = config.features.exportToWorkspace;
     const isLinked = await checkFederatedLoginStatus(setDownloadStatus, selectedResources, manifestFieldName, history, location);
     if (!isLinked) {
       return;
@@ -271,11 +291,12 @@ const handleDownloadZipClick = async (
     return;
   }
 
-  const studyIDs = selectedResources.map((study) => study[config.minimalFieldMapping.uid]);
+  // const studyIDs = selectedResources.map((study) => study[config.minimalFieldMapping.uid]);
+  const manifest = assembleFileManifest(manifestFieldName, selectedResources);
   fetchWithCreds({
     path: `${jobAPIPath}dispatch`,
     method: 'POST',
-    body: JSON.stringify({ action: 'batch-export', input: { study_ids: studyIDs } }),
+    body: JSON.stringify({ action: 'batch-export', input: { file_manifest: manifest } }),
   }).then(
     (dispatchResponse) => {
       const { uid } = dispatchResponse.data;
@@ -314,22 +335,8 @@ const handleDownloadManifestClick = (config: DiscoveryConfig, selectedResources:
   if (healIDPLoginNeeded) {
     return;
   }
-  // combine manifests from all selected studies
-  const manifest:any = [];
-  selectedResources.forEach((study) => {
-    if (study[manifestFieldName]) {
-      if ('commons_url' in study && !(hostname.includes(study.commons_url))) { // PlanX addition to allow hostname based DRS in manifest download clients
-        // like FUSE
-        manifest.push(...study[manifestFieldName].map((x) => ({
-          ...x,
-          commons_url: ('commons_url' in x)
-            ? x.commons_url : study.commons_url,
-        })));
-      } else {
-        manifest.push(...study[manifestFieldName]);
-      }
-    }
-  });
+
+  const manifest = assembleFileManifest(manifestFieldName, selectedResources);
   const projectNumber = selectedResources.map((study) => study.project_number);
   const studyName = selectedResources.map((study) => study.study_name);
   const repositoryName = selectedResources.map((study) => study.commons);

--- a/src/Discovery/DiscoveryDetails/Components/FieldGrouping/TabField/DataDownloadList/ActionButtons/ActionsButtons.test.tsx
+++ b/src/Discovery/DiscoveryDetails/Components/FieldGrouping/TabField/DataDownloadList/ActionButtons/ActionsButtons.test.tsx
@@ -103,7 +103,7 @@ describe('ActionButtons', () => {
     }
   };
 
-  const checkConditionalPopoverMissingRequiredIdentityProvidersInCommon = async (buttonTestID: string, popoverShouldRender: boolean) => {
+  const checkConditionalPopoverMissingRequiredIdentityProvidersSingle = async (buttonTestID: string, popoverShouldRender: boolean) => {
     render(
       <ActionButtons
         {...testProps}
@@ -232,7 +232,7 @@ describe('ActionButtons', () => {
       ${
   button.id
 } button when missing required identity providers is InCommon`, async () => {
-      checkConditionalPopoverMissingRequiredIdentityProvidersInCommon(
+      checkConditionalPopoverMissingRequiredIdentityProvidersSingle(
         button.id,
         button.showsPopover,
       );

--- a/src/Discovery/DiscoveryDetails/Components/FieldGrouping/TabField/Utils/GetMissingRequiredIdentityProviders.ts
+++ b/src/Discovery/DiscoveryDetails/Components/FieldGrouping/TabField/Utils/GetMissingRequiredIdentityProviders.ts
@@ -22,7 +22,9 @@ const GetMissingRequiredIdentityProviders = (
               console.log(`Required Identity Provider does not expect: ${tag.name}`);
               return; // do not add tag to list
             }
-            missingRequiredIdentityProvider.push(tag.name);
+            if (!missingRequiredIdentityProvider.includes(tag.name)) {
+              missingRequiredIdentityProvider.push(tag.name);
+            }
           }
         });
       }


### PR DESCRIPTION
### Bug Fixes
- Discovery: fixed a bug that button incorrectly disabled because of duplicated required IDP tags

### Improvements
- Discovery: use file manifest instead of study IDs for direct download
