### PR TITLE
HP-1525 Feat/disco status icon

### DIFF
--- a/docs/portal_config.md
+++ b/docs/portal_config.md
@@ -498,7 +498,7 @@ Below is an example, with inline comments describing what each JSON block config
             "enabled": false,
             "menuText": "Not Accessible"
           },
-          "pending": {...},
+          "waiting": {...},
           "notAvailable": {...}
         }
       },
@@ -662,7 +662,7 @@ Below is an example, with inline comments describing what each JSON block config
     "minimalFieldMapping": { // maps
       "tagsListFieldName": "tags", // required; the field which contains the list of tags (format: [{name: string, category: string}] )
       "authzField": "authz", // optional if features.authorization.enabled is false, otherwise required
-      "dataAvailabilityField": "data_availability", // optional, for checking if a study has data pending to be available
+      "dataAvailabilityField": "data_availability", // optional, for checking if no data will be made available for a study
       "uid": "study_id" // required; a unique identifier for each study. Can be any unique value and does not have to have any special meaning (eg does not need to be a GUID)
     },
     "tagCategories": [ // configures the categories displayed in the tag selector. If a tag category appears in the `tagsListFieldName` field but is not configured here, it will not be displayed in the tag selector.

--- a/src/Discovery/Discovery.test.tsx
+++ b/src/Discovery/Discovery.test.tsx
@@ -21,7 +21,7 @@ const initStoreData = {
     accessFilters: {
       [AccessLevel.ACCESSIBLE]: true,
       [AccessLevel.UNACCESSIBLE]: true,
-      [AccessLevel.PENDING]: true,
+      [AccessLevel.WAITING]: true,
       [AccessLevel.NOT_AVAILABLE]: true,
     },
     selectedTags: {},

--- a/src/Discovery/Discovery.tsx
+++ b/src/Discovery/Discovery.tsx
@@ -40,7 +40,7 @@ export const accessibleFieldName = '__accessible';
 export enum AccessLevel {
   ACCESSIBLE = 1,
   UNACCESSIBLE = 2,
-  PENDING = 3,
+  WAITING = 3,
   NOT_AVAILABLE = 4,
   OTHER = 5,
 }
@@ -64,9 +64,9 @@ const setUpMenuItemInfo = (menuItemInfo, supportedValues) => {
       [AccessLevel.UNACCESSIBLE, supportedValues.unaccessible.menuText, <LockOutlined />],
     );
   }
-  if (supportedValues?.pending?.enabled === true) {
+  if (supportedValues?.waiting?.enabled === true) {
     menuItemInfo.push(
-      [AccessLevel.PENDING, supportedValues.pending.menuText, <ClockCircleOutlined />],
+      [AccessLevel.WAITING, supportedValues.waiting.menuText, <ClockCircleOutlined />],
     );
   }
   if (supportedValues?.notAvailable?.enabled === true) {
@@ -493,7 +493,7 @@ const Discovery: React.FunctionComponent<Props> = (props: Props) => {
             onClick={() => props.onAccessFilterSet({
               [AccessLevel.ACCESSIBLE]: true,
               [AccessLevel.NOT_AVAILABLE]: true,
-              [AccessLevel.PENDING]: true,
+              [AccessLevel.WAITING]: true,
               [AccessLevel.UNACCESSIBLE]: true,
             },
             )}
@@ -561,7 +561,7 @@ const Discovery: React.FunctionComponent<Props> = (props: Props) => {
       width: '200px',
       textWrap: 'word-break',
       render: (_, record) => {
-        if (record[accessibleFieldName] === AccessLevel.PENDING) {
+        if (record[accessibleFieldName] === AccessLevel.WAITING) {
           return (
             <Popover
               overlayClassName='discovery-popover'
@@ -569,7 +569,7 @@ const Discovery: React.FunctionComponent<Props> = (props: Props) => {
               arrowPointAtCenter
               content={(
                 <div className='discovery-popover__text'>
-                  This study will have data soon
+                  Data are not yet available for this study
                 </div>
               )}
             >
@@ -585,7 +585,7 @@ const Discovery: React.FunctionComponent<Props> = (props: Props) => {
               arrowPointAtCenter
               content={(
                 <div className='discovery-popover__text'>
-                  This study does not have any data yet.
+                  No data will be shared by this study
                 </div>
               )}
             >
@@ -626,7 +626,8 @@ const Discovery: React.FunctionComponent<Props> = (props: Props) => {
               content={(
                 <div className='discovery-popover__text'>
                   <React.Fragment>You don&apos;t have <code>{ARBORIST_READ_PRIV}</code> access to </React.Fragment>
-                  <React.Fragment><code>{record[config.minimalFieldMapping.authzField]}</code>.</React.Fragment>
+                  <React.Fragment><code>{record[config.minimalFieldMapping.authzField]}</code>. </React.Fragment>
+                  <React.Fragment>Visit the repository to request access to these data</React.Fragment>
                 </div>
               )}
             >

--- a/src/Discovery/DiscoveryDetails/Components/NonTabbedDiscoveryDetails/NonTabbedDiscoveryDetails.tsx
+++ b/src/Discovery/DiscoveryDetails/Components/NonTabbedDiscoveryDetails/NonTabbedDiscoveryDetails.tsx
@@ -17,11 +17,11 @@ const { Panel } = Collapse;
 const NonTabbedDiscoveryDetails = ({ props }) => {
   const userHasAccess = props.config.features.authorization.enabled
     && props.modalData[accessibleFieldName] !== AccessLevel.NOT_AVAILABLE
-    && props.modalData[accessibleFieldName] !== AccessLevel.PENDING
+    && props.modalData[accessibleFieldName] !== AccessLevel.WAITING
     && props.modalData[accessibleFieldName] === AccessLevel.ACCESSIBLE;
   const userDoesNotHaveAccess = props.config.features.authorization.enabled
     && props.modalData[accessibleFieldName] !== AccessLevel.NOT_AVAILABLE
-    && props.modalData[accessibleFieldName] !== AccessLevel.PENDING
+    && props.modalData[accessibleFieldName] !== AccessLevel.WAITING
     && props.modalData[accessibleFieldName] !== AccessLevel.ACCESSIBLE;
 
   const showDownloadPanel = props.config.studyPageFields.downloadLinks

--- a/src/Discovery/__mocks__/mock_config.json
+++ b/src/Discovery/__mocks__/mock_config.json
@@ -30,9 +30,9 @@
           "enabled": false,
           "menuText": "Not Accessible"
         },
-        "pending": {
+        "waiting": {
           "enabled": true,
-          "menuText": "Pending"
+          "menuText": "Waiting"
         },
         "notAvailable": {
           "enabled": true,

--- a/src/Discovery/index.tsx
+++ b/src/Discovery/index.tsx
@@ -103,10 +103,10 @@ const DiscoveryWithMDSBackend: React.FC<{
         }
         const studiesWithAccessibleField = rawStudies.map((study) => {
           let accessible: AccessLevel;
-          if (supportedValues?.pending?.enabled && dataAvailabilityField && study[dataAvailabilityField] === 'pending') {
-            accessible = AccessLevel.PENDING;
-          } else if (supportedValues?.notAvailable?.enabled && !study[authzField]) {
+          if (supportedValues?.notAvailable?.enabled && dataAvailabilityField && study[dataAvailabilityField] === 'not_available') {
             accessible = AccessLevel.NOT_AVAILABLE;
+          } else if (supportedValues?.waiting?.enabled && !study[authzField]) {
+            accessible = AccessLevel.WAITING;
           } else {
             let authMapping;
             if (isEnabled('discoveryUseAggWTS')) {

--- a/src/Discovery/reducers.js
+++ b/src/Discovery/reducers.js
@@ -7,7 +7,7 @@ const discovery = (
     accessFilters: {
       [AccessLevel.ACCESSIBLE]: true,
       [AccessLevel.UNACCESSIBLE]: true,
-      [AccessLevel.PENDING]: true,
+      [AccessLevel.WAITING]: true,
       [AccessLevel.NOT_AVAILABLE]: true,
     },
     selectedTags: {},


### PR DESCRIPTION
Link to JIRA ticket if there is one: https://ctds-planx.atlassian.net/browse/HP-1525


### Improvements
- Discovery: re-org some data avalibility icons and states. `Pending` has been renamed to `Waiting` and has became the default state for metadata that doesn't have an `authz` value. `Not Avaliable` now is a state that need to be explicitly set from a metadata field.

