### PR TITLE
MIDRC-794 Fix discovery page when buttons are disabled

### DIFF
--- a/src/Discovery/DiscoveryActionBar/components/DownloadManifestButton.tsx
+++ b/src/Discovery/DiscoveryActionBar/components/DownloadManifestButton.tsx
@@ -6,7 +6,7 @@ import { handleRedirectToLoginClickResumable } from '../../Utils/HandleRedirectT
 
 const DownloadManifestButton = ({
   props, healIDPLoginNeeded, onlyInCommonMsg, history, location,
-}) => (props.config.features.exportToWorkspace?.enableDownloadManifest && (
+}) => (props.config.features.exportToWorkspace?.enableDownloadManifest ? (
   <Popover
     className='discovery-popover'
     arrowPointAtCenter
@@ -68,5 +68,5 @@ const DownloadManifestButton = ({
         }`}
     </Button>
   </Popover>
-));
+) : null);
 export default DownloadManifestButton;

--- a/src/Discovery/DiscoveryActionBar/components/ExportToWorkspaceButton.tsx
+++ b/src/Discovery/DiscoveryActionBar/components/ExportToWorkspaceButton.tsx
@@ -6,7 +6,7 @@ import { handleRedirectToLoginClickResumable } from '../../Utils/HandleRedirectT
 
 const ExportToWorkspaceButton = ({
   props, healIDPLoginNeeded, onlyInCommonMsg, setDownloadStatus, history, location,
-}) => (props.config.features.exportToWorkspace?.enabled && (
+}) => (props.config.features.exportToWorkspace?.enabled ? (
   <Popover
     className='discovery-popover'
     arrowPointAtCenter
@@ -61,6 +61,6 @@ const ExportToWorkspaceButton = ({
         : 'Login to Open In Workspace'}
     </Button>
   </Popover>
-));
+) : null);
 
 export default ExportToWorkspaceButton;


### PR DESCRIPTION
Fix this error:
```
Error: DownloadManifestButton(...): Nothing was returned from render. This usually means a return statement is missing. Or, to render nothing, return null.
```

Link to JIRA ticket if there is one: https://ctds-planx.atlassian.net/browse/MIDRC-794

### New Features

### Breaking Changes

### Bug Fixes
- Fix an issue with the discovery page not loading when the "download manifest" or "export to workspace" buttons are not enabled

### Improvements

### Dependency updates

### Deployment changes
<!-- This section should only contain important things devops should know when updating service versions. -->
