### PR TITLE
Feat/results app workflow limit error UI

### DIFF
--- a/src/Analysis/GWASResults/TestData/TableData.js
+++ b/src/Analysis/GWASResults/TestData/TableData.js
@@ -26,7 +26,7 @@ const TableData = [
     gen3username: 'jakedoe@aol.com',
     startedAt: '2023-02-16T10:00:00Z',
     finishedAt: '2023-02-16T10:00:00Z',
-    phase: 'Succeeded',
+    phase: 'Failed',
     submittedAt: '2023-02-16T10:30:00Z',
   },
 ];

--- a/src/Analysis/GWASResults/Views/Home/Home.stories.jsx
+++ b/src/Analysis/GWASResults/Views/Home/Home.stories.jsx
@@ -77,7 +77,7 @@ const getMockWorkflowList = () => {
         .toString(36)
         .substr(2, 5)}@aol.com`,
       wf_name: 'User Added WF Name ' + requestCount,
-      uid: 'uid-' + requestCount,
+      uid: 'uid-' + requestCount + Math.random(),
       phase: getMockPhase(requestCount / 2),
       finishedAt: new Date(new Date() - Math.random() * 1e12).toISOString(),
       submittedAt: new Date(new Date() - Math.random() * 1e12).toISOString(),
@@ -101,16 +101,24 @@ MockedSuccess.parameters = {
         'http://:argowrapperpath/ga4gh/wes/v2/workflows',
         (req, res, ctx) => {
           const { argowrapperpath } = req.params;
-          // console.log(argowrapperpath);
           return res(ctx.delay(2000), ctx.json(getMockWorkflowList()));
+        }
+      ),
+      rest.get(
+        'http://:argowrapperpath/ga4gh/wes/v2/workflows/user-monthly',
+        (req, res, ctx) => {
+          const { argowrapperpath } = req.params;
+          return res(
+            ctx.delay(1000),
+            ctx.json({ workflow_run: 5, workflow_limit: 50 })
+          );
         }
       ),
       rest.post(
         'http://:argowrapperpath/ga4gh/wes/v2/retry/:workflow',
         (req, res, ctx) => {
           const { argowrapperpath, workflow } = req.params;
-          // console.log(argowrapperpath);
-          // console.log(workflow);
+          console.log('workflow', workflow);
           return res(
             ctx.delay(800),
             ctx.text(`${workflow} retried sucessfully`)
@@ -129,8 +137,17 @@ MockedSuccessButFailedRetry.parameters = {
         'http://:argowrapperpath/ga4gh/wes/v2/workflows',
         (req, res, ctx) => {
           const { argowrapperpath } = req.params;
-          // console.log(argowrapperpath);
           return res(ctx.delay(2000), ctx.json(getMockWorkflowList()));
+        }
+      ),
+      rest.get(
+        'http://:argowrapperpath/ga4gh/wes/v2/workflows/user-monthly',
+        (req, res, ctx) => {
+          const { argowrapperpath } = req.params;
+          return res(
+            ctx.delay(1000),
+            ctx.json({ workflow_run: 5, workflow_limit: 50 })
+          );
         }
       ),
       rest.post(

--- a/src/Analysis/GWASResults/Views/Home/Home.stories.jsx
+++ b/src/Analysis/GWASResults/Views/Home/Home.stories.jsx
@@ -117,7 +117,6 @@ MockedSuccess.parameters = {
         'http://:argowrapperpath/ga4gh/wes/v2/retry/:workflow',
         (req, res, ctx) => {
           const { argowrapperpath, workflow } = req.params;
-          console.log('workflow', workflow);
           return res(
             ctx.delay(800),
             ctx.text(`${workflow} retried sucessfully`)
@@ -215,7 +214,6 @@ MockedSuccessButWorkflowLimitReturnsMalformedDataForRetries.parameters = {
         'http://:argowrapperpath/ga4gh/wes/v2/workflows',
         (req, res, ctx) => {
           const { argowrapperpath } = req.params;
-          // console.log(argowrapperpath);
           return res(ctx.delay(2000), ctx.json(getMockWorkflowList()));
         }
       ),
@@ -245,7 +243,6 @@ MockedSuccessButWorkflowLimitReturns500ForRetries.parameters = {
         'http://:argowrapperpath/ga4gh/wes/v2/workflows',
         (req, res, ctx) => {
           const { argowrapperpath } = req.params;
-          // console.log(argowrapperpath);
           return res(ctx.delay(2000), ctx.json(getMockWorkflowList()));
         }
       ),

--- a/src/Analysis/GWASResults/Views/Home/Home.stories.jsx
+++ b/src/Analysis/GWASResults/Views/Home/Home.stories.jsx
@@ -48,11 +48,11 @@ let rowCount = 1;
 const getMockPhase = (requestCount) => {
   if (requestCount % 2 === 0) {
     return PHASES.Running;
-  } else if (requestCount % 5 === 0) {
+  } else if (requestCount % 3 === 0) {
     return PHASES.Error;
-  } else if (requestCount % 7 === 0) {
+  } else if (requestCount % 5 === 0) {
     return PHASES.Failed;
-  } else if (requestCount % 9 === 0) {
+  } else if (requestCount % 7 === 0) {
     return PHASES.Pending;
   } else {
     return PHASES.Succeeded;
@@ -166,8 +166,9 @@ MockedError.parameters = {
   },
 };
 
-export const MockedSuccessButExceededWorkflowLimit = MockTemplate.bind({});
-MockedSuccessButExceededWorkflowLimit.parameters = {
+export const MockedSuccessButExceededWorkflowLimitForRetries =
+  MockTemplate.bind({});
+MockedSuccessButExceededWorkflowLimitForRetries.parameters = {
   msw: {
     handlers: [
       rest.get(
@@ -187,6 +188,61 @@ MockedSuccessButExceededWorkflowLimit.parameters = {
             ctx.delay(1000),
             ctx.json({ workflow_run: 50, workflow_limit: 50 })
           );
+        }
+      ),
+    ],
+  },
+};
+
+export const MockedSuccessButWorkflowLimitReturnsMalformedDataForRetries =
+  MockTemplate.bind({});
+MockedSuccessButWorkflowLimitReturnsMalformedDataForRetries.parameters = {
+  msw: {
+    handlers: [
+      rest.get(
+        'http://:argowrapperpath/ga4gh/wes/v2/workflows',
+        (req, res, ctx) => {
+          const { argowrapperpath } = req.params;
+          // console.log(argowrapperpath);
+          return res(ctx.delay(2000), ctx.json(getMockWorkflowList()));
+        }
+      ),
+      rest.get(
+        'http://:argowrapperpath/ga4gh/wes/v2/workflows/user-monthly',
+        (req, res, ctx) => {
+          const { argowrapperpath } = req.params;
+          // console.log(argowrapperpath);
+          return res(
+            ctx.delay(3000),
+            ctx.json({
+              workflow_run: 'a string and an array?',
+              workflow_limit: [],
+            })
+          );
+        }
+      ),
+    ],
+  },
+};
+
+export const MockedSuccessButWorkflowLimitReturns500ForRetries =
+  MockTemplate.bind({});
+MockedSuccessButWorkflowLimitReturns500ForRetries.parameters = {
+  msw: {
+    handlers: [
+      rest.get(
+        'http://:argowrapperpath/ga4gh/wes/v2/workflows',
+        (req, res, ctx) => {
+          const { argowrapperpath } = req.params;
+          // console.log(argowrapperpath);
+          return res(ctx.delay(2000), ctx.json(getMockWorkflowList()));
+        }
+      ),
+      rest.get(
+        'http://:argowrapperpath/ga4gh/wes/v2/workflows/user-monthly',
+        (req, res, ctx) => {
+          const { argowrapperpath } = req.params;
+          return res(ctx.delay(3000), ctx.status(500), ctx.json('error'));
         }
       ),
     ],

--- a/src/Analysis/GWASResults/Views/Home/Home.stories.jsx
+++ b/src/Analysis/GWASResults/Views/Home/Home.stories.jsx
@@ -73,10 +73,12 @@ const getMockWorkflowList = () => {
   if (requestCount % 2 == 0) {
     workflowList.splice(0, 0, {
       name: 'argo-wrapper-workflow-' + createWorkflowNum(),
-      gen3username: `${(requestCount*Math.E).toString(36).substr(2, 5)}@aol.com`,
+      gen3username: `${(requestCount * Math.E)
+        .toString(36)
+        .substr(2, 5)}@aol.com`,
       wf_name: 'User Added WF Name ' + requestCount,
       uid: 'uid-' + requestCount,
-      phase: getMockPhase(requestCount/2),
+      phase: getMockPhase(requestCount / 2),
       finishedAt: new Date(new Date() - Math.random() * 1e12).toISOString(),
       submittedAt: new Date(new Date() - Math.random() * 1e12).toISOString(),
     });
@@ -87,7 +89,7 @@ const getMockWorkflowList = () => {
     workflowList[1].phase = PHASES.Succeeded;
     workflowList[2].phase = PHASES.Failed;
   }
-  console.log('workflowList: ', workflowList);
+  // console.log('workflowList: ', workflowList);
   return workflowList;
 };
 
@@ -99,7 +101,7 @@ MockedSuccess.parameters = {
         'http://:argowrapperpath/ga4gh/wes/v2/workflows',
         (req, res, ctx) => {
           const { argowrapperpath } = req.params;
-          console.log(argowrapperpath);
+          // console.log(argowrapperpath);
           return res(ctx.delay(2000), ctx.json(getMockWorkflowList()));
         }
       ),
@@ -107,9 +109,12 @@ MockedSuccess.parameters = {
         'http://:argowrapperpath/ga4gh/wes/v2/retry/:workflow',
         (req, res, ctx) => {
           const { argowrapperpath, workflow } = req.params;
-          console.log(argowrapperpath);
-          console.log(workflow);
-          return res(ctx.delay(800), ctx.text(`${workflow} retried sucessfully`));
+          // console.log(argowrapperpath);
+          // console.log(workflow);
+          return res(
+            ctx.delay(800),
+            ctx.text(`${workflow} retried sucessfully`)
+          );
         }
       ),
     ],
@@ -124,7 +129,7 @@ MockedSuccessButFailedRetry.parameters = {
         'http://:argowrapperpath/ga4gh/wes/v2/workflows',
         (req, res, ctx) => {
           const { argowrapperpath } = req.params;
-          console.log(argowrapperpath);
+          // console.log(argowrapperpath);
           return res(ctx.delay(2000), ctx.json(getMockWorkflowList()));
         }
       ),
@@ -132,9 +137,13 @@ MockedSuccessButFailedRetry.parameters = {
         'http://:argowrapperpath/ga4gh/wes/v2/retry/:workflow',
         (req, res, ctx) => {
           const { argowrapperpath, workflow } = req.params;
-          console.log(argowrapperpath);
-          console.log(workflow);
-          return res(ctx.delay(800), ctx.status(500), ctx.text(`${workflow} retry failed`));
+          // console.log(argowrapperpath);
+          // console.log(workflow);
+          return res(
+            ctx.delay(800),
+            ctx.status(500),
+            ctx.text(`${workflow} retry failed`)
+          );
         }
       ),
     ],
@@ -150,7 +159,34 @@ MockedError.parameters = {
         (req, res, ctx) => {
           const { argowrapperpath } = req.params;
           console.log(argowrapperpath);
-          return res(ctx.delay(1000), ctx.status(500), ctx.json({"test":123}));
+          return res(ctx.delay(1000), ctx.status(500), ctx.json({ test: 123 }));
+        }
+      ),
+    ],
+  },
+};
+
+export const MockedSuccessButExceededWorkflowLimit = MockTemplate.bind({});
+MockedSuccessButExceededWorkflowLimit.parameters = {
+  msw: {
+    handlers: [
+      rest.get(
+        'http://:argowrapperpath/ga4gh/wes/v2/workflows',
+        (req, res, ctx) => {
+          const { argowrapperpath } = req.params;
+          // console.log(argowrapperpath);
+          return res(ctx.delay(2000), ctx.json(getMockWorkflowList()));
+        }
+      ),
+      rest.get(
+        'http://:argowrapperpath/ga4gh/wes/v2/workflows/user-monthly',
+        (req, res, ctx) => {
+          const { argowrapperpath } = req.params;
+          // console.log(argowrapperpath);
+          return res(
+            ctx.delay(1000),
+            ctx.json({ workflow_run: 50, workflow_limit: 50 })
+          );
         }
       ),
     ],

--- a/src/Analysis/GWASResults/Views/Home/Home.stories.jsx
+++ b/src/Analysis/GWASResults/Views/Home/Home.stories.jsx
@@ -77,7 +77,7 @@ const getMockWorkflowList = () => {
         .toString(36)
         .substr(2, 5)}@aol.com`,
       wf_name: 'User Added WF Name ' + requestCount,
-      uid: 'uid-' + requestCount + Math.random(),
+      uid: 'uid-' + requestCount,
       phase: getMockPhase(requestCount / 2),
       finishedAt: new Date(new Date() - Math.random() * 1e12).toISOString(),
       submittedAt: new Date(new Date() - Math.random() * 1e12).toISOString(),

--- a/src/Analysis/GWASResults/Views/Home/Home.stories.jsx
+++ b/src/Analysis/GWASResults/Views/Home/Home.stories.jsx
@@ -48,11 +48,11 @@ let rowCount = 1;
 const getMockPhase = (requestCount) => {
   if (requestCount % 2 === 0) {
     return PHASES.Running;
-  } else if (requestCount % 3 === 0) {
-    return PHASES.Error;
   } else if (requestCount % 5 === 0) {
-    return PHASES.Failed;
+    return PHASES.Error;
   } else if (requestCount % 7 === 0) {
+    return PHASES.Failed;
+  } else if (requestCount % 9 === 0) {
     return PHASES.Pending;
   } else {
     return PHASES.Succeeded;
@@ -89,7 +89,6 @@ const getMockWorkflowList = () => {
     workflowList[1].phase = PHASES.Succeeded;
     workflowList[2].phase = PHASES.Failed;
   }
-  // console.log('workflowList: ', workflowList);
   return workflowList;
 };
 
@@ -154,8 +153,6 @@ MockedSuccessButFailedRetry.parameters = {
         'http://:argowrapperpath/ga4gh/wes/v2/retry/:workflow',
         (req, res, ctx) => {
           const { argowrapperpath, workflow } = req.params;
-          // console.log(argowrapperpath);
-          // console.log(workflow);
           return res(
             ctx.delay(800),
             ctx.status(500),
@@ -192,7 +189,6 @@ MockedSuccessButExceededWorkflowLimitForRetries.parameters = {
         'http://:argowrapperpath/ga4gh/wes/v2/workflows',
         (req, res, ctx) => {
           const { argowrapperpath } = req.params;
-          // console.log(argowrapperpath);
           return res(ctx.delay(2000), ctx.json(getMockWorkflowList()));
         }
       ),
@@ -200,7 +196,6 @@ MockedSuccessButExceededWorkflowLimitForRetries.parameters = {
         'http://:argowrapperpath/ga4gh/wes/v2/workflows/user-monthly',
         (req, res, ctx) => {
           const { argowrapperpath } = req.params;
-          // console.log(argowrapperpath);
           return res(
             ctx.delay(1000),
             ctx.json({ workflow_run: 50, workflow_limit: 50 })
@@ -228,7 +223,6 @@ MockedSuccessButWorkflowLimitReturnsMalformedDataForRetries.parameters = {
         'http://:argowrapperpath/ga4gh/wes/v2/workflows/user-monthly',
         (req, res, ctx) => {
           const { argowrapperpath } = req.params;
-          // console.log(argowrapperpath);
           return res(
             ctx.delay(3000),
             ctx.json({

--- a/src/Analysis/GWASResults/Views/Home/HomeTable/ActionsDropdown/ActionsDropdown.jsx
+++ b/src/Analysis/GWASResults/Views/Home/HomeTable/ActionsDropdown/ActionsDropdown.jsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Space, Dropdown, Button, notification, Spin } from 'antd';
+import {
+  Space, Dropdown, Button, notification, Spin,
+} from 'antd';
 import { EllipsisOutlined } from '@ant-design/icons';
 import { components } from '../../../../../../params';
 import {
@@ -39,7 +41,7 @@ const ActionsDropdown = ({ record }) => {
             <h3 style={{ color: '#2E77B8' }}>Monthly Workflow Limit</h3>
             {workflowLimitsInvalidDataMessage}
           </React.Fragment>,
-          'retry'
+          'retry',
         );
         return false;
       }
@@ -50,7 +52,7 @@ const ActionsDropdown = ({ record }) => {
             limit reached. Please contact support for assistance:{' '}
             <a href={supportEmail}>{supportEmail}</a>
           </React.Fragment>,
-          'retry'
+          'retry',
         );
         return false;
       }
@@ -62,7 +64,7 @@ const ActionsDropdown = ({ record }) => {
           <h3 style={{ color: '#2E77B8' }}>Monthly Workflow Limit</h3>
           {workflowLimitsLoadingErrorMessage}
         </React.Fragment>,
-        'retry'
+        'retry',
       );
       console.error('Error fetching workflow limit info: ', error);
     }
@@ -95,7 +97,7 @@ const ActionsDropdown = ({ record }) => {
             fetchPresignedUrlForWorkflowArtifact(
               record.name,
               record.uid,
-              'gwas_archive_index'
+              'gwas_archive_index',
             )
               .then((res) => {
                 window.open(res, '_blank');
@@ -103,7 +105,7 @@ const ActionsDropdown = ({ record }) => {
               .catch((error) => {
                 openOrUpdateNotification(
                   `❌ Could not download. \n\n${error}`,
-                  'download'
+                  'download',
                 );
               });
           }}

--- a/src/Analysis/GWASResults/Views/Home/HomeTable/ActionsDropdown/ActionsDropdown.jsx
+++ b/src/Analysis/GWASResults/Views/Home/HomeTable/ActionsDropdown/ActionsDropdown.jsx
@@ -19,6 +19,30 @@ const ActionsDropdown = ({ record }) => {
       duration: 0,
     });
   };
+
+
+  const checkWorkflowLimit =()=> {
+    return true;
+  }
+  const checkThenRetryWorkflow =  () => {
+    const isUserUnderWorkflowLimit = checkWorkflowLimit();
+    if (isUserUnderWorkflowLimit) {
+      retryWorkflow(record.name, record.uid)
+      .then(() => {
+        openNotification('Workflow successfully restarted.');
+      })
+      .catch(() => {
+        openNotification('❌ Retry request failed.');
+      });
+    }
+    else {
+      openNotification(<><h3 style={{color:'#2E77B8'}}>Monthly Workflow Limit</h3>Workflow limit reached. Please contact support for assistance: <a href='mailto:support@datacommons.io'>support@datacommons.io</a></>);
+      return null;
+    }
+
+  }
+
+
   const items = [
     {
       key: '1',
@@ -52,13 +76,14 @@ const ActionsDropdown = ({ record }) => {
           href=''
           onClick={(e) => {
             e.preventDefault();
-            retryWorkflow(record.name, record.uid)
+            checkThenRetryWorkflow(record.name, record.uid);
+/*             retryWorkflow(record.name, record.uid)
               .then(() => {
                 openNotification('Workflow successfully restarted.');
               })
               .catch(() => {
                 openNotification('❌ Retry request failed.');
-              });
+              }); */
           }}
         >
           Retry

--- a/src/Analysis/GWASResults/Views/Home/HomeTable/ActionsDropdown/ActionsDropdown.jsx
+++ b/src/Analysis/GWASResults/Views/Home/HomeTable/ActionsDropdown/ActionsDropdown.jsx
@@ -1,6 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Space, Dropdown, Button, notification, Spin } from 'antd';
+import {
+  Space, Dropdown, Button, notification, Spin,
+} from 'antd';
 import { EllipsisOutlined } from '@ant-design/icons';
 import { components } from '../../../../../../params';
 import {
@@ -36,7 +38,7 @@ const ActionsDropdown = ({ record }) => {
             <h3 style={{ color: '#2E77B8' }}>Monthly Workflow Limit</h3>
             {workflowLimitsInvalidDataMessage}
           </React.Fragment>,
-          'retry'
+          'retry',
         );
         return false;
       }
@@ -47,7 +49,7 @@ const ActionsDropdown = ({ record }) => {
             limit reached. Please contact support for assistance:{' '}
             <a href={supportEmail}>{supportEmail}</a>
           </React.Fragment>,
-          'retry'
+          'retry',
         );
         return false;
       }
@@ -59,7 +61,7 @@ const ActionsDropdown = ({ record }) => {
           <h3 style={{ color: '#2E77B8' }}>Monthly Workflow Limit</h3>
           {workflowLimitsLoadingErrorMessage}
         </React.Fragment>,
-        'retry'
+        'retry',
       );
       console.error('Error fetching workflow limit info: ', error);
     }
@@ -92,7 +94,7 @@ const ActionsDropdown = ({ record }) => {
             fetchPresignedUrlForWorkflowArtifact(
               record.name,
               record.uid,
-              'gwas_archive_index'
+              'gwas_archive_index',
             )
               .then((res) => {
                 window.open(res, '_blank');
@@ -100,7 +102,7 @@ const ActionsDropdown = ({ record }) => {
               .catch((error) => {
                 displayNotification(
                   `❌ Could not download. \n\n${error}`,
-                  'download'
+                  'download',
                 );
               });
           }}

--- a/src/Analysis/GWASResults/Views/Home/HomeTable/ActionsDropdown/ActionsDropdown.jsx
+++ b/src/Analysis/GWASResults/Views/Home/HomeTable/ActionsDropdown/ActionsDropdown.jsx
@@ -31,7 +31,7 @@ const ActionsDropdown = ({ record }) => {
   const supportEmail = components.login?.email || 'support@datacommons.io';
   const checkWorkflowLimit = async () => {
     try {
-      const data = await fetchMonthlyWorkflowLimitInfo(); // Await the function to get the JSON data
+      const data = await fetchMonthlyWorkflowLimitInfo();
       if (!workflowLimitInfoIsValid(data)) {
         displayNotification(
           <React.Fragment>
@@ -41,8 +41,7 @@ const ActionsDropdown = ({ record }) => {
           'retry',
         );
         return false;
-      }
-      if (data.workflow_run >= data.workflow_limit) {
+      } if (data.workflow_run >= data.workflow_limit) {
         displayNotification(
           <React.Fragment>
             <h3 style={{ color: '#2E77B8' }}>Monthly Workflow Limit</h3>Workflow
@@ -65,6 +64,7 @@ const ActionsDropdown = ({ record }) => {
       );
       console.error('Error fetching workflow limit info: ', error);
     }
+    return false;
   };
 
   const checkWorkflowLimitThenRetryWorkflow = async () => {
@@ -78,9 +78,8 @@ const ActionsDropdown = ({ record }) => {
           console.error(error);
           displayNotification('❌ Retry request failed.', 'retry');
         });
-    } else {
-      return null;
     }
+    return null;
   };
 
   const items = [

--- a/src/Analysis/GWASResults/Views/Home/HomeTable/ActionsDropdown/ActionsDropdown.jsx
+++ b/src/Analysis/GWASResults/Views/Home/HomeTable/ActionsDropdown/ActionsDropdown.jsx
@@ -19,7 +19,7 @@ const ActionsDropdown = ({ record }) => {
   const [api, contextHolder] = notification.useNotification();
   const displayNotification = (notificationMessage, key) => {
     api.open({
-      key: key,
+      key,
       message: notificationMessage,
       description: '',
       duration: 0,
@@ -39,7 +39,8 @@ const ActionsDropdown = ({ record }) => {
           'retry'
         );
         return false;
-      } else if (data.workflow_run >= data.workflow_limit) {
+      }
+      if (data.workflow_run >= data.workflow_limit) {
         displayNotification(
           <React.Fragment>
             <h3 style={{ color: '#2E77B8' }}>Monthly Workflow Limit</h3>Workflow
@@ -71,7 +72,8 @@ const ActionsDropdown = ({ record }) => {
         .then(() => {
           displayNotification('Workflow successfully restarted.', 'retry');
         })
-        .catch(() => {
+        .catch((error) => {
+          console.error(error);
           displayNotification('❌ Retry request failed.', 'retry');
         });
     } else {

--- a/src/Analysis/GWASResults/Views/Home/HomeTable/ActionsDropdown/ActionsDropdown.jsx
+++ b/src/Analysis/GWASResults/Views/Home/HomeTable/ActionsDropdown/ActionsDropdown.jsx
@@ -1,8 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import {
-  Space, Dropdown, Button, notification, Spin,
-} from 'antd';
+import { Space, Dropdown, Button, notification, Spin } from 'antd';
 import { EllipsisOutlined } from '@ant-design/icons';
 import { components } from '../../../../../../params';
 import {
@@ -19,7 +17,10 @@ import PHASES from '../../../../Utils/PhasesEnumeration';
 
 const ActionsDropdown = ({ record }) => {
   const [api, contextHolder] = notification.useNotification();
-  const displayNotification = (notificationMessage, key) => {
+
+  // Updates notifaction if already open and the key matches
+  // otherwise opens a new notification
+  const openOrUpdateNotification = (notificationMessage, key) => {
     api.open({
       key,
       message: notificationMessage,
@@ -33,34 +34,35 @@ const ActionsDropdown = ({ record }) => {
     try {
       const data = await fetchMonthlyWorkflowLimitInfo();
       if (!workflowLimitInfoIsValid(data)) {
-        displayNotification(
+        openOrUpdateNotification(
           <React.Fragment>
             <h3 style={{ color: '#2E77B8' }}>Monthly Workflow Limit</h3>
             {workflowLimitsInvalidDataMessage}
           </React.Fragment>,
-          'retry',
+          'retry'
         );
         return false;
-      } if (data.workflow_run >= data.workflow_limit) {
-        displayNotification(
+      }
+      if (data.workflow_run >= data.workflow_limit) {
+        openOrUpdateNotification(
           <React.Fragment>
             <h3 style={{ color: '#2E77B8' }}>Monthly Workflow Limit</h3>Workflow
             limit reached. Please contact support for assistance:{' '}
             <a href={supportEmail}>{supportEmail}</a>
           </React.Fragment>,
-          'retry',
+          'retry'
         );
         return false;
       }
       // workflow info is valid, return true to continue to Retry workflow
       return true;
     } catch (error) {
-      displayNotification(
+      openOrUpdateNotification(
         <React.Fragment>
           <h3 style={{ color: '#2E77B8' }}>Monthly Workflow Limit</h3>
           {workflowLimitsLoadingErrorMessage}
         </React.Fragment>,
-        'retry',
+        'retry'
       );
       console.error('Error fetching workflow limit info: ', error);
     }
@@ -72,11 +74,11 @@ const ActionsDropdown = ({ record }) => {
     if (isUserUnderWorkflowLimit === true) {
       retryWorkflow(record.name, record.uid)
         .then(() => {
-          displayNotification('Workflow successfully restarted.', 'retry');
+          openOrUpdateNotification('Workflow successfully restarted.', 'retry');
         })
         .catch((error) => {
           console.error(error);
-          displayNotification('❌ Retry request failed.', 'retry');
+          openOrUpdateNotification('❌ Retry request failed.', 'retry');
         });
     }
     return null;
@@ -93,15 +95,15 @@ const ActionsDropdown = ({ record }) => {
             fetchPresignedUrlForWorkflowArtifact(
               record.name,
               record.uid,
-              'gwas_archive_index',
+              'gwas_archive_index'
             )
               .then((res) => {
                 window.open(res, '_blank');
               })
               .catch((error) => {
-                displayNotification(
+                openOrUpdateNotification(
                   `❌ Could not download. \n\n${error}`,
-                  'download',
+                  'download'
                 );
               });
           }}
@@ -118,7 +120,7 @@ const ActionsDropdown = ({ record }) => {
           href=''
           onClick={(e) => {
             e.preventDefault();
-            displayNotification(<Spin />, 'retry');
+            openOrUpdateNotification(<Spin />, 'retry');
             checkWorkflowLimitThenRetryWorkflow(record.name, record.uid);
           }}
         >

--- a/src/Analysis/GWASResults/Views/Home/HomeTable/ActionsDropdown/ActionsDropdown.jsx
+++ b/src/Analysis/GWASResults/Views/Home/HomeTable/ActionsDropdown/ActionsDropdown.jsx
@@ -7,6 +7,7 @@ import {
   fetchMonthlyWorkflowLimitInfo,
   workflowLimitInfoIsValid,
   workflowLimitsInvalidDataMessage,
+  workflowLimitsLoadingErrorMessage,
 } from '../../../../../SharedUtils/WorkflowLimitsDashboard/WorkflowLimitsUtils';
 import {
   fetchPresignedUrlForWorkflowArtifact,
@@ -32,27 +33,33 @@ const ActionsDropdown = ({ record }) => {
       if (!workflowLimitInfoIsValid(data)) {
         console.log('workflow limit info sent is invalid: ', data);
         openNotification(
-          <>
+          <React.Fragment>
             <h3 style={{ color: '#2E77B8' }}>Monthly Workflow Limit</h3>
             {workflowLimitsInvalidDataMessage}
-          </>
+          </React.Fragment>
         );
         return false;
-      } else if (data['workflow_run'] >= data['workflow_limit']) {
+      }
+      if (data.workflow_run >= data.workflow_limit) {
         console.log('HERE!!! HERE!! ');
         openNotification(
-          <>
+          <React.Fragment>
             <h3 style={{ color: '#2E77B8' }}>Monthly Workflow Limit</h3>Workflow
             limit reached. Please contact support for assistance:{' '}
             <a href={supportEmail}>{supportEmail}</a>
-          </>
+          </React.Fragment>
         );
         return false;
-      } else {
-        // workflow info is valid, return true to continue to Retry workflow
-        return true;
       }
+      // workflow info is valid, return true to continue to Retry workflow
+      return true;
     } catch (error) {
+      openNotification(
+        <React.Fragment>
+          <h3 style={{ color: '#2E77B8' }}>Monthly Workflow Limit</h3>
+          {workflowLimitsLoadingErrorMessage}
+        </React.Fragment>
+      );
       console.error('Error fetching workflow limit info: ', error); // Log errors if any
     }
     /*

--- a/src/Analysis/GWASResults/Views/Home/HomeTable/ActionsDropdown/ActionsDropdown.test.jsx
+++ b/src/Analysis/GWASResults/Views/Home/HomeTable/ActionsDropdown/ActionsDropdown.test.jsx
@@ -13,7 +13,7 @@ jest.mock(
     workflowLimitInfoIsValid: jest.fn(),
     workflowLimitsInvalidDataMessage: 'Invalid data message',
     workflowLimitsLoadingErrorMessage: 'Loading error message',
-  }),
+  })
 );
 
 jest.mock('../../../../Utils/gwasWorkflowApi', () => ({
@@ -21,7 +21,8 @@ jest.mock('../../../../Utils/gwasWorkflowApi', () => ({
   retryWorkflow: jest.fn(),
 }));
 
-const mockFetchMonthlyWorkflowLimitInfo = WorkflowUtils.fetchMonthlyWorkflowLimitInfo;
+const mockFetchMonthlyWorkflowLimitInfo =
+  WorkflowUtils.fetchMonthlyWorkflowLimitInfo;
 const mockWorkflowLimitInfoIsValid = WorkflowUtils.workflowLimitInfoIsValid;
 const mockRetryWorkflow = gwasWorkflowApi.retryWorkflow;
 
@@ -40,7 +41,7 @@ describe('ActionsDropdown', () => {
   it('should open the dropdown menu when the button is clicked and Retry option should be disabled for the Phase "running"', () => {
     const record = { phase: PHASES.Running };
     const { getByRole, getByText } = render(
-      <ActionsDropdown record={record} />,
+      <ActionsDropdown record={record} />
     );
     const dropdownButton = getByRole('button');
     waitFor(() => {
@@ -49,13 +50,13 @@ describe('ActionsDropdown', () => {
     expect(getByText('Download')).toBeInTheDocument();
     expect(getByText('Retry')).toBeInTheDocument();
     expect(getByText('Retry').parentElement.parentElement).toHaveClass(
-      'ant-dropdown-menu-item-disabled',
+      'ant-dropdown-menu-item-disabled'
     );
   });
   it('should open the dropdown menu when the button is clicked and Retry option should be enabled for the Phase "failed"', () => {
     const record = { phase: PHASES.Failed };
     const { getByRole, getByText } = render(
-      <ActionsDropdown record={record} />,
+      <ActionsDropdown record={record} />
     );
     const dropdownButton = getByRole('button');
     waitFor(() => {
@@ -64,14 +65,14 @@ describe('ActionsDropdown', () => {
     expect(getByText('Download')).toBeInTheDocument();
     expect(getByText('Retry')).toBeInTheDocument();
     expect(getByText('Retry').parentElement.parentElement).not.toHaveClass(
-      'ant-dropdown-menu-item-disabled',
+      'ant-dropdown-menu-item-disabled'
     );
   });
 
   it('should disabled Download option for the Phase "failed"', () => {
     const record = { phase: PHASES.Failed };
     const { getByRole, getByText } = render(
-      <ActionsDropdown record={record} />,
+      <ActionsDropdown record={record} />
     );
     const dropdownButton = getByRole('button');
     waitFor(() => {
@@ -80,13 +81,13 @@ describe('ActionsDropdown', () => {
     expect(getByText('Download')).toBeInTheDocument();
     expect(getByText('Retry')).toBeInTheDocument();
     expect(getByText('Download').parentElement.parentElement).toHaveClass(
-      'ant-dropdown-menu-item-disabled',
+      'ant-dropdown-menu-item-disabled'
     );
   });
   it('should enabled Download option for the Phase "Succeeded"', () => {
     const record = { phase: PHASES.Succeeded };
     const { getByRole, getByText } = render(
-      <ActionsDropdown record={record} />,
+      <ActionsDropdown record={record} />
     );
     const dropdownButton = getByRole('button');
     waitFor(() => {
@@ -95,7 +96,7 @@ describe('ActionsDropdown', () => {
     expect(getByText('Download')).toBeInTheDocument();
     expect(getByText('Retry')).toBeInTheDocument();
     expect(getByText('Download').parentElement.parentElement).not.toHaveClass(
-      'ant-dropdown-menu-item-disabled',
+      'ant-dropdown-menu-item-disabled'
     );
   });
 
@@ -111,7 +112,7 @@ describe('ActionsDropdown', () => {
     mockRetryWorkflow.mockResolvedValue();
 
     const { getByRole, getByText } = render(
-      <ActionsDropdown record={mockRecord} />,
+      <ActionsDropdown record={mockRecord} />
     );
 
     const dropdownButton = getByRole('button');
@@ -127,18 +128,18 @@ describe('ActionsDropdown', () => {
       expect(mockFetchMonthlyWorkflowLimitInfo).toHaveBeenCalled();
       expect(mockRetryWorkflow).toHaveBeenCalledWith(
         mockRecord.name,
-        mockRecord.uid,
+        mockRecord.uid
       );
     });
   });
 
   it('displays error notification when workflow limit fetch fails', async () => {
     mockFetchMonthlyWorkflowLimitInfo.mockRejectedValue(
-      new Error('Fetch error'),
+      new Error('Fetch error')
     );
 
     const { getByRole, getByText } = render(
-      <ActionsDropdown record={mockRecord} />,
+      <ActionsDropdown record={mockRecord} />
     );
 
     const dropdownButton = getByRole('button');
@@ -163,11 +164,13 @@ describe('ActionsDropdown', () => {
     mockRetryWorkflow.mockRejectedValue(new Error('Retry error'));
 
     const { getByRole, getByText } = render(
-      <ActionsDropdown record={mockRecord} />,
+      <ActionsDropdown record={mockRecord} />
     );
 
-    const dropdownButton = getByRole('button', { name: /ellipsis/i });
-    fireEvent.click(dropdownButton);
+    const dropdownButton = getByRole('button');
+    waitFor(() => {
+      fireEvent.click(dropdownButton);
+    });
 
     const retryLink = getByText(/Retry/i);
     fireEvent.click(retryLink);

--- a/src/Analysis/GWASResults/Views/Home/HomeTable/ActionsDropdown/ActionsDropdown.test.jsx
+++ b/src/Analysis/GWASResults/Views/Home/HomeTable/ActionsDropdown/ActionsDropdown.test.jsx
@@ -1,14 +1,46 @@
 import React from 'react';
-import { render, fireEvent, waitFor } from '@testing-library/react';
+import { render, fireEvent, waitFor, getByRole } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import ActionsDropdown from './ActionsDropdown';
 import PHASES from '../../../../Utils/PhasesEnumeration';
+import * as WorkflowUtils from '../../../../../SharedUtils/WorkflowLimitsDashboard/WorkflowLimitsUtils';
+import * as gwasWorkflowApi from '../../../../Utils/gwasWorkflowApi';
+
+// Mock the imported functions and components
+jest.mock(
+  '../../../../../SharedUtils/WorkflowLimitsDashboard/WorkflowLimitsUtils',
+  () => ({
+    fetchMonthlyWorkflowLimitInfo: jest.fn(),
+    workflowLimitInfoIsValid: jest.fn(),
+    workflowLimitsInvalidDataMessage: 'Invalid data message',
+    workflowLimitsLoadingErrorMessage: 'Loading error message',
+  })
+);
+
+jest.mock('../../../../Utils/gwasWorkflowApi', () => ({
+  fetchPresignedUrlForWorkflowArtifact: jest.fn(),
+  retryWorkflow: jest.fn(),
+}));
+
+const mockFetchMonthlyWorkflowLimitInfo =
+  WorkflowUtils.fetchMonthlyWorkflowLimitInfo;
+const mockWorkflowLimitInfoIsValid = WorkflowUtils.workflowLimitInfoIsValid;
+const mockRetryWorkflow = gwasWorkflowApi.retryWorkflow;
+const mockFetchPresignedUrlForWorkflowArtifact =
+  gwasWorkflowApi.fetchPresignedUrlForWorkflowArtifact;
+
+const mockRecord = {
+  name: 'testWorkflow',
+  uid: '12345',
+  phase: PHASES.Succeeded,
+};
 
 describe('ActionsDropdown', () => {
+  /*
   it('should open the dropdown menu when the button is clicked and Retry option should be disabled for the Phase "running"', () => {
     const record = { phase: PHASES.Running };
     const { getByRole, getByText } = render(
-      <ActionsDropdown record={record} />,
+      <ActionsDropdown record={record} />
     );
     const dropdownButton = getByRole('button');
     waitFor(() => {
@@ -17,13 +49,13 @@ describe('ActionsDropdown', () => {
     expect(getByText('Download')).toBeInTheDocument();
     expect(getByText('Retry')).toBeInTheDocument();
     expect(getByText('Retry').parentElement.parentElement).toHaveClass(
-      'ant-dropdown-menu-item-disabled',
+      'ant-dropdown-menu-item-disabled'
     );
   });
   it('should open the dropdown menu when the button is clicked and Retry option should be enabled for the Phase "failed"', () => {
     const record = { phase: PHASES.Failed };
     const { getByRole, getByText } = render(
-      <ActionsDropdown record={record} />,
+      <ActionsDropdown record={record} />
     );
     const dropdownButton = getByRole('button');
     waitFor(() => {
@@ -32,14 +64,14 @@ describe('ActionsDropdown', () => {
     expect(getByText('Download')).toBeInTheDocument();
     expect(getByText('Retry')).toBeInTheDocument();
     expect(getByText('Retry').parentElement.parentElement).not.toHaveClass(
-      'ant-dropdown-menu-item-disabled',
+      'ant-dropdown-menu-item-disabled'
     );
   });
 
   it('should disabled Download option for the Phase "failed"', () => {
     const record = { phase: PHASES.Failed };
     const { getByRole, getByText } = render(
-      <ActionsDropdown record={record} />,
+      <ActionsDropdown record={record} />
     );
     const dropdownButton = getByRole('button');
     waitFor(() => {
@@ -48,13 +80,13 @@ describe('ActionsDropdown', () => {
     expect(getByText('Download')).toBeInTheDocument();
     expect(getByText('Retry')).toBeInTheDocument();
     expect(getByText('Download').parentElement.parentElement).toHaveClass(
-      'ant-dropdown-menu-item-disabled',
+      'ant-dropdown-menu-item-disabled'
     );
   });
   it('should enabled Download option for the Phase "Succeeded"', () => {
     const record = { phase: PHASES.Succeeded };
     const { getByRole, getByText } = render(
-      <ActionsDropdown record={record} />,
+      <ActionsDropdown record={record} />
     );
     const dropdownButton = getByRole('button');
     waitFor(() => {
@@ -63,7 +95,88 @@ describe('ActionsDropdown', () => {
     expect(getByText('Download')).toBeInTheDocument();
     expect(getByText('Retry')).toBeInTheDocument();
     expect(getByText('Download').parentElement.parentElement).not.toHaveClass(
-      'ant-dropdown-menu-item-disabled',
+      'ant-dropdown-menu-item-disabled'
     );
+  });
+
+  */
+  // NEW TESTS
+
+  /*
+  it('handles the Retry click event correctly when workflow limit is valid', async () => {
+    mockFetchMonthlyWorkflowLimitInfo.mockResolvedValue({
+      workflow_run: 0,
+      workflow_limit: 50,
+    });
+    mockWorkflowLimitInfoIsValid.mockReturnValue(true);
+    mockRetryWorkflow.mockResolvedValue();
+
+    const { getByRole, getByText } = render(
+      <ActionsDropdown record={mockRecord} />
+    );
+
+    const dropdownButton = getByRole('button');
+    waitFor(() => {
+      fireEvent.click(dropdownButton);
+    });
+
+    const retryLink = getByText(/Retry/i);
+    waitFor(() => {
+      fireEvent.click(retryLink);
+    });
+    await waitFor(() => {
+      expect(mockFetchMonthlyWorkflowLimitInfo).toHaveBeenCalled();
+      expect(mockRetryWorkflow).toHaveBeenCalledWith(
+        mockRecord.name,
+        mockRecord.uid
+      );
+    });
+  });
+
+
+  it('displays error notification when workflow limit fetch fails', async () => {
+    mockFetchMonthlyWorkflowLimitInfo.mockRejectedValue(
+      new Error('Fetch error')
+    );
+
+    const { getByRole, getByText } = render(
+      <ActionsDropdown record={mockRecord} />
+    );
+
+    const dropdownButton = getByRole('button');
+    waitFor(() => {
+      fireEvent.click(dropdownButton);
+    });
+
+    const retryLink = getByText(/Retry/i);
+    fireEvent.click(retryLink);
+
+    await waitFor(() => {
+      expect(getByText(/Loading error message/i)).toBeInTheDocument();
+    });
+  });
+
+   */
+  it('displays error notification when retry workflow fails', async () => {
+    mockFetchMonthlyWorkflowLimitInfo.mockResolvedValue({
+      workflow_run: 0,
+      workflow_limit: 10,
+    });
+    mockWorkflowLimitInfoIsValid.mockReturnValue(true);
+    mockRetryWorkflow.mockRejectedValue(new Error('Retry error'));
+
+    const { getByRole, getByText } = render(
+      <ActionsDropdown record={mockRecord} />
+    );
+
+    const dropdownButton = getByRole('button', { name: /ellipsis/i });
+    fireEvent.click(dropdownButton);
+
+    const retryLink = getByText(/Retry/i);
+    fireEvent.click(retryLink);
+
+    await waitFor(() => {
+      expect(getByText(/Retry request failed./i)).toBeInTheDocument();
+    });
   });
 });

--- a/src/Analysis/GWASResults/Views/Home/HomeTable/ActionsDropdown/ActionsDropdown.test.jsx
+++ b/src/Analysis/GWASResults/Views/Home/HomeTable/ActionsDropdown/ActionsDropdown.test.jsx
@@ -13,7 +13,7 @@ jest.mock(
     workflowLimitInfoIsValid: jest.fn(),
     workflowLimitsInvalidDataMessage: 'Invalid data message',
     workflowLimitsLoadingErrorMessage: 'Loading error message',
-  })
+  }),
 );
 
 jest.mock('../../../../Utils/gwasWorkflowApi', () => ({
@@ -21,8 +21,7 @@ jest.mock('../../../../Utils/gwasWorkflowApi', () => ({
   retryWorkflow: jest.fn(),
 }));
 
-const mockFetchMonthlyWorkflowLimitInfo =
-  WorkflowUtils.fetchMonthlyWorkflowLimitInfo;
+const mockFetchMonthlyWorkflowLimitInfo = WorkflowUtils.fetchMonthlyWorkflowLimitInfo;
 const mockWorkflowLimitInfoIsValid = WorkflowUtils.workflowLimitInfoIsValid;
 const mockRetryWorkflow = gwasWorkflowApi.retryWorkflow;
 
@@ -41,7 +40,7 @@ describe('ActionsDropdown', () => {
   it('should open the dropdown menu when the button is clicked and Retry option should be disabled for the Phase "running"', () => {
     const record = { phase: PHASES.Running };
     const { getByRole, getByText } = render(
-      <ActionsDropdown record={record} />
+      <ActionsDropdown record={record} />,
     );
     const dropdownButton = getByRole('button');
     waitFor(() => {
@@ -50,13 +49,13 @@ describe('ActionsDropdown', () => {
     expect(getByText('Download')).toBeInTheDocument();
     expect(getByText('Retry')).toBeInTheDocument();
     expect(getByText('Retry').parentElement.parentElement).toHaveClass(
-      'ant-dropdown-menu-item-disabled'
+      'ant-dropdown-menu-item-disabled',
     );
   });
   it('should open the dropdown menu when the button is clicked and Retry option should be enabled for the Phase "failed"', () => {
     const record = { phase: PHASES.Failed };
     const { getByRole, getByText } = render(
-      <ActionsDropdown record={record} />
+      <ActionsDropdown record={record} />,
     );
     const dropdownButton = getByRole('button');
     waitFor(() => {
@@ -65,14 +64,14 @@ describe('ActionsDropdown', () => {
     expect(getByText('Download')).toBeInTheDocument();
     expect(getByText('Retry')).toBeInTheDocument();
     expect(getByText('Retry').parentElement.parentElement).not.toHaveClass(
-      'ant-dropdown-menu-item-disabled'
+      'ant-dropdown-menu-item-disabled',
     );
   });
 
   it('should disabled Download option for the Phase "failed"', () => {
     const record = { phase: PHASES.Failed };
     const { getByRole, getByText } = render(
-      <ActionsDropdown record={record} />
+      <ActionsDropdown record={record} />,
     );
     const dropdownButton = getByRole('button');
     waitFor(() => {
@@ -81,13 +80,13 @@ describe('ActionsDropdown', () => {
     expect(getByText('Download')).toBeInTheDocument();
     expect(getByText('Retry')).toBeInTheDocument();
     expect(getByText('Download').parentElement.parentElement).toHaveClass(
-      'ant-dropdown-menu-item-disabled'
+      'ant-dropdown-menu-item-disabled',
     );
   });
   it('should enabled Download option for the Phase "Succeeded"', () => {
     const record = { phase: PHASES.Succeeded };
     const { getByRole, getByText } = render(
-      <ActionsDropdown record={record} />
+      <ActionsDropdown record={record} />,
     );
     const dropdownButton = getByRole('button');
     waitFor(() => {
@@ -96,7 +95,7 @@ describe('ActionsDropdown', () => {
     expect(getByText('Download')).toBeInTheDocument();
     expect(getByText('Retry')).toBeInTheDocument();
     expect(getByText('Download').parentElement.parentElement).not.toHaveClass(
-      'ant-dropdown-menu-item-disabled'
+      'ant-dropdown-menu-item-disabled',
     );
   });
 
@@ -112,7 +111,7 @@ describe('ActionsDropdown', () => {
     mockRetryWorkflow.mockResolvedValue();
 
     const { getByRole, getByText } = render(
-      <ActionsDropdown record={mockRecord} />
+      <ActionsDropdown record={mockRecord} />,
     );
 
     const dropdownButton = getByRole('button');
@@ -128,18 +127,18 @@ describe('ActionsDropdown', () => {
       expect(mockFetchMonthlyWorkflowLimitInfo).toHaveBeenCalled();
       expect(mockRetryWorkflow).toHaveBeenCalledWith(
         mockRecord.name,
-        mockRecord.uid
+        mockRecord.uid,
       );
     });
   });
 
   it('displays error notification when workflow limit fetch fails', async () => {
     mockFetchMonthlyWorkflowLimitInfo.mockRejectedValue(
-      new Error('Fetch error')
+      new Error('Fetch error'),
     );
 
     const { getByRole, getByText } = render(
-      <ActionsDropdown record={mockRecord} />
+      <ActionsDropdown record={mockRecord} />,
     );
 
     const dropdownButton = getByRole('button');
@@ -164,7 +163,7 @@ describe('ActionsDropdown', () => {
     mockRetryWorkflow.mockRejectedValue(new Error('Retry error'));
 
     const { getByRole, getByText } = render(
-      <ActionsDropdown record={mockRecord} />
+      <ActionsDropdown record={mockRecord} />,
     );
 
     const dropdownButton = getByRole('button');

--- a/src/Analysis/GWASResults/Views/Home/HomeTable/ActionsDropdown/ActionsDropdown.test.jsx
+++ b/src/Analysis/GWASResults/Views/Home/HomeTable/ActionsDropdown/ActionsDropdown.test.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, fireEvent, waitFor, getByRole } from '@testing-library/react';
+import { render, fireEvent, waitFor } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import ActionsDropdown from './ActionsDropdown';
 import PHASES from '../../../../Utils/PhasesEnumeration';
@@ -13,7 +13,7 @@ jest.mock(
     workflowLimitInfoIsValid: jest.fn(),
     workflowLimitsInvalidDataMessage: 'Invalid data message',
     workflowLimitsLoadingErrorMessage: 'Loading error message',
-  })
+  }),
 );
 
 jest.mock('../../../../Utils/gwasWorkflowApi', () => ({
@@ -21,12 +21,9 @@ jest.mock('../../../../Utils/gwasWorkflowApi', () => ({
   retryWorkflow: jest.fn(),
 }));
 
-const mockFetchMonthlyWorkflowLimitInfo =
-  WorkflowUtils.fetchMonthlyWorkflowLimitInfo;
+const mockFetchMonthlyWorkflowLimitInfo = WorkflowUtils.fetchMonthlyWorkflowLimitInfo;
 const mockWorkflowLimitInfoIsValid = WorkflowUtils.workflowLimitInfoIsValid;
 const mockRetryWorkflow = gwasWorkflowApi.retryWorkflow;
-const mockFetchPresignedUrlForWorkflowArtifact =
-  gwasWorkflowApi.fetchPresignedUrlForWorkflowArtifact;
 
 const mockRecord = {
   name: 'testWorkflow',
@@ -43,7 +40,7 @@ describe('ActionsDropdown', () => {
   it('should open the dropdown menu when the button is clicked and Retry option should be disabled for the Phase "running"', () => {
     const record = { phase: PHASES.Running };
     const { getByRole, getByText } = render(
-      <ActionsDropdown record={record} />
+      <ActionsDropdown record={record} />,
     );
     const dropdownButton = getByRole('button');
     waitFor(() => {
@@ -52,13 +49,13 @@ describe('ActionsDropdown', () => {
     expect(getByText('Download')).toBeInTheDocument();
     expect(getByText('Retry')).toBeInTheDocument();
     expect(getByText('Retry').parentElement.parentElement).toHaveClass(
-      'ant-dropdown-menu-item-disabled'
+      'ant-dropdown-menu-item-disabled',
     );
   });
   it('should open the dropdown menu when the button is clicked and Retry option should be enabled for the Phase "failed"', () => {
     const record = { phase: PHASES.Failed };
     const { getByRole, getByText } = render(
-      <ActionsDropdown record={record} />
+      <ActionsDropdown record={record} />,
     );
     const dropdownButton = getByRole('button');
     waitFor(() => {
@@ -67,14 +64,14 @@ describe('ActionsDropdown', () => {
     expect(getByText('Download')).toBeInTheDocument();
     expect(getByText('Retry')).toBeInTheDocument();
     expect(getByText('Retry').parentElement.parentElement).not.toHaveClass(
-      'ant-dropdown-menu-item-disabled'
+      'ant-dropdown-menu-item-disabled',
     );
   });
 
   it('should disabled Download option for the Phase "failed"', () => {
     const record = { phase: PHASES.Failed };
     const { getByRole, getByText } = render(
-      <ActionsDropdown record={record} />
+      <ActionsDropdown record={record} />,
     );
     const dropdownButton = getByRole('button');
     waitFor(() => {
@@ -83,13 +80,13 @@ describe('ActionsDropdown', () => {
     expect(getByText('Download')).toBeInTheDocument();
     expect(getByText('Retry')).toBeInTheDocument();
     expect(getByText('Download').parentElement.parentElement).toHaveClass(
-      'ant-dropdown-menu-item-disabled'
+      'ant-dropdown-menu-item-disabled',
     );
   });
   it('should enabled Download option for the Phase "Succeeded"', () => {
     const record = { phase: PHASES.Succeeded };
     const { getByRole, getByText } = render(
-      <ActionsDropdown record={record} />
+      <ActionsDropdown record={record} />,
     );
     const dropdownButton = getByRole('button');
     waitFor(() => {
@@ -98,7 +95,7 @@ describe('ActionsDropdown', () => {
     expect(getByText('Download')).toBeInTheDocument();
     expect(getByText('Retry')).toBeInTheDocument();
     expect(getByText('Download').parentElement.parentElement).not.toHaveClass(
-      'ant-dropdown-menu-item-disabled'
+      'ant-dropdown-menu-item-disabled',
     );
   });
 
@@ -114,7 +111,7 @@ describe('ActionsDropdown', () => {
     mockRetryWorkflow.mockResolvedValue();
 
     const { getByRole, getByText } = render(
-      <ActionsDropdown record={mockRecord} />
+      <ActionsDropdown record={mockRecord} />,
     );
 
     const dropdownButton = getByRole('button');
@@ -130,18 +127,18 @@ describe('ActionsDropdown', () => {
       expect(mockFetchMonthlyWorkflowLimitInfo).toHaveBeenCalled();
       expect(mockRetryWorkflow).toHaveBeenCalledWith(
         mockRecord.name,
-        mockRecord.uid
+        mockRecord.uid,
       );
     });
   });
 
   it('displays error notification when workflow limit fetch fails', async () => {
     mockFetchMonthlyWorkflowLimitInfo.mockRejectedValue(
-      new Error('Fetch error')
+      new Error('Fetch error'),
     );
 
     const { getByRole, getByText } = render(
-      <ActionsDropdown record={mockRecord} />
+      <ActionsDropdown record={mockRecord} />,
     );
 
     const dropdownButton = getByRole('button');
@@ -166,7 +163,7 @@ describe('ActionsDropdown', () => {
     mockRetryWorkflow.mockRejectedValue(new Error('Retry error'));
 
     const { getByRole, getByText } = render(
-      <ActionsDropdown record={mockRecord} />
+      <ActionsDropdown record={mockRecord} />,
     );
 
     const dropdownButton = getByRole('button', { name: /ellipsis/i });

--- a/src/Analysis/GWASResults/Views/Home/HomeTable/ActionsDropdown/ActionsDropdown.test.jsx
+++ b/src/Analysis/GWASResults/Views/Home/HomeTable/ActionsDropdown/ActionsDropdown.test.jsx
@@ -6,7 +6,6 @@ import PHASES from '../../../../Utils/PhasesEnumeration';
 import * as WorkflowUtils from '../../../../../SharedUtils/WorkflowLimitsDashboard/WorkflowLimitsUtils';
 import * as gwasWorkflowApi from '../../../../Utils/gwasWorkflowApi';
 
-// Mock the imported functions and components
 jest.mock(
   '../../../../../SharedUtils/WorkflowLimitsDashboard/WorkflowLimitsUtils',
   () => ({
@@ -36,7 +35,11 @@ const mockRecord = {
 };
 
 describe('ActionsDropdown', () => {
-  /*
+  beforeEach(() => {
+    // Mock console.error to suppress error messages
+    console.error = jest.fn();
+  });
+
   it('should open the dropdown menu when the button is clicked and Retry option should be disabled for the Phase "running"', () => {
     const record = { phase: PHASES.Running };
     const { getByRole, getByText } = render(
@@ -99,15 +102,14 @@ describe('ActionsDropdown', () => {
     );
   });
 
-  */
-  // NEW TESTS
+  // Tests for Retry Event
 
-  /*
   it('handles the Retry click event correctly when workflow limit is valid', async () => {
     mockFetchMonthlyWorkflowLimitInfo.mockResolvedValue({
       workflow_run: 0,
       workflow_limit: 50,
     });
+
     mockWorkflowLimitInfoIsValid.mockReturnValue(true);
     mockRetryWorkflow.mockResolvedValue();
 
@@ -133,7 +135,6 @@ describe('ActionsDropdown', () => {
     });
   });
 
-
   it('displays error notification when workflow limit fetch fails', async () => {
     mockFetchMonthlyWorkflowLimitInfo.mockRejectedValue(
       new Error('Fetch error')
@@ -156,7 +157,6 @@ describe('ActionsDropdown', () => {
     });
   });
 
-   */
   it('displays error notification when retry workflow fails', async () => {
     mockFetchMonthlyWorkflowLimitInfo.mockResolvedValue({
       workflow_run: 0,

--- a/src/Discovery/index.tsx
+++ b/src/Discovery/index.tsx
@@ -103,13 +103,7 @@ const DiscoveryWithMDSBackend: React.FC<{
         }
         const studiesWithAccessibleField = rawStudies.map((study) => {
           let accessible: AccessLevel;
-          if (supportedValues?.unaccessible?.enabled
-            && dataAvailabilityField
-            && study[dataAvailabilityField] === 'unaccessible') {
-            accessible = AccessLevel.UNACCESSIBLE;
-          } else if (supportedValues?.notAvailable?.enabled
-            && dataAvailabilityField
-            && study[dataAvailabilityField] === 'not_available') {
+          if (supportedValues?.notAvailable?.enabled && dataAvailabilityField && study[dataAvailabilityField] === 'not_available') {
             accessible = AccessLevel.NOT_AVAILABLE;
           } else if (supportedValues?.waiting?.enabled && !study[authzField]) {
             accessible = AccessLevel.WAITING;

--- a/src/Discovery/index.tsx
+++ b/src/Discovery/index.tsx
@@ -103,7 +103,13 @@ const DiscoveryWithMDSBackend: React.FC<{
         }
         const studiesWithAccessibleField = rawStudies.map((study) => {
           let accessible: AccessLevel;
-          if (supportedValues?.notAvailable?.enabled && dataAvailabilityField && study[dataAvailabilityField] === 'not_available') {
+          if (supportedValues?.unaccessible?.enabled
+            && dataAvailabilityField
+            && study[dataAvailabilityField] === 'unaccessible') {
+            accessible = AccessLevel.UNACCESSIBLE;
+          } else if (supportedValues?.notAvailable?.enabled
+            && dataAvailabilityField
+            && study[dataAvailabilityField] === 'not_available') {
             accessible = AccessLevel.NOT_AVAILABLE;
           } else if (supportedValues?.waiting?.enabled && !study[authzField]) {
             accessible = AccessLevel.WAITING;


### PR DESCRIPTION
Link to JIRA ticket if there is one: 
https://ctds-planx.atlassian.net/browse/VADC-1269

**Dev Notes**
* Functionality can be tested using storybook, i.e. ```npm run storybook```
* Updates test data to make storybook easier to use
* Per discussion with stakeholder, uses AntD notification component instead of AntD Modal. This allows for display of a loading state, a consistent UI with other Action Dropdown events and multiple notifications when retrying multiple workflows simultaneously 

DESIGN
<img width="1061" alt="image" src="https://github.com/user-attachments/assets/fa54aae1-fce9-4562-b40c-fd46d7dc7c27">

IMPLEMENTATION
![output](https://github.com/user-attachments/assets/a13c921f-6484-4cc8-bc05-6cfef809b023)
![output](https://github.com/user-attachments/assets/24a3fc75-9639-4c06-845e-fbfbb537cf70)


### New Features
* Adds messaging for VADC Results app for workflow limits and prevents submission of retries if workflow limit service is unavailable, returns malformed data or if user's workflow limit is exceeded