### PR TITLE
Bugfix/fallback for null unprocessed chart data

### DIFF
--- a/src/Analysis/AtlasDataDictionary/AtlasDataDictionaryTable/Components/TableRow/ValueSummaryChart/ValueSummaryChart.tsx
+++ b/src/Analysis/AtlasDataDictionary/AtlasDataDictionaryTable/Components/TableRow/ValueSummaryChart/ValueSummaryChart.tsx
@@ -46,7 +46,7 @@ const ValueSummaryChart = ({
   const xAxisInterval = chartType === 'Number' ? 1 : 0;
 
   const processNumericChartData = (unProcessedChartData:IValueSummary[]) => {
-    if (unProcessedChartData == null) return false;
+    if (!Array.isArray(unProcessedChartData)) return false;
     let processedNumericData = unProcessedChartData.sort(
       (a: IValueSummary | any, b: IValueSummary| any) => a.start - b.start,
     );

--- a/src/Analysis/AtlasDataDictionary/AtlasDataDictionaryTable/Components/TableRow/ValueSummaryChart/ValueSummaryChart.tsx
+++ b/src/Analysis/AtlasDataDictionary/AtlasDataDictionaryTable/Components/TableRow/ValueSummaryChart/ValueSummaryChart.tsx
@@ -46,8 +46,7 @@ const ValueSummaryChart = ({
   const xAxisInterval = chartType === 'Number' ? 1 : 0;
 
   const processNumericChartData = (unProcessedChartData:IValueSummary[]) => {
-    console.log('unProcessedChartData',unProcessedChartData);
-    if(unProcessedChartData == null) return false;
+    if (unProcessedChartData == null) return false;
     let processedNumericData = unProcessedChartData.sort(
       (a: IValueSummary | any, b: IValueSummary| any) => a.start - b.start,
     );

--- a/src/Analysis/AtlasDataDictionary/AtlasDataDictionaryTable/Components/TableRow/ValueSummaryChart/ValueSummaryChart.tsx
+++ b/src/Analysis/AtlasDataDictionary/AtlasDataDictionaryTable/Components/TableRow/ValueSummaryChart/ValueSummaryChart.tsx
@@ -46,6 +46,8 @@ const ValueSummaryChart = ({
   const xAxisInterval = chartType === 'Number' ? 1 : 0;
 
   const processNumericChartData = (unProcessedChartData:IValueSummary[]) => {
+    console.log('unProcessedChartData',unProcessedChartData);
+    if(unProcessedChartData == null) return false;
     let processedNumericData = unProcessedChartData.sort(
       (a: IValueSummary | any, b: IValueSummary| any) => a.start - b.start,
     );


### PR DESCRIPTION
Link to JIRA ticket if there is one: 
https://ctds-planx.atlassian.net/browse/VADC-1300

**Screenshots**
Before fix VADC Atlas Data Dictionary application crashes due to it being unable to process null data for the preview chart. After the fix, the preview charts do not render: 
![output](https://github.com/user-attachments/assets/c5845e99-c162-4ac7-b81f-bf80008dd8d6)


### Bug Fixes
* prevents Atlas Data Dictionary app from crashing when unProcessChartData input to processNumericChartData function is null. 
