### PR TITLE
Bugfix/prevent gwas app undefined request

### DIFF
--- a/src/Analysis/GWASApp/Components/SelectCohort/Utils/CohortDefinitions.jsx
+++ b/src/Analysis/GWASApp/Components/SelectCohort/Utils/CohortDefinitions.jsx
@@ -14,10 +14,13 @@ const CohortDefinitions = ({
   selectedTeamProject,
 }) => {
   const { source } = useSourceContext();
+  console.log('source',source)
+
   const cohorts = useQuery(
     ['cohortdefinitions', source, selectedTeamProject],
     () => fetchCohortDefinitions(source, selectedTeamProject),
-    queryConfig,
+    // only call this once with the queryConfig once the source is truthy
+    { enabled: !!source, ...queryConfig}
   );
   const fetchedCohorts = useFetch(cohorts, 'cohort_definitions_and_stats');
   const displayedCohorts = useFilter(fetchedCohorts, searchTerm, 'cohort_name');

--- a/src/Analysis/GWASApp/Components/SelectCohort/Utils/CohortDefinitions.jsx
+++ b/src/Analysis/GWASApp/Components/SelectCohort/Utils/CohortDefinitions.jsx
@@ -18,7 +18,7 @@ const CohortDefinitions = ({
   const cohorts = useQuery(
     ['cohortdefinitions', source, selectedTeamProject],
     () => fetchCohortDefinitions(source, selectedTeamProject),
-    // only call this once with the queryConfig once the source is not undefined
+    // only call this once the source is not undefined
     { enabled: source !== undefined, ...queryConfig },
   );
   const fetchedCohorts = useFetch(cohorts, 'cohort_definitions_and_stats');

--- a/src/Analysis/GWASApp/Components/SelectCohort/Utils/CohortDefinitions.jsx
+++ b/src/Analysis/GWASApp/Components/SelectCohort/Utils/CohortDefinitions.jsx
@@ -14,13 +14,12 @@ const CohortDefinitions = ({
   selectedTeamProject,
 }) => {
   const { source } = useSourceContext();
-  console.log('source',source)
 
   const cohorts = useQuery(
     ['cohortdefinitions', source, selectedTeamProject],
     () => fetchCohortDefinitions(source, selectedTeamProject),
-    // only call this once with the queryConfig once the source is truthy
-    { enabled: !!source, ...queryConfig}
+    // only call this once with the queryConfig once the source is not undefined
+    { enabled: source !== undefined, ...queryConfig },
   );
   const fetchedCohorts = useFetch(cohorts, 'cohort_definitions_and_stats');
   const displayedCohorts = useFilter(fetchedCohorts, searchTerm, 'cohort_name');

--- a/src/Analysis/GWASApp/Steps/SelectStudyPopulation/SelectStudyPopulation.jsx
+++ b/src/Analysis/GWASApp/Steps/SelectStudyPopulation/SelectStudyPopulation.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import ACTIONS from '../../Utils/StateManagement/Actions';
-import CohortSelect from '../../Components/SelectCohort/SelectCohort';
+import SelectCohort from '../../Components/SelectCohort/SelectCohort';
 
 const SelectStudyPopulation = ({ selectedCohort, dispatch, selectedTeamProject }) => {
   const handleStudyPopulationSelect = (selectedRow) => {
@@ -13,7 +13,7 @@ const SelectStudyPopulation = ({ selectedCohort, dispatch, selectedTeamProject }
 
   return (
     <div data-tour='cohort-select'>
-      <CohortSelect
+      <SelectCohort
         selectedCohort={selectedCohort}
         handleCohortSelect={handleStudyPopulationSelect}
         selectedTeamProject={selectedTeamProject}


### PR DESCRIPTION
Link to JIRA ticket if there is one: 
https://ctds-planx.atlassian.net/browse/VADC-1299

BEFORE: 
In the GEN3 GWAS App on load the network requests include a failed request with a status 400 Bad Request
![output](https://github.com/user-attachments/assets/91ca224d-e81c-431e-9711-81fbb32fb4f1)

AFTER: 
Failed request does not exist
![output](https://github.com/user-attachments/assets/a3b3ad35-9757-4d43-9f74-e6fcd7a5c038)

### Improvements
* Fixed naming error for SelectCohort, which was wrongly referenced as "CohortSelect" in SelectStudyPopulation.jsx

### Bug Fixes
* Prevents an initial request from fetchCohortDefinitions with an undefined sourceID. Instead the request is delayed until the sourceID is not undefined. 


