### PR TITLE
fix(downloadVLMDButtonReset): Initial commit

### DIFF
--- a/src/Discovery/DiscoveryDetails/Components/FieldGrouping/TabField/DataDownloadList/ActionButtons/ActionButtons.tsx
+++ b/src/Discovery/DiscoveryDetails/Components/FieldGrouping/TabField/DataDownloadList/ActionButtons/ActionButtons.tsx
@@ -69,11 +69,11 @@ const ActionButtons = ({
     discoveryConfig.features.exportToWorkspace.variableMetadataFieldName
       && discoveryConfig.features.exportToWorkspace.enableDownloadVariableMetadata,
   );
-
-  const [variableMetadataInfo, setVariableMetadataInfo] = useState({
+  const defaultVariableMetadataInfo = {
     noVariableLevelMetadata: true,
     variableLevelMetadataRecords: {} as VariableLevelMetadata,
-  });
+  };
+  const [variableMetadataInfo, setVariableMetadataInfo] = useState(defaultVariableMetadataInfo);
 
   let uid = '';
   if (resourceInfo) {
@@ -87,6 +87,8 @@ const ActionButtons = ({
       showDownloadVariableMetadataButton,
       setVariableMetadataInfo,
     );
+    // reset variableMetadataInfo on unmount:
+    return setVariableMetadataInfo(defaultVariableMetadataInfo);
   }, [resourceInfo]);
 
   const ConditionalPopover = ({ children }) => {


### PR DESCRIPTION
Link to JIRA ticket if there is one: 
https://ctds-planx.atlassian.net/browse/HP-1759

**Dev Notes**
_Before_
State is incorrectly retained for VLMD button after choosing a differet study; a study with VLMD available incorrectly makes other studies show that they have VLMD. 

![output](https://github.com/user-attachments/assets/f06ed4f6-94a3-437b-a0c0-96aee84a3c12)


_After_
State is updated for VLMD button after choosing a different study; one study's VLMD availability does not impact other studies. 
![output](https://github.com/user-attachments/assets/46e0c30b-51d0-4597-9181-1ebe01c31260)

### Bug Fixes
Resets noVariableLevelMetadata when choosing different studies so VLMD button behaves as expected. 
