### PR TITLE
fix(vaLogoAltText): initial commit

### DIFF
--- a/docs/portal_config.md
+++ b/docs/portal_config.md
@@ -63,6 +63,7 @@ Below is an example, with inline comments describing what each JSON block config
       }
     ],
     "homepageHref": "https://example.gen3.org/", // optional; link that the logo in header will pointing to
+    "logoAltText": "VA logo and Seal, U.S. Department of Veterans Affairs Data Commons", // optional; alt text for logo
     "index": { // required; relates to the homepage
       "introduction": { // optional; text on homepage
         "heading": "", // optional; title of introduction

--- a/docs/portal_config.md
+++ b/docs/portal_config.md
@@ -63,7 +63,7 @@ Below is an example, with inline comments describing what each JSON block config
       }
     ],
     "homepageHref": "https://example.gen3.org/", // optional; link that the logo in header will pointing to
-    "logoAltText": "VA logo and Seal, U.S. Department of Veterans Affairs Data Commons", // optional; alt text for logo
+    "logoAltText": "VA logo and Seal, U.S. Department of Veterans Affairs Data Commons", // optional; alt text for logo, appName is used instead if this is not set
     "index": { // required; relates to the homepage
       "introduction": { // optional; text on homepage
         "heading": "", // optional; title of introduction

--- a/src/localconf.js
+++ b/src/localconf.js
@@ -496,11 +496,13 @@ function buildConfig(opts) {
   const cedarWrapperURL = `${hostname}cedar`;
   const gen3ZendeskURL = 'https://<SUBDOMAIN_NAME>.zendesk.com';
 
-  // Disallow gitops.json configurability of Gen3 Data Commons and CTDS logo alt text.
-  // This allows for one point-of-change in the case of future rebranding.
-  // Map href or explicit descriptor to alt text.
+  const portalLogoAltText = () => {
+    if (components?.logoAltText) return `${components.logoAltText} - home`;
+    return `${components.appName} - home`;
+  };
+
   const commonsWideAltText = {
-    portalLogo: `${components.appName} - home`, // Standardized, accessible logo alt text for all commons
+    portalLogo: portalLogoAltText(),
     'https://ctds.uchicago.edu/gen3': 'Gen3 Data Commons - information and resources',
     'https://ctds.uchicago.edu/': 'Center for Translational Data Science at the University of Chicago - information and resources',
 


### PR DESCRIPTION
Link to JIRA ticket if there is one: 
https://ctds-planx.atlassian.net/browse/VADC-1430

**Before**
<img width="784" alt="image" src="https://github.com/user-attachments/assets/7b46ab7d-745d-4637-bcd4-9280a77f6f29">

**After**
<img width="784" alt="image" src="https://github.com/user-attachments/assets/7d5a23b0-f959-4b08-aa17-b4c15f7ccf16">

### Bug Fixes
Using the new key value pair `logoAltText` added from https://github.com/uc-cdis/gitops-qa/pull/3049 this updates the VA logo alt text to explicitly mention it is a logo; the alt text is updated to "A logo and Seal, U.S. Department of Veterans Affairs Data Commons - home" per 508 analysis. If the `logoAltText` doesn't exist, it continues to use the `appName` as before. 

### Improvements
Updates portal config documentation to explain new optional key value pair
