### PR TITLE
VADC-1479: Updated Previous/Next buttons' colors for VA GWAS according to 508

### DIFF
--- a/src/Analysis/GWASApp/GWASContainer.jsx
+++ b/src/Analysis/GWASApp/GWASContainer.jsx
@@ -14,6 +14,7 @@ import DismissibleMessagesList from './Components/DismissibleMessagesList/Dismis
 import MakeFullscreenButton from './Components/MakeFullscreenButton/MakeFullscreenButton';
 import InitializeCurrentState from './Utils/StateManagement/InitializeCurrentState';
 import './GWASApp.css';
+import '../SharedUtils/AccessibilityUtils/Accessibility.css';
 import WorkflowLimitsDashboard from '../SharedUtils/WorkflowLimitsDashboard/WorkflowLimitsDashboard';
 
 const GWASContainer = () => {

--- a/src/Analysis/SharedUtils/AccessibilityUtils/Accessibility.css
+++ b/src/Analysis/SharedUtils/AccessibilityUtils/Accessibility.css
@@ -36,13 +36,13 @@
 
 /* GWAS App */
 
-.steps-action .ant-btn-primary:not([disabled]) {
+.GWASUI-navBtn:not([disabled]) {
   background: #194C90;
   border: #194C90;
 }
 
-.steps-action .ant-btn-primary:not([disabled]):hover,
-.steps-action .ant-btn-primary:not([disabled]):focus {
+.GWASUI-navBtn:not([disabled]):hover,
+.GWASUI-navBtn:not([disabled]):focus {
   background: #2466AC;
   border: #2466AC;
 }

--- a/src/Analysis/SharedUtils/AccessibilityUtils/Accessibility.css
+++ b/src/Analysis/SharedUtils/AccessibilityUtils/Accessibility.css
@@ -1,3 +1,5 @@
+/* Global */
+
 :root {
   --focus-outline-color: #007bff; /* Bright Blue */
 }
@@ -13,10 +15,13 @@
   white-space: nowrap;
   border: 0;
 }
+
 .ant-modal-content button:focus {
   outline: 1px dashed var(--focus-outline-color);
   outline-offset: 1px;
 }
+
+/* VADC Apps */
 
 .team-project-modal .ant-btn-primary {
   background: #194C90;
@@ -25,6 +30,19 @@
 
 .team-project-modal .ant-btn-primary:hover,
 .team-project-modal .ant-btn-primary:focus {
+  background: #2466AC;
+  border: #2466AC;
+}
+
+/* GWAS App */
+
+.steps-action .ant-btn-primary:not([disabled]) {
+  background: #194C90;
+  border: #194C90;
+}
+
+.steps-action .ant-btn-primary:not([disabled]):hover,
+.steps-action .ant-btn-primary:not([disabled]):focus {
   background: #2466AC;
   border: #2466AC;
 }

--- a/src/Discovery/DiscoveryLoadingProgressBar/DiscoveryLoadingProgress.css
+++ b/src/Discovery/DiscoveryLoadingProgressBar/DiscoveryLoadingProgress.css
@@ -1,9 +1,9 @@
 .discovery-loading-progress-bar {
-    text-align: center;
-    margin-bottom: 5px;
+  text-align: center;
+  margin-bottom: 5px;
 }
 
 .discovery-loading-progress-bar  .discovery-header__stat-label {
-    line-height: normal;
-    text-transform: inherit;
+  line-height: normal;
+  text-transform: inherit;
 }


### PR DESCRIPTION
Link to JIRA ticket if there is one: [VADC-1479](https://ctds-planx.atlassian.net/browse/VADC-1479)

**Before**
![image](https://github.com/user-attachments/assets/942b0c54-b6ea-4a3e-87d0-50198e81376f)
![image](https://github.com/user-attachments/assets/16a41698-9efe-433d-985f-80d158fab7e9)

**After**
![image](https://github.com/user-attachments/assets/25e86337-4d2a-484d-877b-89532441579d)
![image](https://github.com/user-attachments/assets/4411e805-a502-4fcf-b1a4-21ceef0a72e3)


### Bug Fixes
* VADC-1479: Updated Previous/Next buttons' colors for VA GWAS according to 508 guidelines


[VADC-1479]: https://ctds-planx.atlassian.net/browse/VADC-1479?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ