### PR TITLE
fix discovery batch loading

### DIFF
--- a/src/Discovery/index.tsx
+++ b/src/Discovery/index.tsx
@@ -86,7 +86,11 @@ const DiscoveryWithMDSBackend: React.FC<{
 
   useEffect(() => {
     // Update the numberOfBatchesLoaded to enable calling of different batch sizes with different parameters
-    if (numberOfBatchesLoaded < expectedNumberOfTotalBatches) setNumberOfBatchesLoaded(numberOfBatchesLoaded + 1);
+    if (numberOfBatchesLoaded < expectedNumberOfTotalBatches) {
+      setNumberOfBatchesLoaded(numberOfBatchesLoaded + 1);
+    } else {
+      return;
+    }
 
     const studyRegistrationValidationField = studyRegistrationConfig?.studyRegistrationValidationField;
     async function fetchRawStudies() {
@@ -94,12 +98,12 @@ const DiscoveryWithMDSBackend: React.FC<{
       let loadStudiesParameters: any[] = [];
       if (isEnabled('discoveryUseAggMDS')) {
         loadStudiesFunction = loadStudiesFromAggMDS;
-        loadStudiesParameters.push(numberOfBatchesLoaded === 1
+        loadStudiesParameters.push(numberOfBatchesLoaded === 0
           ? numberOfStudiesForSmallerBatch
           : numberOfStudiesForAllStudiesBatch);
       } else {
         loadStudiesFunction = loadStudiesFromMDS;
-        loadStudiesParameters = (numberOfBatchesLoaded === 1
+        loadStudiesParameters = (numberOfBatchesLoaded === 0
           ? [props.config?.features?.guidType, 10, false] : [props.config?.features?.guidType, 2000, true]);
       }
       const rawStudiesRegistered = await loadStudiesFunction(
@@ -110,7 +114,7 @@ const DiscoveryWithMDSBackend: React.FC<{
       if (isEnabled('studyRegistration')) {
         // Load fewer raw studies if on the first studies batch
         // Otherwise load them all
-        rawStudiesUnregistered = numberOfBatchesLoaded === 1
+        rawStudiesUnregistered = numberOfBatchesLoaded === 0
           ? (rawStudiesUnregistered = await loadStudiesFromMDS(
             'unregistered_discovery_metadata',
             numberOfStudiesForSmallerBatch,

--- a/src/Discovery/index.tsx
+++ b/src/Discovery/index.tsx
@@ -99,7 +99,8 @@ const DiscoveryWithMDSBackend: React.FC<{
           : numberOfStudiesForAllStudiesBatch);
       } else {
         loadStudiesFunction = loadStudiesFromMDS;
-        loadStudiesParameters = [props.config?.features?.guidType, 10, false];
+        loadStudiesParameters = (numberOfBatchesLoaded === 1
+          ? [props.config?.features?.guidType, 10, false] : [props.config?.features?.guidType, 2000, true]);
       }
       const rawStudiesRegistered = await loadStudiesFunction(
         ...loadStudiesParameters,


### PR DESCRIPTION


### Bug Fixes
- Discovery: fixed a bug causing the discovery page cannot correctly loads metadata in batches if neither AggMDS or StudyRegsistration has been enabled
