### PR TITLE
Fix/aria selected attribute removal

### DIFF
--- a/src/Analysis/GWASApp/Components/Covariates/Covariates.jsx
+++ b/src/Analysis/GWASApp/Components/Covariates/Covariates.jsx
@@ -7,6 +7,7 @@ import queryConfig from '../../../SharedUtils/QueryConfig';
 import { useFetch, useFilter } from '../../Utils/formHooks';
 import { useSourceContext } from '../../Utils/Source';
 import SearchBar from '../SearchBar/SearchBar';
+import { AntDTableAccessibilityFix } from '../../../SharedUtils/AccessibilityUtils/AntDAccessibilityFixes';
 
 const Covariates = ({ selected, handleSelect, submittedCovariateIds }) => {
   const { source } = useSourceContext();
@@ -76,6 +77,7 @@ const Covariates = ({ selected, handleSelect, submittedCovariateIds }) => {
   }
 
   if (covariates?.status === 'success') {
+    AntDTableAccessibilityFix();
     return (
       <div data-tour='select-concept'>
         <SearchBar

--- a/src/Analysis/GWASApp/Components/SelectCohort/Utils/CohortDefinitions.jsx
+++ b/src/Analysis/GWASApp/Components/SelectCohort/Utils/CohortDefinitions.jsx
@@ -6,7 +6,7 @@ import { fetchCohortDefinitions } from '../../../Utils/cohortMiddlewareApi';
 import queryConfig from '../../../../SharedUtils/QueryConfig';
 import { useFetch, useFilter } from '../../../Utils/formHooks';
 import { useSourceContext } from '../../../Utils/Source';
-import AntDTableAccessibilityFix from '../../../../SharedUtils/AccessibilityUtils/AntDAccessibilityFixes';
+import { AntDTableAccessibilityFix } from '../../../../SharedUtils/AccessibilityUtils/AntDAccessibilityFixes';
 
 const CohortDefinitions = ({
   selectedCohort = undefined,

--- a/src/Analysis/GWASApp/Components/SelectCohort/Utils/CohortDefinitions.jsx
+++ b/src/Analysis/GWASApp/Components/SelectCohort/Utils/CohortDefinitions.jsx
@@ -6,6 +6,7 @@ import { fetchCohortDefinitions } from '../../../Utils/cohortMiddlewareApi';
 import queryConfig from '../../../../SharedUtils/QueryConfig';
 import { useFetch, useFilter } from '../../../Utils/formHooks';
 import { useSourceContext } from '../../../Utils/Source';
+import { AntDTableAccessibilityFix } from '../../../../SharedUtils/AccessibilityUtils/AntDAccessibilityFixes';
 
 const CohortDefinitions = ({
   selectedCohort = undefined,
@@ -48,26 +49,30 @@ const CohortDefinitions = ({
   ];
   if (cohorts?.status === 'error') return <React.Fragment>Error getting data for table</React.Fragment>;
 
-  return cohorts?.status === 'success' ? (
-    <Table
-      className='GWASUI-table1'
-      rowKey='cohort_definition_id'
-      size='middle'
-      pagination={{
-        defaultPageSize: 10,
-        showSizeChanger: true,
-        pageSizeOptions: ['10', '20', '50', '100', '500'],
-      }}
-      onRow={(selectedRow) => ({
-        onClick: () => {
-          handleCohortSelect(selectedRow);
-        },
-      })}
-      rowSelection={cohortSelection(selectedCohort)}
-      columns={cohortTableConfig}
-      dataSource={displayedCohorts}
-    />
-  ) : (
+  if (cohorts?.status === 'success') {
+    AntDTableAccessibilityFix();
+    return (
+      <Table
+        className='GWASUI-table1'
+        rowKey='cohort_definition_id'
+        size='middle'
+        pagination={{
+          defaultPageSize: 10,
+          showSizeChanger: true,
+          pageSizeOptions: ['10', '20', '50', '100', '500'],
+        }}
+        onRow={(selectedRow) => ({
+          onClick: () => {
+            handleCohortSelect(selectedRow);
+          },
+        })}
+        rowSelection={cohortSelection(selectedCohort)}
+        columns={cohortTableConfig}
+        dataSource={displayedCohorts}
+      />
+    );
+  }
+  return (
     <React.Fragment>
       <div className='GWASUI-spinnerContainer GWASUI-emptyTable'>
         <Spin />

--- a/src/Analysis/GWASApp/Components/SelectCohort/Utils/CohortDefinitions.jsx
+++ b/src/Analysis/GWASApp/Components/SelectCohort/Utils/CohortDefinitions.jsx
@@ -6,7 +6,7 @@ import { fetchCohortDefinitions } from '../../../Utils/cohortMiddlewareApi';
 import queryConfig from '../../../../SharedUtils/QueryConfig';
 import { useFetch, useFilter } from '../../../Utils/formHooks';
 import { useSourceContext } from '../../../Utils/Source';
-import { AntDTableAccessibilityFix } from '../../../../SharedUtils/AccessibilityUtils/AntDAccessibilityFixes';
+import AntDTableAccessibilityFix from '../../../../SharedUtils/AccessibilityUtils/AntDAccessibilityFixes';
 
 const CohortDefinitions = ({
   selectedCohort = undefined,

--- a/src/Analysis/SharedUtils/AccessibilityUtils/AntDAccessibilityFixes/Fixes/FixPaginationDropdown.js
+++ b/src/Analysis/SharedUtils/AccessibilityUtils/AntDAccessibilityFixes/Fixes/FixPaginationDropdown.js
@@ -1,19 +1,19 @@
-const handlePaginationDropdownClick = () => {
-    RemoveDOMAttribute(
-      '.ant-select-item-option-active',
-      'aria-selected',
-    );
-    RemoveDOMAttribute(
-      '.ant-select-item',
-      'aria-selected',
-    );
-  };
+import isEnterOrSpace from '../../IsEnterOrSpace';
+import RemoveDOMAttribute from '../Utils/RemoveDOMAttribute';
 
 const FixPaginationDropDown = () => {
-    const pageDropdown = document.querySelector('.ant-pagination-options-size-changer');
-    if (pageDropdown) {
-      pageDropdown.addEventListener('click', handlePaginationDropdownClick);
-    }
-  };
-
-  export default FixPaginationDropDown;
+  const pageDropdown = document.querySelector(
+    '.ant-pagination-options-size-changer'
+  );
+  if (pageDropdown) {
+    pageDropdown.addEventListener('click', () => {
+      RemoveDOMAttribute('.ant-select-item', 'aria-selected');
+    });
+    pageDropdown.addEventListener('keydown', function (event) {
+      if (isEnterOrSpace(event)) {
+        RemoveDOMAttribute('.ant-select-item', 'aria-selected');
+      }
+    });
+  }
+};
+export default FixPaginationDropDown;

--- a/src/Analysis/SharedUtils/AccessibilityUtils/AntDAccessibilityFixes/Fixes/FixPaginationDropdown.js
+++ b/src/Analysis/SharedUtils/AccessibilityUtils/AntDAccessibilityFixes/Fixes/FixPaginationDropdown.js
@@ -3,13 +3,13 @@ import RemoveDOMAttribute from '../Utils/RemoveDOMAttribute';
 
 const FixPaginationDropDown = () => {
   const pageDropdown = document.querySelector(
-    '.ant-pagination-options-size-changer'
+    '.ant-pagination-options-size-changer',
   );
   if (pageDropdown) {
     pageDropdown.addEventListener('click', () => {
       RemoveDOMAttribute('.ant-select-item', 'aria-selected');
     });
-    pageDropdown.addEventListener('keydown', function (event) {
+    pageDropdown.addEventListener('keydown', (event) => {
       if (isEnterOrSpace(event)) {
         RemoveDOMAttribute('.ant-select-item', 'aria-selected');
       }

--- a/src/Analysis/SharedUtils/AccessibilityUtils/AntDAccessibilityFixes/Fixes/FixPaginationDropdown.js
+++ b/src/Analysis/SharedUtils/AccessibilityUtils/AntDAccessibilityFixes/Fixes/FixPaginationDropdown.js
@@ -1,0 +1,19 @@
+const handlePaginationDropdownClick = () => {
+    RemoveDOMAttribute(
+      '.ant-select-item-option-active',
+      'aria-selected',
+    );
+    RemoveDOMAttribute(
+      '.ant-select-item',
+      'aria-selected',
+    );
+  };
+
+const FixPaginationDropDown = () => {
+    const pageDropdown = document.querySelector('.ant-pagination-options-size-changer');
+    if (pageDropdown) {
+      pageDropdown.addEventListener('click', handlePaginationDropdownClick);
+    }
+  };
+
+  export default FixPaginationDropDown;

--- a/src/Analysis/SharedUtils/AccessibilityUtils/AntDAccessibilityFixes/Fixes/FixPaginationDropdown.js
+++ b/src/Analysis/SharedUtils/AccessibilityUtils/AntDAccessibilityFixes/Fixes/FixPaginationDropdown.js
@@ -4,7 +4,7 @@ import RemoveDOMAttribute from '../Utils/RemoveDOMAttribute';
 
 const FixPaginationDropDown = () => {
   const pageDropdown = document.querySelector(
-    '.ant-pagination-options-size-changer'
+    '.ant-pagination-options-size-changer',
   );
   if (pageDropdown) {
     pageDropdown.addEventListener('click', () => {

--- a/src/Analysis/SharedUtils/AccessibilityUtils/AntDAccessibilityFixes/Fixes/FixPaginationDropdown.js
+++ b/src/Analysis/SharedUtils/AccessibilityUtils/AntDAccessibilityFixes/Fixes/FixPaginationDropdown.js
@@ -1,17 +1,18 @@
 import isEnterOrSpace from '../../IsEnterOrSpace';
+import DelayExecution from '../Utils/DelayExecution';
 import RemoveDOMAttribute from '../Utils/RemoveDOMAttribute';
 
 const FixPaginationDropDown = () => {
   const pageDropdown = document.querySelector(
-    '.ant-pagination-options-size-changer',
+    '.ant-pagination-options-size-changer'
   );
   if (pageDropdown) {
     pageDropdown.addEventListener('click', () => {
-      RemoveDOMAttribute('.ant-select-item', 'aria-selected');
+      DelayExecution(RemoveDOMAttribute, '.ant-select-item', 'aria-selected');
     });
     pageDropdown.addEventListener('keydown', (event) => {
       if (isEnterOrSpace(event)) {
-        RemoveDOMAttribute('.ant-select-item', 'aria-selected');
+        DelayExecution(RemoveDOMAttribute, '.ant-select-item', 'aria-selected');
       }
     });
   }

--- a/src/Analysis/SharedUtils/AccessibilityUtils/AntDAccessibilityFixes/Utils/Constants.js
+++ b/src/Analysis/SharedUtils/AccessibilityUtils/AntDAccessibilityFixes/Utils/Constants.js
@@ -1,0 +1,3 @@
+const DELAY_TIME = 500;
+
+export { DELAY_TIME };

--- a/src/Analysis/SharedUtils/AccessibilityUtils/AntDAccessibilityFixes/Utils/Constants.js
+++ b/src/Analysis/SharedUtils/AccessibilityUtils/AntDAccessibilityFixes/Utils/Constants.js
@@ -1,3 +1,0 @@
-const DELAY_TIME = 500;
-
-export { DELAY_TIME };

--- a/src/Analysis/SharedUtils/AccessibilityUtils/AntDAccessibilityFixes/Utils/DelayExecution.js
+++ b/src/Analysis/SharedUtils/AccessibilityUtils/AntDAccessibilityFixes/Utils/DelayExecution.js
@@ -1,4 +1,4 @@
-const DELAY_TIME = 500;
+const DELAY_TIME = 250;
 
 // Utility function to call other function with a delay for loading
 // example: DelayExecution(myFunction, 'parameter1', 'parameter2');

--- a/src/Analysis/SharedUtils/AccessibilityUtils/AntDAccessibilityFixes/Utils/DelayExecution.js
+++ b/src/Analysis/SharedUtils/AccessibilityUtils/AntDAccessibilityFixes/Utils/DelayExecution.js
@@ -1,0 +1,11 @@
+import { DELAY_TIME } from "./Constants";
+
+// Utility function to call other function with a delay for loading
+// example: DelayExecution(myFunction, 'parameter1', 'parameter2');
+const DelayExecution = (fn, ...args) => {
+    setTimeout(() => {
+      fn(...args);
+    }, DELAY_TIME);
+  }
+
+  export default DelayExecution;

--- a/src/Analysis/SharedUtils/AccessibilityUtils/AntDAccessibilityFixes/Utils/DelayExecution.js
+++ b/src/Analysis/SharedUtils/AccessibilityUtils/AntDAccessibilityFixes/Utils/DelayExecution.js
@@ -1,11 +1,11 @@
-import { DELAY_TIME } from "./Constants";
+const DELAY_TIME = 500;
 
 // Utility function to call other function with a delay for loading
 // example: DelayExecution(myFunction, 'parameter1', 'parameter2');
 const DelayExecution = (fn, ...args) => {
-    setTimeout(() => {
-      fn(...args);
-    }, DELAY_TIME);
-  }
+  setTimeout(() => {
+    fn(...args);
+  }, DELAY_TIME);
+};
 
-  export default DelayExecution;
+export default DelayExecution;

--- a/src/Analysis/SharedUtils/AccessibilityUtils/AntDAccessibilityFixes/Utils/RemoveDOMAttribute.js
+++ b/src/Analysis/SharedUtils/AccessibilityUtils/AntDAccessibilityFixes/Utils/RemoveDOMAttribute.js
@@ -4,18 +4,15 @@
  */
 
 const RemoveDOMAttribute = (selector, attribute) => {
-    const elements = document.querySelectorAll(selector);
-    console.log('elements',elements, selector)
-    elements?.forEach((element) => {
-      if (element) {
-        console.log('removing element and attribute', element, attribute);
-        element.removeAttribute(attribute);
-      } else {
-        /* eslint-disable no-console */
-        console.error('Unable to find selector in removeDOMAttribute: ', selector);
-        /* eslint-enable no-console */
-      }
-    });
+  const elements = document.querySelectorAll(selector);
+  elements?.forEach((element) => {
+    if (element) {
+      element.removeAttribute(attribute);
+    } else {
+      // eslint-disable-next-line no-console
+      console.error('Unable to find selector in removeDOMAttribute: ', selector);
+    }
+  });
 };
 
 export default RemoveDOMAttribute;

--- a/src/Analysis/SharedUtils/AccessibilityUtils/AntDAccessibilityFixes/Utils/RemoveDOMAttribute.js
+++ b/src/Analysis/SharedUtils/AccessibilityUtils/AntDAccessibilityFixes/Utils/RemoveDOMAttribute.js
@@ -7,10 +7,14 @@ const RemoveDOMAttribute = (selector, attribute) => {
   const elements = document.querySelectorAll(selector);
   elements?.forEach((element) => {
     if (element) {
+      console.log(element);
       element.removeAttribute(attribute);
     } else {
       // eslint-disable-next-line no-console
-      console.error('Unable to find selector in removeDOMAttribute: ', selector);
+      console.error(
+        'Unable to find selector in removeDOMAttribute: ',
+        selector
+      );
     }
   });
 };

--- a/src/Analysis/SharedUtils/AccessibilityUtils/AntDAccessibilityFixes/Utils/RemoveDOMAttribute.js
+++ b/src/Analysis/SharedUtils/AccessibilityUtils/AntDAccessibilityFixes/Utils/RemoveDOMAttribute.js
@@ -1,0 +1,21 @@
+/*
+ * Used to update Remove Dom attributes
+ * example: RemoveDOMAttribute('.ant-radio-input','aria-selected',)
+ */
+
+const RemoveDOMAttribute = (selector, attribute) => {
+    const elements = document.querySelectorAll(selector);
+    console.log('elements',elements, selector)
+    elements?.forEach((element) => {
+      if (element) {
+        console.log('removing element and attribute', element, attribute);
+        element.removeAttribute(attribute);
+      } else {
+        /* eslint-disable no-console */
+        console.error('Unable to find selector in removeDOMAttribute: ', selector);
+        /* eslint-enable no-console */
+      }
+    });
+};
+
+export default RemoveDOMAttribute;

--- a/src/Analysis/SharedUtils/AccessibilityUtils/AntDAccessibilityFixes/Utils/RemoveDOMAttribute.js
+++ b/src/Analysis/SharedUtils/AccessibilityUtils/AntDAccessibilityFixes/Utils/RemoveDOMAttribute.js
@@ -13,7 +13,7 @@ const RemoveDOMAttribute = (selector, attribute) => {
       // eslint-disable-next-line no-console
       console.error(
         'Unable to find selector in removeDOMAttribute: ',
-        selector
+        selector,
       );
     }
   });

--- a/src/Analysis/SharedUtils/AccessibilityUtils/AntDAccessibilityFixes/index.js
+++ b/src/Analysis/SharedUtils/AccessibilityUtils/AntDAccessibilityFixes/index.js
@@ -1,9 +1,6 @@
 import DelayExecution from './Utils/DelayExecution';
 import FixPaginationDropDown from './Fixes/FixPaginationDropdown';
 
-
-const AntDTableAccessibilityFix = () => {
+export const AntDTableAccessibilityFix = () => {
   DelayExecution(FixPaginationDropDown);
 };
-
-export { AntDTableAccessibilityFix };

--- a/src/Analysis/SharedUtils/AccessibilityUtils/AntDAccessibilityFixes/index.js
+++ b/src/Analysis/SharedUtils/AccessibilityUtils/AntDAccessibilityFixes/index.js
@@ -1,0 +1,31 @@
+import { DELAY_TIME } from './Utils/Constants';
+import DelayExecution from './Utils/DelayExecution';
+import RemoveDOMAttribute from './Utils/RemoveDOMAttribute';
+
+
+const fixPaginationDropDown = () => {
+    const pageDropdown = document.querySelector('.ant-pagination-options-size-changer');
+    const handleClick = () => {
+      console.log('called handleClick');
+      RemoveDOMAttribute(
+          '.ant-select-item-option-active',
+          'aria-selected'
+        );
+        RemoveDOMAttribute(
+          '.ant-select-item',
+          'aria-selected'
+        );
+    }
+    if(pageDropdown) {
+      pageDropdown.addEventListener('click', handleClick);
+      console.log(pageDropdown);
+    }
+}
+
+const AntDTableAccessibilityFix = () => {
+  console.log('called fix');
+ DelayExecution(fixPaginationDropDown);
+
+};
+
+export { AntDTableAccessibilityFix };

--- a/src/Analysis/SharedUtils/AccessibilityUtils/AntDAccessibilityFixes/index.js
+++ b/src/Analysis/SharedUtils/AccessibilityUtils/AntDAccessibilityFixes/index.js
@@ -1,6 +1,7 @@
 import DelayExecution from './Utils/DelayExecution';
 import FixPaginationDropDown from './Fixes/FixPaginationDropdown';
 
+// eslint-disable-next-line import/prefer-default-export
 export const AntDTableAccessibilityFix = () => {
   DelayExecution(FixPaginationDropDown);
 };

--- a/src/Analysis/SharedUtils/AccessibilityUtils/AntDAccessibilityFixes/index.js
+++ b/src/Analysis/SharedUtils/AccessibilityUtils/AntDAccessibilityFixes/index.js
@@ -1,31 +1,9 @@
-import { DELAY_TIME } from './Utils/Constants';
 import DelayExecution from './Utils/DelayExecution';
-import RemoveDOMAttribute from './Utils/RemoveDOMAttribute';
+import FixPaginationDropDown from './Fixes/FixPaginationDropdown';
 
-
-const fixPaginationDropDown = () => {
-    const pageDropdown = document.querySelector('.ant-pagination-options-size-changer');
-    const handleClick = () => {
-      console.log('called handleClick');
-      RemoveDOMAttribute(
-          '.ant-select-item-option-active',
-          'aria-selected'
-        );
-        RemoveDOMAttribute(
-          '.ant-select-item',
-          'aria-selected'
-        );
-    }
-    if(pageDropdown) {
-      pageDropdown.addEventListener('click', handleClick);
-      console.log(pageDropdown);
-    }
-}
 
 const AntDTableAccessibilityFix = () => {
-  console.log('called fix');
- DelayExecution(fixPaginationDropDown);
-
+  DelayExecution(FixPaginationDropDown);
 };
 
 export { AntDTableAccessibilityFix };


### PR DESCRIPTION
Link to JIRA ticket if there is one: 
https://ctds-planx.atlassian.net/browse/VADC-1462

**Dev Notes**
- Creates library `AntDAccessibilityFixes`, which will include other programmatic fixes for AntD accessibility issues going forward
- **Description of the problem**: When an end user toggles the AntD table pagination component button (the button that shows 10 / page by default) either by click or keyboard interaction to open the dropdown, AntD creates new DOM elements to show the end user their pagination options (20 / page, 50 / page etc). However within these DOM elements the elements with class name `.ant-select-item` have the attribute `aria-selected`. This is identified as an error in axe accessibility checker. 
- **Solution**: This adds a new function `AntDTableAccessibilityFix` that is now called once the data for the AntD table is available and this calls the function `FixPaginationDropdown` after a delay allowing everything time to render. This function adds an event handler to AntD table pagination component button. When the end user open the dropdown and new DOM elements are created by AntD, a secondary script runs to remove all attributes of type `aria-selected` from the elements with class name `.ant-select-item`. Following this axe accessibility no longer identities errors for the `aria-selected` attributes. 
- **How to duplicate the defect**: First install the [axe accessibility extension](https://chromewebstore.google.com/detail/axe-devtools-web-accessib/lhdoppojpmngadmnindnejefpokejbdd). 
&ensp;1. Load the view containing the table
&ensp;2. Click start new scan
&ensp;3. Click the dropdown with text `10 / page` or navigate to using your keyboard with `tab` and then trigger it with `return` or spacebar.
&ensp;3. Then with that open click run the axe full page scan button
&ensp;4. The errors show up under the heading: _Elements must only use supported ARIA attributes_
- **Before**: axe finds 5 errors related to `Elements must only use supported ARIA attributes` and  attribute `aria-selected`

https://github.com/user-attachments/assets/2e25b193-57f0-406d-b2e8-827469cf3e38

- **After**: axe does not find errors related `Elements must only use supported ARIA attributes` and attribute `aria-selected`

https://github.com/user-attachments/assets/0777ed96-e45f-46fc-9777-9aaa9b43acd5



### Bug Fixes
- Improves accessibility 
