### PR TITLE
VADC-1486: Fix selected phenotypes/covariates colors according to 508 guidelines

### DIFF
--- a/src/Analysis/SharedUtils/AccessibilityUtils/AccessibilityStyles/Accessibility.less
+++ b/src/Analysis/SharedUtils/AccessibilityUtils/AccessibilityStyles/Accessibility.less
@@ -125,4 +125,16 @@
   .ant-pagination-options:hover .ant-select:not([disabled]) .ant-select-selector {
     border-color: #2466AC;
   }
+
+  .ant-card-meta-description {
+    color: #333333;
+  }
+
+  .ant-card-actions .anticon {
+    color: #333333;
+  }
+
+  .ant-card-actions .anticon:hover {
+    color: #2466AC;
+  }
 }

--- a/src/Analysis/SharedUtils/AccessibilityUtils/AccessibilityStyles/Accessibility.less
+++ b/src/Analysis/SharedUtils/AccessibilityUtils/AccessibilityStyles/Accessibility.less
@@ -1,6 +1,7 @@
 /* App-specific styles */
 
 @import "AccessibilityGWAS.less";
+@import "AccessibilityTeams.less";
 
 /* Global styles */
 

--- a/src/Analysis/SharedUtils/AccessibilityUtils/AccessibilityStyles/AccessibilityGWAS.less
+++ b/src/Analysis/SharedUtils/AccessibilityUtils/AccessibilityStyles/AccessibilityGWAS.less
@@ -1,5 +1,29 @@
 /* GWAS App */
 
+.gwas-modal {
+  .ant-btn-primary:not([disabled]) {
+    background: #194C90;
+    border-color: #194C90;
+  }
+
+  .ant-btn-primary:not([disabled]):hover,
+  .ant-btn-primary:not([disabled]):focus {
+    background: #2466AC;
+    border-color: #2466AC;
+  }
+
+  .ant-btn-default {
+    color: #194C90;
+    border-color: #194C90;
+  }
+
+  .ant-btn-default:hover,
+  .ant-btn-default:focus {
+    color: #2466AC;
+    border-color: #2466AC;
+  }
+}
+
 .GWASApp {
   .GWASUI-navBtn:not([disabled]) {
     background: #194C90;

--- a/src/Analysis/SharedUtils/AccessibilityUtils/AccessibilityStyles/AccessibilityTeams.less
+++ b/src/Analysis/SharedUtils/AccessibilityUtils/AccessibilityStyles/AccessibilityTeams.less
@@ -1,0 +1,14 @@
+/* Rules for Teams selection in VADC */
+
+.team-project-modal {
+  .ant-btn-primary:not([disabled]) {
+    background: #194C90;
+    border-color: #194C90;
+  }
+  
+  .ant-btn-primary:not([disabled]):hover,
+  .ant-btn-primary:not([disabled]):focus {
+    background: #2466AC;
+    border-color: #2466AC;
+  }
+}


### PR DESCRIPTION
Link to JIRA ticket if there is one: [VADC-1486](https://ctds-planx.atlassian.net/browse/VADC-1486)

**Before**
![image](https://github.com/user-attachments/assets/a8495129-0933-4bc2-a45a-db449e6a8d18)

**After**
![image](https://github.com/user-attachments/assets/557ca71e-7cda-4c21-8de7-86c1ea606855)

### Bug Fixes
* Fix selected phenotypes/covariates colors
* Restored styles for GWAS and Teams modals

[VADC-1486]: https://ctds-planx.atlassian.net/browse/VADC-1486?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ