### PR TITLE
Show refresh warning when user switch team project in another tab

### DIFF
--- a/src/Analysis/SharedUtils/TeamProject/TeamProjectHeader/TeamProjectHeader.jsx
+++ b/src/Analysis/SharedUtils/TeamProject/TeamProjectHeader/TeamProjectHeader.jsx
@@ -38,13 +38,7 @@ const TeamProjectHeader = ({ isEditable }) => {
 
   useEffect(() => {
     const handleMessage = () => {
-      // Only Show Warning Modal for tabs
-      // that didn't just submit the team change
-      if (!isModalOpen) {
-        showWarningModal();
-      }
-      // Close Open Team Change Modal
-      setIsModalOpen(false);
+      showWarningModal();
     };
 
     channel.onmessage = handleMessage;

--- a/src/Analysis/SharedUtils/TeamProject/TeamProjectHeader/TeamProjectHeader.jsx
+++ b/src/Analysis/SharedUtils/TeamProject/TeamProjectHeader/TeamProjectHeader.jsx
@@ -9,6 +9,7 @@ import queryConfig from '../../QueryConfig';
 import fetchArboristTeamProjectRoles from '../Utils/teamProjectApi';
 import IsCurrentTeamProjectValid from './IsCurrentTeamProjectValid';
 import './TeamProjectHeader.css';
+import { BroadcastChannel } from 'broadcast-channel';
 
 const TeamProjectHeader = ({ isEditable }) => {
   const [isModalOpen, setIsModalOpen] = useState(false);
@@ -27,6 +28,34 @@ const TeamProjectHeader = ({ isEditable }) => {
       history.push('/analysis');
     }
   };
+
+  const channel = new BroadcastChannel('teamProjectChannel');
+
+  const [isWarningModalOpen, setIsWarningModalOpen] = useState(false);
+  const showWarningModal = () => {
+    console.log("show warning modal");
+    setIsWarningModalOpen(true);
+  };
+
+  useEffect(() => {
+      const handleMessage = (event) => {
+        //Only Show Warning Modal for tabs
+        //that didn't just submit the team change
+        if(!isModalOpen)
+        {
+          showWarningModal();
+        }
+        //Close Open Team Change Modal
+        setIsModalOpen(false);
+      };
+
+      channel.onmessage = handleMessage;
+
+      // Clean up the channel when the component unmounts
+      return () => {
+          channel.close();
+      };
+  }, [channel, showWarningModal]);
 
   const { data, status } = useQuery(
     'teamprojects',
@@ -76,11 +105,26 @@ const TeamProjectHeader = ({ isEditable }) => {
           </button>
         )}
       </div>
+      {isWarningModalOpen && (
+        <TeamProjectModal
+          isModalOpen={isModalOpen}
+          setIsModalOpen={setIsModalOpen}
+          setBannerText={setBannerText}
+          isWarningModalOpen={isWarningModalOpen}
+          setIsWarningModalOpen={setIsWarningModalOpen}
+          data={data}
+          status={status}
+          selectedTeamProject={selectedTeamProject}
+          setSelectedTeamProject={setSelectedTeamProject}
+        />
+      )}
       {isEditable && (
         <TeamProjectModal
           isModalOpen={isModalOpen}
           setIsModalOpen={setIsModalOpen}
           setBannerText={setBannerText}
+          isWarningModalOpen={isWarningModalOpen}
+          setIsWarningModalOpen={setIsWarningModalOpen}
           data={data}
           status={status}
           selectedTeamProject={selectedTeamProject}

--- a/src/Analysis/SharedUtils/TeamProject/TeamProjectHeader/TeamProjectHeader.jsx
+++ b/src/Analysis/SharedUtils/TeamProject/TeamProjectHeader/TeamProjectHeader.jsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { useHistory } from 'react-router-dom';
 import { useQuery } from 'react-query';
+import { BroadcastChannel } from 'broadcast-channel';
 import EditIcon from './Icons/EditIcon';
 import isEnterOrSpace from '../../AccessibilityUtils/IsEnterOrSpace';
 import TeamProjectModal from '../TeamProjectModal/TeamProjectModal';
@@ -9,7 +10,6 @@ import queryConfig from '../../QueryConfig';
 import fetchArboristTeamProjectRoles from '../Utils/teamProjectApi';
 import IsCurrentTeamProjectValid from './IsCurrentTeamProjectValid';
 import './TeamProjectHeader.css';
-import { BroadcastChannel } from 'broadcast-channel';
 
 const TeamProjectHeader = ({ isEditable }) => {
   const [isModalOpen, setIsModalOpen] = useState(false);
@@ -33,28 +33,27 @@ const TeamProjectHeader = ({ isEditable }) => {
 
   const [isWarningModalOpen, setIsWarningModalOpen] = useState(false);
   const showWarningModal = () => {
-    console.log("show warning modal");
+    console.log('show warning modal');
     setIsWarningModalOpen(true);
   };
 
   useEffect(() => {
-      const handleMessage = (event) => {
-        //Only Show Warning Modal for tabs
-        //that didn't just submit the team change
-        if(!isModalOpen)
-        {
-          showWarningModal();
-        }
-        //Close Open Team Change Modal
-        setIsModalOpen(false);
-      };
+    const handleMessage = (event) => {
+      // Only Show Warning Modal for tabs
+      // that didn't just submit the team change
+      if (!isModalOpen) {
+        showWarningModal();
+      }
+      // Close Open Team Change Modal
+      setIsModalOpen(false);
+    };
 
-      channel.onmessage = handleMessage;
+    channel.onmessage = handleMessage;
 
-      // Clean up the channel when the component unmounts
-      return () => {
-          channel.close();
-      };
+    // Clean up the channel when the component unmounts
+    return () => {
+      channel.close();
+    };
   }, [channel, showWarningModal]);
 
   const { data, status } = useQuery(

--- a/src/Analysis/SharedUtils/TeamProject/TeamProjectHeader/TeamProjectHeader.jsx
+++ b/src/Analysis/SharedUtils/TeamProject/TeamProjectHeader/TeamProjectHeader.jsx
@@ -33,12 +33,11 @@ const TeamProjectHeader = ({ isEditable }) => {
 
   const [isWarningModalOpen, setIsWarningModalOpen] = useState(false);
   const showWarningModal = () => {
-    console.log('show warning modal');
     setIsWarningModalOpen(true);
   };
 
   useEffect(() => {
-    const handleMessage = (event) => {
+    const handleMessage = () => {
       // Only Show Warning Modal for tabs
       // that didn't just submit the team change
       if (!isModalOpen) {

--- a/src/Analysis/SharedUtils/TeamProject/TeamProjectModal/TeamProjectModal.jsx
+++ b/src/Analysis/SharedUtils/TeamProject/TeamProjectModal/TeamProjectModal.jsx
@@ -2,10 +2,11 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { useHistory } from 'react-router-dom';
 import { Button, Modal, Spin } from 'antd';
+import { BroadcastChannel } from 'broadcast-channel';
 import LoadingErrorMessage from '../../LoadingErrorMessage/LoadingErrorMessage';
 import TeamsDropdown from './TeamsDropdown/TeamsDropdown';
 import './TeamProjectModal.css';
-import { BroadcastChannel } from 'broadcast-channel';
+
 
 const TeamProjectModal = ({
   isModalOpen,

--- a/src/Analysis/SharedUtils/TeamProject/TeamProjectModal/TeamProjectModal.jsx
+++ b/src/Analysis/SharedUtils/TeamProject/TeamProjectModal/TeamProjectModal.jsx
@@ -27,7 +27,7 @@ const TeamProjectModal = ({
   };
 
   const closeAndUpdateTeamProject = () => {
-    // Closing Modal is handled in the header
+    setIsModalOpen(false);
     sendMessage('Team Project Changed!');
     setBannerText(selectedTeamProject);
     localStorage.setItem('teamProject', selectedTeamProject);

--- a/src/Analysis/SharedUtils/TeamProject/TeamProjectModal/TeamProjectModal.jsx
+++ b/src/Analysis/SharedUtils/TeamProject/TeamProjectModal/TeamProjectModal.jsx
@@ -1,14 +1,17 @@
-import React from 'react';
+import React, { useEffect, useState }  from 'react';
 import PropTypes from 'prop-types';
 import { useHistory } from 'react-router-dom';
 import { Button, Modal, Spin } from 'antd';
 import LoadingErrorMessage from '../../LoadingErrorMessage/LoadingErrorMessage';
 import TeamsDropdown from './TeamsDropdown/TeamsDropdown';
 import './TeamProjectModal.css';
+import { BroadcastChannel } from 'broadcast-channel';
 
 const TeamProjectModal = ({
   isModalOpen,
   setIsModalOpen,
+  isWarningModalOpen,
+  setIsWarningModalOpen,
   setBannerText,
   data,
   status,
@@ -16,11 +19,24 @@ const TeamProjectModal = ({
   setSelectedTeamProject,
 }) => {
   const history = useHistory();
+
+  const channel = new BroadcastChannel('teamProjectChannel');
+  const sendMessage = (msg) => {
+    channel.postMessage(msg);
+  };
+
   const closeAndUpdateTeamProject = () => {
-    setIsModalOpen(false);
+    //Closing Modal is handled in the header
+    sendMessage('Team Project Changed!')
     setBannerText(selectedTeamProject);
     localStorage.setItem('teamProject', selectedTeamProject);
   };
+
+  const closeWarningAndRefreshPage = () => {
+    setIsWarningModalOpen(false);
+    window.location.reload();
+  };
+
   const redirectToHomepage = () => {
     history.push('/');
   };
@@ -41,6 +57,32 @@ const TeamProjectModal = ({
         />
       </Modal>
     );
+  }
+  if (isWarningModalOpen === true) {
+    return (
+      <Modal
+        open={isWarningModalOpen}
+        className='team-project-modal'
+        title='Team Projects'
+        closable={true}
+        maskClosable={false}
+        keyboard={false}
+        footer={[
+          <Button
+            key='submit'
+            type='primary'
+            disabled={!selectedTeamProject}
+            onClick={() => closeWarningAndRefreshPage()}
+          >
+            Refresh Page
+          </Button>,
+        ]}
+      >
+        <div className='team-project-modal_modal-description'>
+          Team Project has been updated in another tab. Please click refresh page to prevent errors.
+        </div>
+      </Modal>
+    )
   }
   if (data) {
     if (data.teams.length > 0) {
@@ -119,6 +161,8 @@ const TeamProjectModal = ({
 TeamProjectModal.propTypes = {
   isModalOpen: PropTypes.bool.isRequired,
   setIsModalOpen: PropTypes.func.isRequired,
+  isWarningModalOpen: PropTypes.bool.isRequired,
+  setIsWarningModalOpen: PropTypes.func.isRequired,
   setBannerText: PropTypes.func.isRequired,
   data: PropTypes.object,
   status: PropTypes.string.isRequired,

--- a/src/Analysis/SharedUtils/TeamProject/TeamProjectModal/TeamProjectModal.jsx
+++ b/src/Analysis/SharedUtils/TeamProject/TeamProjectModal/TeamProjectModal.jsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState }  from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import { useHistory } from 'react-router-dom';
 import { Button, Modal, Spin } from 'antd';
@@ -26,8 +26,8 @@ const TeamProjectModal = ({
   };
 
   const closeAndUpdateTeamProject = () => {
-    //Closing Modal is handled in the header
-    sendMessage('Team Project Changed!')
+    // Closing Modal is handled in the header
+    sendMessage('Team Project Changed!');
     setBannerText(selectedTeamProject);
     localStorage.setItem('teamProject', selectedTeamProject);
   };
@@ -64,7 +64,7 @@ const TeamProjectModal = ({
         open={isWarningModalOpen}
         className='team-project-modal'
         title='Team Projects'
-        closable={true}
+        closable
         maskClosable={false}
         keyboard={false}
         footer={[
@@ -82,7 +82,7 @@ const TeamProjectModal = ({
           Team Project has been updated in another tab. Please click refresh page to prevent errors.
         </div>
       </Modal>
-    )
+    );
   }
   if (data) {
     if (data.teams.length > 0) {

--- a/src/Analysis/SharedUtils/TeamProject/TeamProjectModal/TeamProjectModal.test.jsx
+++ b/src/Analysis/SharedUtils/TeamProject/TeamProjectModal/TeamProjectModal.test.jsx
@@ -21,7 +21,7 @@ describe('TeamProjectModal', () => {
       <TeamProjectModal
         isModalOpen
         setIsModalOpen={setIsModalOpen}
-        isWarningModalOpen ={false}
+        isWarningModalOpen={false}
         setIsWarningModalOpen={setIsWarningModalOpen}
         setBannerText={setBannerText}
         data={undefined}
@@ -43,7 +43,7 @@ describe('TeamProjectModal', () => {
       <TeamProjectModal
         isModalOpen
         setIsModalOpen={setIsModalOpen}
-        isWarningModalOpen ={false}
+        isWarningModalOpen={false}
         setIsWarningModalOpen={setIsWarningModalOpen}
         setBannerText={setBannerText}
         data={TeamProjectTestData.data}
@@ -72,7 +72,7 @@ describe('TeamProjectModal', () => {
       <TeamProjectModal
         isModalOpen
         setIsModalOpen={setIsModalOpen}
-        isWarningModalOpen ={false}
+        isWarningModalOpen={false}
         setIsWarningModalOpen={setIsWarningModalOpen}
         setBannerText={setBannerText}
         data={TeamProjectTestData.data}
@@ -100,7 +100,7 @@ describe('TeamProjectModal', () => {
         isModalOpen
         setIsModalOpen={setIsModalOpen}
         setBannerText={setBannerText}
-        isWarningModalOpen ={false}
+        isWarningModalOpen={false}
         setIsWarningModalOpen={setIsWarningModalOpen}
         data={TeamProjectTestData.data}
         status='success'
@@ -124,7 +124,7 @@ describe('TeamProjectModal', () => {
         isModalOpen
         setIsModalOpen={setIsModalOpen}
         setBannerText={setBannerText}
-        isWarningModalOpen ={true}
+        isWarningModalOpen
         setIsWarningModalOpen={setIsWarningModalOpen}
         data={TeamProjectTestData.data}
         status='success'

--- a/src/Analysis/SharedUtils/TeamProject/TeamProjectModal/TeamProjectModal.test.jsx
+++ b/src/Analysis/SharedUtils/TeamProject/TeamProjectModal/TeamProjectModal.test.jsx
@@ -13,6 +13,7 @@ const testTeamName = TeamProjectTestData.data.teams[0].teamName;
 const setIsModalOpen = jest.fn();
 const setBannerText = jest.fn();
 const setSelectedTeamProject = jest.fn();
+const setIsWarningModalOpen = jest.fn();
 
 describe('TeamProjectModal', () => {
   test('renders with loading text initially', async () => {
@@ -20,6 +21,8 @@ describe('TeamProjectModal', () => {
       <TeamProjectModal
         isModalOpen
         setIsModalOpen={setIsModalOpen}
+        isWarningModalOpen ={false}
+        setIsWarningModalOpen={setIsWarningModalOpen}
         setBannerText={setBannerText}
         data={undefined}
         status='loading'
@@ -40,6 +43,8 @@ describe('TeamProjectModal', () => {
       <TeamProjectModal
         isModalOpen
         setIsModalOpen={setIsModalOpen}
+        isWarningModalOpen ={false}
+        setIsWarningModalOpen={setIsWarningModalOpen}
         setBannerText={setBannerText}
         data={TeamProjectTestData.data}
         status='success'
@@ -67,6 +72,8 @@ describe('TeamProjectModal', () => {
       <TeamProjectModal
         isModalOpen
         setIsModalOpen={setIsModalOpen}
+        isWarningModalOpen ={false}
+        setIsWarningModalOpen={setIsWarningModalOpen}
         setBannerText={setBannerText}
         data={TeamProjectTestData.data}
         status='success'
@@ -93,6 +100,8 @@ describe('TeamProjectModal', () => {
         isModalOpen
         setIsModalOpen={setIsModalOpen}
         setBannerText={setBannerText}
+        isWarningModalOpen ={false}
+        setIsWarningModalOpen={setIsWarningModalOpen}
         data={TeamProjectTestData.data}
         status='success'
         selectedTeamProject={testTeamName}
@@ -106,7 +115,25 @@ describe('TeamProjectModal', () => {
     fireEvent.click(submitButton);
 
     // Assert that the modal closes and sets banner text
-    expect(setIsModalOpen).toHaveBeenCalledWith(false);
     expect(setBannerText).toHaveBeenCalledWith(testTeamName);
+  });
+
+  test('Render warning modal based ', async () => {
+    render(
+      <TeamProjectModal
+        isModalOpen
+        setIsModalOpen={setIsModalOpen}
+        setBannerText={setBannerText}
+        isWarningModalOpen ={true}
+        setIsWarningModalOpen={setIsWarningModalOpen}
+        data={TeamProjectTestData.data}
+        status='success'
+        selectedTeamProject={testTeamName}
+        setSelectedTeamProject={setSelectedTeamProject}
+      />,
+    );
+
+    // Assert that the modal closes and sets banner text
+    expect(screen.getByText('Refresh Page')).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
https://ctds-planx.atlassian.net/browse/VADC-1052

### New Features
Use Broadcast channel to send message and detect if team project has been updated in another tab. If a change is detected, present modal screen to ask the user to refresh the screen to prevent discrepancy in the current tab being worked on.

<img width="2033" alt="Screenshot 2025-01-13 at 12 12 11 PM" src="https://github.com/user-attachments/assets/df2acf11-5b45-43fc-a87b-e578646f0d01" />
