### PR TITLE
Feat: add transformation dropdown to histogram

### DIFF
--- a/src/Analysis/GWASApp/Components/AttritionTableWrapper/AttritionTable/AttritionTable.stories.jsx
+++ b/src/Analysis/GWASApp/Components/AttritionTableWrapper/AttritionTable/AttritionTable.stories.jsx
@@ -159,7 +159,7 @@ MockedSuccess.parameters = {
         }
       ),
       rest.post(
-        'http://:cohortmiddlewarepath/cohort-middleware/histogram/by-source-id/:sourceid/by-cohort-definition-id/:cohortdefinitionId/by-histogram-concept-id/:conceptId',
+        'http://:cohortmiddlewarepath/cohort-middleware/histogram/by-source-id/:sourceid/by-cohort-definition-id/:cohortdefinitionId',
         (req, res, ctx) => {
           return res(
             ctx.delay(2000),

--- a/src/Analysis/GWASApp/Components/AttritionTableWrapper/AttritionTableModal/AttritionTableModal.jsx
+++ b/src/Analysis/GWASApp/Components/AttritionTableWrapper/AttritionTableModal/AttritionTableModal.jsx
@@ -23,7 +23,6 @@ const AttritionTableModal = ({ modalInfo, setModalInfo }) => {
         && modalInfo.rowObject.variable_type === 'concept' && (
         <div data-testid='phenotype-histogram-diagram'>
           <PhenotypeHistogram
-            useInlineErrorMessages
             selectedStudyPopulationCohort={modalInfo.selectedCohort}
             selectedCovariates={
               modalInfo.currentCovariateAndCovariatesFromPrecedingRows

--- a/src/Analysis/GWASApp/Components/AttritionTableWrapper/AttritionTableWrapper.stories.jsx
+++ b/src/Analysis/GWASApp/Components/AttritionTableWrapper/AttritionTableWrapper.stories.jsx
@@ -117,7 +117,7 @@ WithConceptOutcome.parameters = {
         }
       ),
       rest.post(
-        'http://:cohortmiddlewarepath/cohort-middleware/histogram/by-source-id/:sourceid/by-cohort-definition-id/:cohortdefinitionId/by-histogram-concept-id/:conceptId',
+        'http://:cohortmiddlewarepath/cohort-middleware/histogram/by-source-id/:sourceid/by-cohort-definition-id/:cohortdefinitionId',
         (req, res, ctx) => {
           return res(
             ctx.delay(2000),

--- a/src/Analysis/GWASApp/Components/AttritionTableWrapper/ChartIcons/BarChart.jsx
+++ b/src/Analysis/GWASApp/Components/AttritionTableWrapper/ChartIcons/BarChart.jsx
@@ -4,7 +4,7 @@ const BarChart = () => (
   <svg
     className='bar-chart-icon'
     role='img'
-    aria-labelledby='barChartDesc'
+    aria-labelledby='barChartTitle'
     xmlns='http://www.w3.org/2000/svg'
     width='16px'
     viewBox='0 0 64 64'

--- a/src/Analysis/GWASApp/Components/Covariates/ContinuousCovariates.jsx
+++ b/src/Analysis/GWASApp/Components/Covariates/ContinuousCovariates.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import Covariates from './Covariates';
 import PhenotypeHistogram from '../Diagrams/PhenotypeHistogram/PhenotypeHistogram';
 import './Covariates.css';
+import FILTERS from '../../../SharedUtils/FiltersEnumeration';
 
 const ContinuousCovariates = ({
   dispatch,
@@ -36,14 +37,14 @@ const ContinuousCovariates = ({
       const filters = prevSelected.filters ? [...prevSelected.filters] : [];
 
       // Find the index of the ">=" filter
-      const minFilterIndex = filters.findIndex((filter) => filter.type === ">=");
+      const minFilterIndex = filters.findIndex((filter) => filter.type === FILTERS.greaterThanOrEqualTo);
 
       if (minFilterIndex !== -1) {
         // Update the existing ">=" filter
-        filters[minFilterIndex] = { type: ">=", value: minOutlierCutoff };
+        filters[minFilterIndex] = { type: FILTERS.greaterThanOrEqualTo, value: minOutlierCutoff };
       } else {
         // Add a new ">=" filter
-        filters.push({ type: ">=", value: minOutlierCutoff });
+        filters.push({ type: FILTERS.greaterThanOrEqualTo, value: minOutlierCutoff });
       }
 
       return { ...prevSelected, filters };
@@ -56,14 +57,14 @@ const ContinuousCovariates = ({
       const filters = prevSelected.filters ? [...prevSelected.filters] : [];
 
       // Find the index of the "<=" filter
-      const maxFilterIndex = filters.findIndex((filter) => filter.type === "<=");
+      const maxFilterIndex = filters.findIndex((filter) => filter.type === FILTERS.lessThanOrEqualTo);
 
       if (maxFilterIndex !== -1) {
         // Update the existing "<=" filter
-        filters[maxFilterIndex] = { type: "<=", value: maxOutlierCutoff };
+        filters[maxFilterIndex] = { type: FILTERS.lessThanOrEqualTo, value: maxOutlierCutoff };
       } else {
         // Add a new "<=" filter
-        filters.push({ type: "<=", value: maxOutlierCutoff });
+        filters.push({ type: FILTERS.lessThanOrEqualTo, value: maxOutlierCutoff });
       }
 
       return { ...prevSelected, filters };

--- a/src/Analysis/GWASApp/Components/Covariates/ContinuousCovariates.jsx
+++ b/src/Analysis/GWASApp/Components/Covariates/ContinuousCovariates.jsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { Select } from 'antd';
+import { Select, InputNumber } from 'antd';
 import PropTypes from 'prop-types';
 import Covariates from './Covariates';
 import PhenotypeHistogram from '../Diagrams/PhenotypeHistogram/PhenotypeHistogram';
@@ -16,16 +16,62 @@ const ContinuousCovariates = ({
 }) => {
   const [selected, setSelected] = useState(null);
 
-  const formatSelected = (transformationType) => ({
+  const formatSelected = () => ({
     variable_type: 'concept',
     concept_id: selected.concept_id,
     concept_name: selected.concept_name,
-    transformation: transformationType,
+    transformation: selected.transformation,
+    filters: selected.filters,
   });
 
-  const onChange = (selectedTransformationType) => {
-    setSelected(formatSelected(selectedTransformationType.key));
+  const onChangeTransformation = (selectedTransformationType) => {
+    setSelected((prevSelected) => {
+      const transformation = selectedTransformationType.key;
+      return { ...prevSelected, transformation };
+    });
   };
+
+  const onChangeMinOutlierCutoff = (minOutlierCutoff) => {
+    setSelected((prevSelected) => {
+      // Ensure filters array exists
+      const filters = prevSelected.filters ? [...prevSelected.filters] : [];
+
+      // Find the index of the ">=" filter
+      const minFilterIndex = filters.findIndex((filter) => filter.type === ">=");
+
+      if (minFilterIndex !== -1) {
+        // Update the existing ">=" filter
+        filters[minFilterIndex] = { type: ">=", value: minOutlierCutoff };
+      } else {
+        // Add a new ">=" filter
+        filters.push({ type: ">=", value: minOutlierCutoff });
+      }
+
+      return { ...prevSelected, filters };
+    });
+  };
+
+  const onChangeMaxOutlierCutoff = (maxOutlierCutoff) => {
+    setSelected((prevSelected) => {
+      // Ensure filters array exists
+      const filters = prevSelected.filters ? [...prevSelected.filters] : [];
+
+      // Find the index of the "<=" filter
+      const maxFilterIndex = filters.findIndex((filter) => filter.type === "<=");
+
+      if (maxFilterIndex !== -1) {
+        // Update the existing "<=" filter
+        filters[maxFilterIndex] = { type: "<=", value: maxOutlierCutoff };
+      } else {
+        // Add a new "<=" filter
+        filters.push({ type: "<=", value: maxOutlierCutoff });
+      }
+
+      return { ...prevSelected, filters };
+    });
+  };
+
+
 
   // when a user has selected a outcome phenotype that is a continuous covariate with a concept ID,
   // that should not appear as a selectable option, and be included in the submitted covariates.
@@ -73,7 +119,7 @@ const ContinuousCovariates = ({
               <Select
                 showSearch={false}
                 labelInValue
-                onChange={onChange}
+                onChange={onChangeTransformation}
                 placeholder='-optional transformation-'
                 fieldNames={{ label: 'description', value: 'type' }}
                 options={[{type: 'log', description: 'log transformation'},{type: 'z_score', description: 'z-score transformation'}]}
@@ -86,6 +132,30 @@ const ContinuousCovariates = ({
                 outcome={outcome}
                 selectedContinuousItem={selected}
               />
+              <div className='GWASUI-row'>
+                <div className='GWASUI-column'>
+                  <label htmlFor='input-minOutlierCutoff'>Minimum outlier cutoff</label>
+                </div>
+                <div className='GWASUI-column'>
+                  <InputNumber
+                    id='input-minOutlierCutoff'
+                    min={1}
+                    max={10}
+                    onChange={onChangeMinOutlierCutoff}
+                  />
+                </div>
+                <div className='GWASUI-column'>
+                  <label htmlFor='input-maxOutlierCutoff'>Maximum outlier cutoff</label>
+                </div>
+                <div className='GWASUI-column'>
+                  <InputNumber
+                    id='input-maxOutlierCutoff'
+                    min={1}
+                    max={10}
+                    onChange={onChangeMaxOutlierCutoff}
+                  />
+                </div>
+              </div>
             </div>
           ) : (
             <div data-tour='phenotype-histogram' className='phenotype-histogram-directions'>

--- a/src/Analysis/GWASApp/Components/Covariates/ContinuousCovariates.jsx
+++ b/src/Analysis/GWASApp/Components/Covariates/ContinuousCovariates.jsx
@@ -1,5 +1,4 @@
 import React, { useState } from 'react';
-import { Select, InputNumber } from 'antd';
 import PropTypes from 'prop-types';
 import Covariates from './Covariates';
 import PhenotypeHistogram from '../Diagrams/PhenotypeHistogram/PhenotypeHistogram';
@@ -116,42 +115,16 @@ const ContinuousCovariates = ({
           </div>
           {selected ? (
             <div data-tour='phenotype-histogram'>
-              <Select
-                showSearch={false}
-                labelInValue
-                onChange={onChangeTransformation}
-                placeholder='-optional transformation-'
-                fieldNames={{ label: 'description', value: 'type' }}
-                options={[{type: 'log', description: 'log transformation'},{type: 'z_score', description: 'z-score transformation'}]}
-                dropdownStyle={{ width: '800' }}
-              />
               <PhenotypeHistogram
                 dispatch={dispatch}
                 selectedStudyPopulationCohort={selectedStudyPopulationCohort}
                 selectedCovariates={selectedCovariates}
                 outcome={outcome}
                 selectedContinuousItem={selected}
+                handleChangeTransformation={onChangeTransformation}
+                handleChangeMinOutlierCutoff={onChangeMinOutlierCutoff}
+                handleChangeMaxOutlierCutoff={onChangeMaxOutlierCutoff}
               />
-              <div className='GWASUI-row'>
-                <div className='GWASUI-column'>
-                  <label htmlFor='input-minOutlierCutoff'>Minimum outlier cutoff</label>
-                </div>
-                <div className='GWASUI-column'>
-                  <InputNumber
-                    id='input-minOutlierCutoff'
-                    onChange={onChangeMinOutlierCutoff}
-                  />
-                </div>
-                <div className='GWASUI-column'>
-                  <label htmlFor='input-maxOutlierCutoff'>Maximum outlier cutoff</label>
-                </div>
-                <div className='GWASUI-column'>
-                  <InputNumber
-                    id='input-maxOutlierCutoff'
-                    onChange={onChangeMaxOutlierCutoff}
-                  />
-                </div>
-              </div>
             </div>
           ) : (
             <div data-tour='phenotype-histogram' className='phenotype-histogram-directions'>

--- a/src/Analysis/GWASApp/Components/Covariates/ContinuousCovariates.jsx
+++ b/src/Analysis/GWASApp/Components/Covariates/ContinuousCovariates.jsx
@@ -71,8 +71,6 @@ const ContinuousCovariates = ({
     });
   };
 
-
-
   // when a user has selected a outcome phenotype that is a continuous covariate with a concept ID,
   // that should not appear as a selectable option, and be included in the submitted covariates.
   // If they selected a outcome phenotype that is dichotomous

--- a/src/Analysis/GWASApp/Components/Covariates/ContinuousCovariates.jsx
+++ b/src/Analysis/GWASApp/Components/Covariates/ContinuousCovariates.jsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import { Select } from 'antd';
 import PropTypes from 'prop-types';
 import Covariates from './Covariates';
 import PhenotypeHistogram from '../Diagrams/PhenotypeHistogram/PhenotypeHistogram';
@@ -15,11 +16,16 @@ const ContinuousCovariates = ({
 }) => {
   const [selected, setSelected] = useState(null);
 
-  const formatSelected = () => ({
+  const formatSelected = (transformationType) => ({
     variable_type: 'concept',
     concept_id: selected.concept_id,
     concept_name: selected.concept_name,
+    transformation: transformationType,
   });
+
+  const onChange = (selectedTransformationType) => {
+    setSelected(formatSelected(selectedTransformationType.key));
+  };
 
   // when a user has selected a outcome phenotype that is a continuous covariate with a concept ID,
   // that should not appear as a selectable option, and be included in the submitted covariates.
@@ -64,6 +70,15 @@ const ContinuousCovariates = ({
           </div>
           {selected ? (
             <div data-tour='phenotype-histogram'>
+              <Select
+                showSearch={false}
+                labelInValue
+                onChange={onChange}
+                placeholder='-optional transformation-'
+                fieldNames={{ label: 'description', value: 'type' }}
+                options={[{type: 'log', description: 'log transformation'},{type: 'z_score', description: 'z-score transformation'}]}
+                dropdownStyle={{ width: '800' }}
+              />
               <PhenotypeHistogram
                 dispatch={dispatch}
                 selectedStudyPopulationCohort={selectedStudyPopulationCohort}

--- a/src/Analysis/GWASApp/Components/Covariates/ContinuousCovariates.jsx
+++ b/src/Analysis/GWASApp/Components/Covariates/ContinuousCovariates.jsx
@@ -139,8 +139,6 @@ const ContinuousCovariates = ({
                 <div className='GWASUI-column'>
                   <InputNumber
                     id='input-minOutlierCutoff'
-                    min={1}
-                    max={10}
                     onChange={onChangeMinOutlierCutoff}
                   />
                 </div>
@@ -150,8 +148,6 @@ const ContinuousCovariates = ({
                 <div className='GWASUI-column'>
                   <InputNumber
                     id='input-maxOutlierCutoff'
-                    min={1}
-                    max={10}
                     onChange={onChangeMaxOutlierCutoff}
                   />
                 </div>

--- a/src/Analysis/GWASApp/Components/Covariates/ContinuousCovariates.jsx
+++ b/src/Analysis/GWASApp/Components/Covariates/ContinuousCovariates.jsx
@@ -113,7 +113,7 @@ const ContinuousCovariates = ({
             </button>
           </div>
           {selected ? (
-            <div data-tour='phenotype-histogram'>
+            <div data-tour='phenotype-histogram' className='phenotype-histogram-component'>
               <PhenotypeHistogram
                 dispatch={dispatch}
                 selectedStudyPopulationCohort={selectedStudyPopulationCohort}

--- a/src/Analysis/GWASApp/Components/Covariates/ContinuousCovariates.jsx
+++ b/src/Analysis/GWASApp/Components/Covariates/ContinuousCovariates.jsx
@@ -2,8 +2,9 @@ import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import Covariates from './Covariates';
 import PhenotypeHistogram from '../Diagrams/PhenotypeHistogram/PhenotypeHistogram';
-import './Covariates.css';
 import FILTERS from '../../../SharedUtils/FiltersEnumeration';
+import BarChart from '../AttritionTableWrapper/ChartIcons/BarChart';
+import './Covariates.css';
 
 const ContinuousCovariates = ({
   dispatch,
@@ -127,7 +128,7 @@ const ContinuousCovariates = ({
             </div>
           ) : (
             <div data-tour='phenotype-histogram' className='phenotype-histogram-directions'>
-              Select a concept to render its corresponding histogram
+              <BarChart />Select a concept to render its corresponding histogram
             </div>
           )}
         </div>

--- a/src/Analysis/GWASApp/Components/Covariates/ContinuousCovariates.stories.jsx
+++ b/src/Analysis/GWASApp/Components/Covariates/ContinuousCovariates.stories.jsx
@@ -105,8 +105,7 @@ SuccessCase.parameters = {
         }
       ),
       rest.post(
-        //histogram/by-source-id/${sourceId}/by-cohort-definition-id/${cohortId}/by-histogram-concept-id/${currentSelection.concept_id}`;
-        'http://:cohortmiddlewarepath/cohort-middleware/histogram/by-source-id/:sourceid/by-cohort-definition-id/:cohortdefinitionId/by-histogram-concept-id/:conceptId',
+        'http://:cohortmiddlewarepath/cohort-middleware/histogram/by-source-id/:sourceid/by-cohort-definition-id/:cohortdefinitionId',
         (req, res, ctx) => {
           const { cohortmiddlewarepath } = req.params;
           const { cohortdefinitionId } = req.params;
@@ -152,8 +151,7 @@ EmptyDataCase.parameters = {
         }
       ),
       rest.post(
-        //histogram/by-source-id/${sourceId}/by-cohort-definition-id/${cohortId}/by-histogram-concept-id/${currentSelection.concept_id}`;
-        'http://:cohortmiddlewarepath/cohort-middleware/histogram/by-source-id/:sourceid/by-cohort-definition-id/:cohortdefinitionId/by-histogram-concept-id/:conceptId',
+        'http://:cohortmiddlewarepath/cohort-middleware/histogram/by-source-id/:sourceid/by-cohort-definition-id/:cohortdefinitionId',
         (req, res, ctx) => {
           const { cohortmiddlewarepath } = req.params;
           const { cohortdefinitionId } = req.params;

--- a/src/Analysis/GWASApp/Components/Covariates/Covariates.css
+++ b/src/Analysis/GWASApp/Components/Covariates/Covariates.css
@@ -95,7 +95,7 @@
 }
 
 .GWASApp .phenotype-histogram .recharts-wrapper {
-  margin-top: 60px;
+  margin-top: 10px;
 }
 
 .GWASApp .phenotype-histogram .histrogram-loading {
@@ -108,6 +108,13 @@
   float: left;
   margin-top: 50px;
   text-align: center;
+  width: 600px;
+}
+
+.GWASApp .phenotype-histogram-component {
+  float: left;
+  margin-top: 25px;
+  text-align: left;
   width: 600px;
 }
 

--- a/src/Analysis/GWASApp/Components/Covariates/Covariates.css
+++ b/src/Analysis/GWASApp/Components/Covariates/Covariates.css
@@ -92,6 +92,7 @@
   display: block;
   float: right;
   height: 36px;
+  margin-right: 5%;
 }
 
 .GWASApp .phenotype-histogram .recharts-wrapper {
@@ -109,6 +110,10 @@
   margin-top: 50px;
   text-align: center;
   width: 600px;
+}
+
+.GWASApp .phenotype-histogram-directions svg {
+  margin-right: 4px;
 }
 
 .GWASApp .phenotype-histogram-component {

--- a/src/Analysis/GWASApp/Components/Diagrams/PhenotypeHistogram/PhenotypeHistogram.css
+++ b/src/Analysis/GWASApp/Components/Diagrams/PhenotypeHistogram/PhenotypeHistogram.css
@@ -1,0 +1,21 @@
+.GWASUI-column.transformation-dropdown-label {
+  max-width: 25%;
+}
+
+.GWASUI-column.transformation-select {
+  max-width: 65%;
+}
+
+label[for='input-minOutlierCutoff'],
+label[for='input-maxOutlierCutoff'] {
+  margin-top: 3px;
+}
+
+.GWASUI-row.outlier-inputs {
+  margin-top: -8px;
+}
+
+.recharts-text.xAxisLabel tspan:nth-child(1) {
+  font-weight: bold;
+  fill: black;
+}

--- a/src/Analysis/GWASApp/Components/Diagrams/PhenotypeHistogram/PhenotypeHistogram.jsx
+++ b/src/Analysis/GWASApp/Components/Diagrams/PhenotypeHistogram/PhenotypeHistogram.jsx
@@ -125,6 +125,16 @@ const PhenotypeHistogram = ({
                     setMinOutlierCutoff(value);
                     handleChangeMinOutlierCutoff(value);
                   }}
+                  min={data.bins[0]?.start || 0}
+                  max={maxOutlierCutoff || data.bins[data.bins.length - 1]?.end || 100}
+                  onKeyDown={(e) => {
+                    const { key } = e;
+                    // Allow only numeric keys, backspace, and delete, and one decimal point
+                    if (!/[\d]/.test(key) && key !== 'Backspace' && key !== 'Delete' && key !== 'ArrowLeft' && key !== 'ArrowRight'
+                    && (key !== '.' || e.target.value.includes('.'))) {
+                      e.preventDefault();
+                    }
+                  }}
                 />
               </div>
               <div className='GWASUI-column'>
@@ -137,6 +147,16 @@ const PhenotypeHistogram = ({
                   onChange={(value) => {
                     setMaxOutlierCutoff(value);
                     handleChangeMaxOutlierCutoff(value);
+                  }}
+                  min={minOutlierCutoff || data.bins[0]?.start || 0}
+                  max={data.bins[data.bins.length - 1]?.end || 100}
+                  onKeyDown={(e) => {
+                    const { key } = e;
+                    // Allow only numeric keys, backspace, and delete, and one decimal point
+                    if (!/[\d]/.test(key) && key !== 'Backspace' && key !== 'Delete' && key !== 'ArrowLeft' && key !== 'ArrowRight'
+                    && (key !== '.' || e.target.value.includes('.'))) {
+                      e.preventDefault();
+                    }
                   }}
                 />
               </div>

--- a/src/Analysis/GWASApp/Components/Diagrams/PhenotypeHistogram/PhenotypeHistogram.jsx
+++ b/src/Analysis/GWASApp/Components/Diagrams/PhenotypeHistogram/PhenotypeHistogram.jsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import { useQuery } from 'react-query';
+import { Select, InputNumber } from 'antd';
 import { Spin } from 'antd';
 import { fetchHistogramInfo } from '../../../Utils/cohortMiddlewareApi';
 import queryConfig from '../../../../SharedUtils/QueryConfig';
@@ -15,8 +16,10 @@ const PhenotypeHistogram = ({
   selectedCovariates,
   outcome,
   selectedContinuousItem,
-  useInlineErrorMessages,
   useAnimation,
+  handleChangeTransformation,
+  handleChangeMinOutlierCutoff,
+  handleChangeMaxOutlierCutoff
 }) => {
   const { source } = useSourceContext();
   const [inlineErrorMessage, setInlineErrorMessage] = useState(null);
@@ -89,28 +92,65 @@ const PhenotypeHistogram = ({
   };
   return (
     <React.Fragment>
-      {useInlineErrorMessages && inlineErrorMessage}
-      <Histogram {...histogramArgs} />
+      {inlineErrorMessage}
+      {data.bins !== null &&
+        <div data-tour='phenotype-histogram-with-filter-and-transformation'>
+          <Select
+            showSearch={false}
+            labelInValue
+            onChange={handleChangeTransformation}
+            placeholder='-optional transformation-'
+            fieldNames={{ label: 'description', value: 'type' }}
+            options={[{type: 'log', description: 'log transformation'},{type: 'z_score', description: 'z-score transformation'}]}
+            dropdownStyle={{ width: '800' }}
+          />
+          <Histogram {...histogramArgs} />
+          <div className='GWASUI-row'>
+            <div className='GWASUI-column'>
+              <label htmlFor='input-minOutlierCutoff'>Minimum outlier cutoff</label>
+            </div>
+            <div className='GWASUI-column'>
+              <InputNumber
+                id='input-minOutlierCutoff'
+                onChange={handleChangeMinOutlierCutoff}
+              />
+            </div>
+            <div className='GWASUI-column'>
+              <label htmlFor='input-maxOutlierCutoff'>Maximum outlier cutoff</label>
+            </div>
+            <div className='GWASUI-column'>
+              <InputNumber
+                id='input-maxOutlierCutoff'
+                onChange={handleChangeMaxOutlierCutoff}
+              />
+            </div>
+          </div>
+        </div>
+      }
     </React.Fragment>
   );
 };
 
 PhenotypeHistogram.propTypes = {
-  useInlineErrorMessages: PropTypes.bool,
   dispatch: PropTypes.func,
   selectedStudyPopulationCohort: PropTypes.object.isRequired,
   selectedCovariates: PropTypes.array,
   outcome: PropTypes.object,
   selectedContinuousItem: PropTypes.object.isRequired,
   useAnimation: PropTypes.bool,
+  handleChangeTransformation: PropTypes.func,
+  handleChangeMinOutlierCutoff: PropTypes.func,
+  handleChangeMaxOutlierCutoff: PropTypes.func
 };
 
 PhenotypeHistogram.defaultProps = {
-  useInlineErrorMessages: false,
   dispatch: null,
   selectedCovariates: [],
   outcome: null,
   useAnimation: true,
+  handleChangeTransformation: null,
+  handleChangeMinOutlierCutoff: null,
+  handleChangeMaxOutlierCutoff: null
 };
 
 export default PhenotypeHistogram;

--- a/src/Analysis/GWASApp/Components/Diagrams/PhenotypeHistogram/PhenotypeHistogram.jsx
+++ b/src/Analysis/GWASApp/Components/Diagrams/PhenotypeHistogram/PhenotypeHistogram.jsx
@@ -29,6 +29,7 @@ const PhenotypeHistogram = ({
       selectedCovariates,
       outcome,
       selectedContinuousItem.concept_id,
+      selectedContinuousItem.transformation,
     ],
     () => fetchHistogramInfo(
       sourceId,
@@ -36,6 +37,7 @@ const PhenotypeHistogram = ({
       selectedCovariates,
       outcome,
       selectedContinuousItem.concept_id,
+      selectedContinuousItem.transformation,
     ),
     queryConfig,
   );

--- a/src/Analysis/GWASApp/Components/Diagrams/PhenotypeHistogram/PhenotypeHistogram.jsx
+++ b/src/Analysis/GWASApp/Components/Diagrams/PhenotypeHistogram/PhenotypeHistogram.jsx
@@ -94,7 +94,7 @@ const PhenotypeHistogram = ({
     <React.Fragment>
       {inlineErrorMessage}
       {data.bins !== null &&
-        <div data-tour='phenotype-histogram-with-filter-and-transformation'>
+        <div>
           <Select
             showSearch={false}
             labelInValue

--- a/src/Analysis/GWASApp/Components/Diagrams/PhenotypeHistogram/PhenotypeHistogram.jsx
+++ b/src/Analysis/GWASApp/Components/Diagrams/PhenotypeHistogram/PhenotypeHistogram.jsx
@@ -30,6 +30,7 @@ const PhenotypeHistogram = ({
       outcome,
       selectedContinuousItem.concept_id,
       selectedContinuousItem.transformation,
+      selectedContinuousItem.filters,
     ],
     () => fetchHistogramInfo(
       sourceId,
@@ -38,6 +39,7 @@ const PhenotypeHistogram = ({
       outcome,
       selectedContinuousItem.concept_id,
       selectedContinuousItem.transformation,
+      selectedContinuousItem.filters,
     ),
     queryConfig,
   );

--- a/src/Analysis/GWASApp/Components/Diagrams/PhenotypeHistogram/PhenotypeHistogram.jsx
+++ b/src/Analysis/GWASApp/Components/Diagrams/PhenotypeHistogram/PhenotypeHistogram.jsx
@@ -99,19 +99,29 @@ const PhenotypeHistogram = ({
       {data.bins !== null
         && (
           <div>
-            <Select
-              showSearch={false}
-              labelInValue
-              value={selectedTransformation}
-              onChange={(value) => {
-                setSelectedTransformation(value);
-                handleChangeTransformation(value);
-              }}
-              placeholder='-optional transformation-'
-              fieldNames={{ label: 'description', value: 'type' }}
-              options={[{ type: 'log', description: 'log transformation' }, { type: 'z_score', description: 'z-score transformation' }]}
-              dropdownStyle={{ width: '800' }}
-            />
+            <div className='GWASUI-row'>
+              <div className='GWASUI-column'>
+                <label id='transformation-dropdown-label' htmlFor='transformation-select'>Select Transformation</label>
+              </div>
+              <div className='GWASUI-column'>
+                <Select
+                  id='transformation-select'
+                  showSearch={false}
+                  labelInValue
+                  value={selectedTransformation}
+                  onChange={(value) => {
+                    setSelectedTransformation(value);
+                    handleChangeTransformation(value);
+                  }}
+                  placeholder='-optional transformation-'
+                  fieldNames={{ label: 'description', value: 'type' }}
+                  options={[{ type: 'log', description: 'log transformation' }, { type: 'z_score', description: 'z-score transformation' }]}
+                  aria-label='Transformation Selection'
+                  aria-labelledby='transformation-dropdown-label'
+                />
+              </div>
+              <div className='GWASUI-column' />
+            </div>
             <Histogram {...histogramArgs} />
             <div className='GWASUI-row'>
               <div className='GWASUI-column'>

--- a/src/Analysis/GWASApp/Components/Diagrams/PhenotypeHistogram/PhenotypeHistogram.jsx
+++ b/src/Analysis/GWASApp/Components/Diagrams/PhenotypeHistogram/PhenotypeHistogram.jsx
@@ -1,8 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import { useQuery } from 'react-query';
-import { Select, InputNumber } from 'antd';
-import { Spin } from 'antd';
+import { Select, InputNumber, Spin } from 'antd';
 import { fetchHistogramInfo } from '../../../Utils/cohortMiddlewareApi';
 import queryConfig from '../../../../SharedUtils/QueryConfig';
 import Histogram from '../../../../SharedUtils/DataViz/Histogram/Histogram';
@@ -20,7 +19,7 @@ const PhenotypeHistogram = ({
   useAnimation,
   handleChangeTransformation,
   handleChangeMinOutlierCutoff,
-  handleChangeMaxOutlierCutoff
+  handleChangeMaxOutlierCutoff,
 }) => {
   const { source } = useSourceContext();
   const [inlineErrorMessage, setInlineErrorMessage] = useState(null);
@@ -88,46 +87,47 @@ const PhenotypeHistogram = ({
     xAxisLegend: selectedContinuousItem.concept_name,
     yAxisLegend: 'Persons',
     useAnimation,
-    minCutoff: selectedContinuousItem.filters?.find(filter => filter.type === FILTERS.greaterThanOrEqualTo)?.value ?? undefined,
-    maxCutoff: selectedContinuousItem.filters?.find(filter => filter.type === FILTERS.lessThanOrEqualTo)?.value ?? undefined,
+    minCutoff: selectedContinuousItem.filters?.find((filter) => filter.type === FILTERS.greaterThanOrEqualTo)?.value ?? undefined,
+    maxCutoff: selectedContinuousItem.filters?.find((filter) => filter.type === FILTERS.lessThanOrEqualTo)?.value ?? undefined,
   };
   return (
     <React.Fragment>
       {inlineErrorMessage}
-      {data.bins !== null &&
-        <div>
-          <Select
-            showSearch={false}
-            labelInValue
-            onChange={handleChangeTransformation}
-            placeholder='-optional transformation-'
-            fieldNames={{ label: 'description', value: 'type' }}
-            options={[{type: 'log', description: 'log transformation'},{type: 'z_score', description: 'z-score transformation'}]}
-            dropdownStyle={{ width: '800' }}
-          />
-          <Histogram {...histogramArgs} />
-          <div className='GWASUI-row'>
-            <div className='GWASUI-column'>
-              <label htmlFor='input-minOutlierCutoff'>Minimum outlier cutoff</label>
-            </div>
-            <div className='GWASUI-column'>
-              <InputNumber
-                id='input-minOutlierCutoff'
-                onChange={handleChangeMinOutlierCutoff}
-              />
-            </div>
-            <div className='GWASUI-column'>
-              <label htmlFor='input-maxOutlierCutoff'>Maximum outlier cutoff</label>
-            </div>
-            <div className='GWASUI-column'>
-              <InputNumber
-                id='input-maxOutlierCutoff'
-                onChange={handleChangeMaxOutlierCutoff}
-              />
+      {data.bins !== null
+        && (
+          <div>
+            <Select
+              showSearch={false}
+              labelInValue
+              onChange={handleChangeTransformation}
+              placeholder='-optional transformation-'
+              fieldNames={{ label: 'description', value: 'type' }}
+              options={[{ type: 'log', description: 'log transformation' }, { type: 'z_score', description: 'z-score transformation' }]}
+              dropdownStyle={{ width: '800' }}
+            />
+            <Histogram {...histogramArgs} />
+            <div className='GWASUI-row'>
+              <div className='GWASUI-column'>
+                <label htmlFor='input-minOutlierCutoff'>Minimum outlier cutoff</label>
+              </div>
+              <div className='GWASUI-column'>
+                <InputNumber
+                  id='input-minOutlierCutoff'
+                  onChange={handleChangeMinOutlierCutoff}
+                />
+              </div>
+              <div className='GWASUI-column'>
+                <label htmlFor='input-maxOutlierCutoff'>Maximum outlier cutoff</label>
+              </div>
+              <div className='GWASUI-column'>
+                <InputNumber
+                  id='input-maxOutlierCutoff'
+                  onChange={handleChangeMaxOutlierCutoff}
+                />
+              </div>
             </div>
           </div>
-        </div>
-      }
+        )}
     </React.Fragment>
   );
 };
@@ -141,7 +141,7 @@ PhenotypeHistogram.propTypes = {
   useAnimation: PropTypes.bool,
   handleChangeTransformation: PropTypes.func,
   handleChangeMinOutlierCutoff: PropTypes.func,
-  handleChangeMaxOutlierCutoff: PropTypes.func
+  handleChangeMaxOutlierCutoff: PropTypes.func,
 };
 
 PhenotypeHistogram.defaultProps = {
@@ -151,7 +151,7 @@ PhenotypeHistogram.defaultProps = {
   useAnimation: true,
   handleChangeTransformation: null,
   handleChangeMinOutlierCutoff: null,
-  handleChangeMaxOutlierCutoff: null
+  handleChangeMaxOutlierCutoff: null,
 };
 
 export default PhenotypeHistogram;

--- a/src/Analysis/GWASApp/Components/Diagrams/PhenotypeHistogram/PhenotypeHistogram.jsx
+++ b/src/Analysis/GWASApp/Components/Diagrams/PhenotypeHistogram/PhenotypeHistogram.jsx
@@ -84,6 +84,8 @@ const PhenotypeHistogram = ({
     xAxisLegend: selectedContinuousItem.concept_name,
     yAxisLegend: 'Persons',
     useAnimation,
+    minCutoff: selectedContinuousItem.filters?.find(filter => filter.type === '>=')?.value ?? undefined,
+    maxCutoff: selectedContinuousItem.filters?.find(filter => filter.type === '<=')?.value ?? undefined,
   };
   return (
     <React.Fragment>

--- a/src/Analysis/GWASApp/Components/Diagrams/PhenotypeHistogram/PhenotypeHistogram.jsx
+++ b/src/Analysis/GWASApp/Components/Diagrams/PhenotypeHistogram/PhenotypeHistogram.jsx
@@ -9,6 +9,7 @@ import { useSourceContext } from '../../../Utils/Source';
 import ACTIONS from '../../../Utils/StateManagement/Actions';
 import { MESSAGES } from '../../../Utils/constants';
 import FILTERS from '../../../../SharedUtils/FiltersEnumeration';
+import './PhenotypeHistogram.css';
 
 const PhenotypeHistogram = ({
   dispatch,
@@ -90,89 +91,121 @@ const PhenotypeHistogram = ({
     xAxisLegend: selectedContinuousItem.concept_name,
     yAxisLegend: 'Persons',
     useAnimation,
-    minCutoff: selectedContinuousItem.filters?.find((filter) => filter.type === FILTERS.greaterThanOrEqualTo)?.value ?? undefined,
-    maxCutoff: selectedContinuousItem.filters?.find((filter) => filter.type === FILTERS.lessThanOrEqualTo)?.value ?? undefined,
+    minCutoff:
+      selectedContinuousItem.filters?.find(
+        (filter) => filter.type === FILTERS.greaterThanOrEqualTo,
+      )?.value ?? undefined,
+    maxCutoff:
+      selectedContinuousItem.filters?.find(
+        (filter) => filter.type === FILTERS.lessThanOrEqualTo,
+      )?.value ?? undefined,
   };
   return (
     <React.Fragment>
       {inlineErrorMessage}
-      {data.bins !== null
-        && (
-          <div>
-            <div className='GWASUI-row'>
-              <div className='GWASUI-column'>
-                <label id='transformation-dropdown-label' htmlFor='transformation-select'>Select Transformation</label>
-              </div>
-              <div className='GWASUI-column'>
-                <Select
-                  id='transformation-select'
-                  showSearch={false}
-                  labelInValue
-                  value={selectedTransformation}
-                  onChange={(value) => {
-                    setSelectedTransformation(value);
-                    handleChangeTransformation(value);
-                  }}
-                  placeholder='-optional transformation-'
-                  fieldNames={{ label: 'description', value: 'type' }}
-                  options={[{ type: 'log', description: 'log transformation' }, { type: 'z_score', description: 'z-score transformation' }]}
-                  aria-label='Transformation Selection'
-                  aria-labelledby='transformation-dropdown-label'
-                />
-              </div>
-              <div className='GWASUI-column' />
+      {data.bins !== null && (
+        <div>
+          <div className='GWASUI-row'>
+            <div className='GWASUI-column transformation-dropdown-label'>
+              <label
+                id='transformation-dropdown-label'
+                htmlFor='transformation-select'
+              >
+                Select Transformation
+              </label>
             </div>
-            <Histogram {...histogramArgs} />
-            <div className='GWASUI-row'>
-              <div className='GWASUI-column'>
-                <label htmlFor='input-minOutlierCutoff'>Minimum outlier cutoff</label>
-              </div>
-              <div className='GWASUI-column'>
-                <InputNumber
-                  id='input-minOutlierCutoff'
-                  value={minOutlierCutoff}
-                  onChange={(value) => {
-                    setMinOutlierCutoff(value);
-                    handleChangeMinOutlierCutoff(value);
-                  }}
-                  min={data.bins[0]?.start || 0}
-                  max={maxOutlierCutoff || data.bins[data.bins.length - 1]?.end || 100}
-                  onKeyDown={(e) => {
-                    const { key } = e;
-                    // Allow only numeric keys, backspace, and delete, and one decimal point
-                    if (!/[\d]/.test(key) && key !== 'Backspace' && key !== 'Delete' && key !== 'ArrowLeft' && key !== 'ArrowRight'
-                    && (key !== '.' || e.target.value.includes('.'))) {
-                      e.preventDefault();
-                    }
-                  }}
-                />
-              </div>
-              <div className='GWASUI-column'>
-                <label htmlFor='input-maxOutlierCutoff'>Maximum outlier cutoff</label>
-              </div>
-              <div className='GWASUI-column'>
-                <InputNumber
-                  id='input-maxOutlierCutoff'
-                  value={maxOutlierCutoff}
-                  onChange={(value) => {
-                    setMaxOutlierCutoff(value);
-                    handleChangeMaxOutlierCutoff(value);
-                  }}
-                  min={minOutlierCutoff || data.bins[0]?.start || 0}
-                  max={data.bins[data.bins.length - 1]?.end || 100}
-                  onKeyDown={(e) => {
-                    const { key } = e;
-                    // Allow only numeric keys, backspace, and delete, and one decimal point
-                    if (!/[\d]/.test(key) && key !== 'Backspace' && key !== 'Delete' && key !== 'ArrowLeft' && key !== 'ArrowRight'
-                    && (key !== '.' || e.target.value.includes('.'))) {
-                      e.preventDefault();
-                    }
-                  }}
-                />
-              </div>
+            <div className='GWASUI-column transformation-select'>
+              <Select
+                id='transformation-select'
+                showSearch={false}
+                labelInValue
+                value={selectedTransformation}
+                onChange={(value) => {
+                  setSelectedTransformation(value);
+                  handleChangeTransformation(value);
+                }}
+                placeholder='-optional transformation-'
+                fieldNames={{ label: 'description', value: 'type' }}
+                options={[
+                  { type: 'log', description: 'log transformation' },
+                  { type: 'z_score', description: 'z-score transformation' },
+                ]}
+                aria-label='Transformation Selection'
+                aria-labelledby='transformation-dropdown-label'
+              />
             </div>
           </div>
-        )}
+          <Histogram {...histogramArgs} />
+          <div className='GWASUI-row outlier-inputs'>
+            <div className='GWASUI-column'>
+              <label htmlFor='input-minOutlierCutoff'>
+                Minimum outlier cutoff
+              </label>
+            </div>
+            <div className='GWASUI-column'>
+              <InputNumber
+                id='input-minOutlierCutoff'
+                value={minOutlierCutoff}
+                onChange={(value) => {
+                  setMinOutlierCutoff(value);
+                  handleChangeMinOutlierCutoff(value);
+                }}
+                min={data.bins[0]?.start || 0}
+                max={
+                  maxOutlierCutoff
+                  || data.bins[data.bins.length - 1]?.end
+                  || 100
+                }
+                onKeyDown={(e) => {
+                  const { key } = e;
+                  // Allow only numeric keys, backspace, and delete, and one decimal point
+                  if (
+                    !/[\d]/.test(key)
+                    && key !== 'Backspace'
+                    && key !== 'Delete'
+                    && key !== 'ArrowLeft'
+                    && key !== 'ArrowRight'
+                    && (key !== '.' || e.target.value.includes('.'))
+                  ) {
+                    e.preventDefault();
+                  }
+                }}
+              />
+            </div>
+            <div className='GWASUI-column'>
+              <label htmlFor='input-maxOutlierCutoff'>
+                Maximum outlier cutoff
+              </label>
+            </div>
+            <div className='GWASUI-column'>
+              <InputNumber
+                id='input-maxOutlierCutoff'
+                value={maxOutlierCutoff}
+                onChange={(value) => {
+                  setMaxOutlierCutoff(value);
+                  handleChangeMaxOutlierCutoff(value);
+                }}
+                min={minOutlierCutoff || data.bins[0]?.start || 0}
+                max={data.bins[data.bins.length - 1]?.end || 100}
+                onKeyDown={(e) => {
+                  const { key } = e;
+                  // Allow only numeric keys, backspace, and delete, and one decimal point
+                  if (
+                    !/[\d]/.test(key)
+                    && key !== 'Backspace'
+                    && key !== 'Delete'
+                    && key !== 'ArrowLeft'
+                    && key !== 'ArrowRight'
+                    && (key !== '.' || e.target.value.includes('.'))
+                  ) {
+                    e.preventDefault();
+                  }
+                }}
+              />
+            </div>
+          </div>
+        </div>
+      )}
     </React.Fragment>
   );
 };

--- a/src/Analysis/GWASApp/Components/Diagrams/PhenotypeHistogram/PhenotypeHistogram.jsx
+++ b/src/Analysis/GWASApp/Components/Diagrams/PhenotypeHistogram/PhenotypeHistogram.jsx
@@ -9,6 +9,7 @@ import Histogram from '../../../../SharedUtils/DataViz/Histogram/Histogram';
 import { useSourceContext } from '../../../Utils/Source';
 import ACTIONS from '../../../Utils/StateManagement/Actions';
 import { MESSAGES } from '../../../Utils/constants';
+import FILTERS from '../../../../SharedUtils/FiltersEnumeration';
 
 const PhenotypeHistogram = ({
   dispatch,
@@ -87,8 +88,8 @@ const PhenotypeHistogram = ({
     xAxisLegend: selectedContinuousItem.concept_name,
     yAxisLegend: 'Persons',
     useAnimation,
-    minCutoff: selectedContinuousItem.filters?.find(filter => filter.type === '>=')?.value ?? undefined,
-    maxCutoff: selectedContinuousItem.filters?.find(filter => filter.type === '<=')?.value ?? undefined,
+    minCutoff: selectedContinuousItem.filters?.find(filter => filter.type === FILTERS.greaterThanOrEqualTo)?.value ?? undefined,
+    maxCutoff: selectedContinuousItem.filters?.find(filter => filter.type === FILTERS.lessThanOrEqualTo)?.value ?? undefined,
   };
   return (
     <React.Fragment>

--- a/src/Analysis/GWASApp/Components/Diagrams/PhenotypeHistogram/PhenotypeHistogram.jsx
+++ b/src/Analysis/GWASApp/Components/Diagrams/PhenotypeHistogram/PhenotypeHistogram.jsx
@@ -23,6 +23,9 @@ const PhenotypeHistogram = ({
 }) => {
   const { source } = useSourceContext();
   const [inlineErrorMessage, setInlineErrorMessage] = useState(null);
+  const [minOutlierCutoff, setMinOutlierCutoff] = useState(null);
+  const [maxOutlierCutoff, setMaxOutlierCutoff] = useState(null);
+  const [selectedTransformation, setSelectedTransformation] = useState(null);
   const sourceId = source; // TODO - change name of source to sourceId for clarity
   const { data, status } = useQuery(
     [
@@ -99,7 +102,11 @@ const PhenotypeHistogram = ({
             <Select
               showSearch={false}
               labelInValue
-              onChange={handleChangeTransformation}
+              value={selectedTransformation}
+              onChange={(value) => {
+                setSelectedTransformation(value);
+                handleChangeTransformation(value);
+              }}
               placeholder='-optional transformation-'
               fieldNames={{ label: 'description', value: 'type' }}
               options={[{ type: 'log', description: 'log transformation' }, { type: 'z_score', description: 'z-score transformation' }]}
@@ -113,7 +120,11 @@ const PhenotypeHistogram = ({
               <div className='GWASUI-column'>
                 <InputNumber
                   id='input-minOutlierCutoff'
-                  onChange={handleChangeMinOutlierCutoff}
+                  value={minOutlierCutoff}
+                  onChange={(value) => {
+                    setMinOutlierCutoff(value);
+                    handleChangeMinOutlierCutoff(value);
+                  }}
                 />
               </div>
               <div className='GWASUI-column'>
@@ -122,7 +133,11 @@ const PhenotypeHistogram = ({
               <div className='GWASUI-column'>
                 <InputNumber
                   id='input-maxOutlierCutoff'
-                  onChange={handleChangeMaxOutlierCutoff}
+                  value={maxOutlierCutoff}
+                  onChange={(value) => {
+                    setMaxOutlierCutoff(value);
+                    handleChangeMaxOutlierCutoff(value);
+                  }}
                 />
               </div>
             </div>

--- a/src/Analysis/GWASApp/Components/Diagrams/PhenotypeHistogram/PhenotypeHistogram.jsx
+++ b/src/Analysis/GWASApp/Components/Diagrams/PhenotypeHistogram/PhenotypeHistogram.jsx
@@ -30,7 +30,6 @@ const PhenotypeHistogram = ({
       outcome,
       selectedContinuousItem.concept_id,
       selectedContinuousItem.transformation,
-      selectedContinuousItem.filters,
     ],
     () => fetchHistogramInfo(
       sourceId,
@@ -39,7 +38,6 @@ const PhenotypeHistogram = ({
       outcome,
       selectedContinuousItem.concept_id,
       selectedContinuousItem.transformation,
-      selectedContinuousItem.filters,
     ),
     queryConfig,
   );

--- a/src/Analysis/GWASApp/Components/Diagrams/PhenotypeHistogram/PhenotypeHistogram.stories.jsx
+++ b/src/Analysis/GWASApp/Components/Diagrams/PhenotypeHistogram/PhenotypeHistogram.stories.jsx
@@ -64,8 +64,7 @@ SuccessCase.parameters = {
   msw: {
     handlers: [
       rest.post(
-        //histogram/by-source-id/${sourceId}/by-cohort-definition-id/${cohortId}/by-histogram-concept-id/${currentSelection.concept_id}`;
-        'http://:cohortmiddlewarepath/cohort-middleware/histogram/by-source-id/:sourceid/by-cohort-definition-id/:cohortdefinitionId/by-histogram-concept-id/:conceptId',
+        'http://:cohortmiddlewarepath/cohort-middleware/histogram/by-source-id/:sourceid/by-cohort-definition-id/:cohortdefinitionId',
         (req, res, ctx) => {
           const { cohortmiddlewarepath } = req.params;
           const { cohortdefinitionId } = req.params;
@@ -106,7 +105,7 @@ ErrorCase.parameters = {
   msw: {
     handlers: [
       rest.post(
-        'http://:cohortmiddlewarepath/cohort-middleware/histogram/by-source-id/:sourceid/by-cohort-definition-id/:cohortdefinitionId/by-histogram-concept-id/:conceptId',
+        'http://:cohortmiddlewarepath/cohort-middleware/histogram/by-source-id/:sourceid/by-cohort-definition-id/:cohortdefinitionId',
         (req, res, ctx) => res(ctx.delay(800), ctx.status(403))
       ),
     ],

--- a/src/Analysis/GWASApp/Components/Diagrams/PhenotypeHistogram/PhenotypeHistogram.stories.jsx
+++ b/src/Analysis/GWASApp/Components/Diagrams/PhenotypeHistogram/PhenotypeHistogram.stories.jsx
@@ -3,6 +3,7 @@ import { QueryClient, QueryClientProvider } from 'react-query';
 import { rest } from 'msw';
 import PhenotypeHistogram from './PhenotypeHistogram';
 import { SourceContextProvider } from '../../../Utils/Source';
+import '../../../GWASApp.css';
 
 export default {
   title: 'Tests3/GWASApp/PhenotypeHistogram',
@@ -14,7 +15,17 @@ const mockedQueryClient = new QueryClient();
 const Template = (args) => (
   <QueryClientProvider client={mockedQueryClient}>
     <SourceContextProvider>
-      <PhenotypeHistogram {...args} />
+      <div className='GWASApp' style={{ background: '#f5f5f5' }}>
+        <div className='steps-content'>
+          <div className='GWASUI-double-column'>
+            <div className='select-container' style={{ background: '#fff' }}>
+              <div style={{ width: 600 }}>
+                <PhenotypeHistogram {...args} />
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
     </SourceContextProvider>
   </QueryClientProvider>
 );

--- a/src/Analysis/GWASApp/Utils/cohortMiddlewareApi.js
+++ b/src/Analysis/GWASApp/Utils/cohortMiddlewareApi.js
@@ -55,7 +55,7 @@ export const fetchHistogramInfo = async (
         variable_type: 'concept',
         concept_id: selectedConceptId,
         transformation: transformationType,
-      }
+      },
     ].filter(Boolean), // filter out any undefined or null items (e.g. in some
     // scenarios "outcome" and "selectedCovariates" are still null and/or empty)
   };

--- a/src/Analysis/GWASApp/Utils/cohortMiddlewareApi.js
+++ b/src/Analysis/GWASApp/Utils/cohortMiddlewareApi.js
@@ -43,6 +43,7 @@ export const fetchHistogramInfo = async (
   outcome,
   selectedConceptId,
   transformationType,
+  filters,
 ) => {
   const variablesPayload = {
     variables: [...selectedCovariates, outcome,
@@ -54,7 +55,8 @@ export const fetchHistogramInfo = async (
       {
         variable_type: 'concept',
         concept_id: selectedConceptId,
-        transformation: transformationType
+        transformation: transformationType,
+        filters: filters
       }
     ].filter(Boolean), // filter out any undefined or null items (e.g. in some
     // scenarios "outcome" and "selectedCovariates" are still null and/or empty)

--- a/src/Analysis/GWASApp/Utils/cohortMiddlewareApi.js
+++ b/src/Analysis/GWASApp/Utils/cohortMiddlewareApi.js
@@ -43,7 +43,6 @@ export const fetchHistogramInfo = async (
   outcome,
   selectedConceptId,
   transformationType,
-  filters,
 ) => {
   const variablesPayload = {
     variables: [...selectedCovariates, outcome,
@@ -56,7 +55,6 @@ export const fetchHistogramInfo = async (
         variable_type: 'concept',
         concept_id: selectedConceptId,
         transformation: transformationType,
-        filters: filters
       }
     ].filter(Boolean), // filter out any undefined or null items (e.g. in some
     // scenarios "outcome" and "selectedCovariates" are still null and/or empty)

--- a/src/Analysis/GWASApp/Utils/cohortMiddlewareApi.js
+++ b/src/Analysis/GWASApp/Utils/cohortMiddlewareApi.js
@@ -42,6 +42,7 @@ export const fetchHistogramInfo = async (
   selectedCovariates,
   outcome,
   selectedConceptId,
+  transformationType,
 ) => {
   const variablesPayload = {
     variables: [...selectedCovariates, outcome,
@@ -49,10 +50,16 @@ export const fetchHistogramInfo = async (
       {
         variable_type: 'concept',
         concept_id: hareConceptId,
-      }].filter(Boolean), // filter out any undefined or null items (e.g. in some
+      },
+      {
+        variable_type: 'concept',
+        concept_id: selectedConceptId,
+        transformation: transformationType
+      }
+    ].filter(Boolean), // filter out any undefined or null items (e.g. in some
     // scenarios "outcome" and "selectedCovariates" are still null and/or empty)
   };
-  const endPoint = `${cohortMiddlewarePath}histogram/by-source-id/${sourceId}/by-cohort-definition-id/${cohortId}/by-histogram-concept-id/${selectedConceptId}`;
+  const endPoint = `${cohortMiddlewarePath}histogram/by-source-id/${sourceId}/by-cohort-definition-id/${cohortId}`;
   const reqBody = {
     method: 'POST',
     credentials: 'include',

--- a/src/Analysis/SharedUtils/DataViz/Histogram/Histogram.jsx
+++ b/src/Analysis/SharedUtils/DataViz/Histogram/Histogram.jsx
@@ -7,6 +7,7 @@ import {
   CartesianGrid,
   Tooltip,
   Label,
+  ReferenceLine,
 } from 'recharts';
 import PropTypes from 'prop-types';
 import './Histogram.css';
@@ -52,8 +53,16 @@ const Histogram = ({
   xAxisLegend,
   yAxisLegend,
   useAnimation,
+  minCutoff,
+  maxCutoff,
 }) => {
   const defaultAnimationTime = 400;
+  const xValues = data.map((d) => d[xAxisDataKey]);
+  const minX = Math.min(minCutoff ?? Infinity, ...xValues);
+  const maxX = Math.max(maxCutoff ?? -Infinity, ...xValues);
+  const padding = (maxX - minX) * 0.10;
+  const xDomain = [minX - padding, maxX + padding];
+
   return (
     <div data-testid='histogram'>
       <BarChart
@@ -64,6 +73,8 @@ const Histogram = ({
       >
         <XAxis
           dataKey={xAxisDataKey}
+          type="number"
+          domain={xDomain}
           minTickGap={50}
           tickFormatter={(tick) => formatNumber(tick)}
         >
@@ -79,6 +90,23 @@ const Histogram = ({
         <Tooltip content={<CustomTooltip />} />
         <CartesianGrid strokeDasharray='3 3' />
         <Bar dataKey={barDataKey} fill={barColor} animationDuration={useAnimation ? defaultAnimationTime : 0} />
+        {/* Add ReferenceLines for min and max cutoffs */}
+        {minCutoff !== undefined && (
+          <ReferenceLine
+            x={minCutoff}
+            stroke="red"
+            strokeDasharray="3 3"
+            label={{ value: 'Min', position: 'top', fill: 'red' }}
+          />
+        )}
+        {maxCutoff !== undefined && (
+          <ReferenceLine
+            x={maxCutoff}
+            stroke="green"
+            strokeDasharray="3 3"
+            label={{ value: 'Max', position: 'top', fill: 'green' }}
+          />
+        )}
       </BarChart>
     </div>
   );
@@ -94,6 +122,8 @@ Histogram.propTypes = {
   xAxisLegend: PropTypes.string,
   yAxisLegend: PropTypes.string,
   useAnimation: PropTypes.bool,
+  minCutoff: PropTypes.number,
+  maxCutoff: PropTypes.number,
 };
 
 Histogram.defaultProps = {
@@ -103,6 +133,8 @@ Histogram.defaultProps = {
   xAxisLegend: null,
   yAxisLegend: null,
   useAnimation: true,
+  minCutoff: undefined,
+  maxCutoff: undefined,
 };
 
 export default Histogram;

--- a/src/Analysis/SharedUtils/DataViz/Histogram/Histogram.jsx
+++ b/src/Analysis/SharedUtils/DataViz/Histogram/Histogram.jsx
@@ -62,7 +62,7 @@ const Histogram = ({
   const minX = Math.min(minCutoff ?? Infinity, ...xValues);
   // Find max value in the set of [(maxCutoff OR -Infinity), and xValues]:
   const maxX = Math.max(maxCutoff ?? -Infinity, ...xValues);
-  const padding = (maxX - minX) * 0.10;
+  const padding = (maxX - minX) * 0.1;
   const xDomain = [minX - padding, maxX + padding];
 
   return (
@@ -81,6 +81,7 @@ const Histogram = ({
           tickFormatter={(tick) => formatNumber(tick)}
         >
           <Label
+            className='xAxisLabel'
             value={xAxisLegend || xAxisDataKey}
             position='bottom'
             offset={20}
@@ -91,7 +92,11 @@ const Histogram = ({
         </YAxis>
         <Tooltip content={<CustomTooltip />} />
         <CartesianGrid strokeDasharray='3 3' />
-        <Bar dataKey={barDataKey} fill={barColor} animationDuration={useAnimation ? defaultAnimationTime : 0} />
+        <Bar
+          dataKey={barDataKey}
+          fill={barColor}
+          animationDuration={useAnimation ? defaultAnimationTime : 0}
+        />
         {/* Add ReferenceLines for min and max cutoffs */}
         {minCutoff !== undefined && (
           <ReferenceLine

--- a/src/Analysis/SharedUtils/DataViz/Histogram/Histogram.jsx
+++ b/src/Analysis/SharedUtils/DataViz/Histogram/Histogram.jsx
@@ -75,7 +75,7 @@ const Histogram = ({
       >
         <XAxis
           dataKey={xAxisDataKey}
-          type="number"
+          type='number'
           domain={xDomain}
           minTickGap={50}
           tickFormatter={(tick) => formatNumber(tick)}
@@ -96,16 +96,16 @@ const Histogram = ({
         {minCutoff !== undefined && (
           <ReferenceLine
             x={minCutoff}
-            stroke="red"
-            strokeDasharray="3 3"
+            stroke='red'
+            strokeDasharray='3 3'
             label={{ value: 'Min', position: 'top', fill: 'red' }}
           />
         )}
         {maxCutoff !== undefined && (
           <ReferenceLine
             x={maxCutoff}
-            stroke="green"
-            strokeDasharray="3 3"
+            stroke='green'
+            strokeDasharray='3 3'
             label={{ value: 'Max', position: 'top', fill: 'green' }}
           />
         )}

--- a/src/Analysis/SharedUtils/DataViz/Histogram/Histogram.jsx
+++ b/src/Analysis/SharedUtils/DataViz/Histogram/Histogram.jsx
@@ -58,7 +58,9 @@ const Histogram = ({
 }) => {
   const defaultAnimationTime = 400;
   const xValues = data.map((d) => d[xAxisDataKey]);
+  // Find min value in the set of [(minCutoff OR Infinity), and xValues]:
   const minX = Math.min(minCutoff ?? Infinity, ...xValues);
+  // Find max value in the set of [(maxCutoff OR -Infinity), and xValues]:
   const maxX = Math.max(maxCutoff ?? -Infinity, ...xValues);
   const padding = (maxX - minX) * 0.10;
   const xDomain = [minX - padding, maxX + padding];

--- a/src/Analysis/SharedUtils/DataViz/Histogram/Histogram.stories.jsx
+++ b/src/Analysis/SharedUtils/DataViz/Histogram/Histogram.stories.jsx
@@ -31,6 +31,8 @@ FirstStepActive.args = {
   xAxisDataKey: 'ageBin',
   barDataKey: 'patients',
   barColor: 'darkblue',
+  minCutoff: 3, // Minimum cutoff value
+  maxCutoff: 4 // Maximum cutoff value
 };
 
 export const SecondStepError = Template.bind({});

--- a/src/Analysis/SharedUtils/FiltersEnumeration.js
+++ b/src/Analysis/SharedUtils/FiltersEnumeration.js
@@ -1,0 +1,9 @@
+const FILTERS = {
+  greaterThanOrEqualTo: '>=',
+  lessThanOrEqualTo: '<=',
+  equalTo: '=',
+  differentFrom: '!=',
+  in: 'in',
+};
+
+export default FILTERS;


### PR DESCRIPTION
Link to JIRA ticket if there is one: https://ctds-planx.atlassian.net/browse/VADC-1635

### New Features
- add transformation dropdown to histogram and adjust histogram endpoint call to include histogram concept id in variables list instead of being part of the url, according to the backend changes implemented for this same endpoint (see https://github.com/uc-cdis/cohort-middleware/pull/125).

![Screenshot 2025-01-25 at 17 54 13](https://github.com/user-attachments/assets/38aaf015-4036-46dd-ad68-c01ac4c76064)

