### PR TITLE
Update docs links to point to new MkDocs documentation

### DIFF
--- a/data/config/dcf.json
+++ b/data/config/dcf.json
@@ -122,7 +122,7 @@
           "name": "Submit Data"
         },
         {
-          "link": "https://gen3.org/resources/user/",
+          "link": "https://docs.gen3.org/gen3-resources/user-guide/",
           "name": "Documentation"
         }
       ]

--- a/data/config/default.json
+++ b/data/config/default.json
@@ -122,7 +122,7 @@
           "name": "Submit Data"
         },
         {
-          "link": "https://gen3.org/resources/user/",
+          "link": "https://docs.gen3.org/gen3-resources/user-guide/",
           "name": "Documentation"
         }
       ]

--- a/docs/portal_config.md
+++ b/docs/portal_config.md
@@ -143,7 +143,7 @@ Below is an example, with inline comments describing what each JSON block config
           "name": "Submit Data"
         },
         {
-          "link": "https://gen3.org/resources/user/",
+          "link": "https://docs.gen3.org/gen3-resources/user-guide/",
           "name": "Documentation"
         }
       ],

--- a/src/Discovery/DiscoveryActionBar/components/DownloadManifestButton.tsx
+++ b/src/Discovery/DiscoveryActionBar/components/DownloadManifestButton.tsx
@@ -20,7 +20,7 @@ const DownloadManifestButton = ({
             <a
               target='_blank'
               rel='noreferrer'
-              href='https://gen3.org/resources/user/gen3-client/'
+              href='https://docs.gen3.org/gen3-resources/user-guide/access-data/#download-files-using-the-gen3-client'
             >
               {'Gen3 Client'}
             </a>

--- a/src/Discovery/DiscoveryActionBar/components/ExportToWorkspaceButton.tsx
+++ b/src/Discovery/DiscoveryActionBar/components/ExportToWorkspaceButton.tsx
@@ -20,7 +20,7 @@ const ExportToWorkspaceButton = ({
             <a
               target='blank'
               rel='noreferrer'
-              href='https://gen3.org/resources/user/analyze-data/'
+              href='https://docs.gen3.org/gen3-resources/user-guide/analyze-data/'
             >
                 Gen3 Workspace
             </a>

--- a/src/Discovery/__mocks__/mock_config.json
+++ b/src/Discovery/__mocks__/mock_config.json
@@ -5,8 +5,8 @@
       "manifestFieldName": "__manifest",
       "enableDownloadManifest": true,
       "documentationLinks": {
-        "gen3Client": "https://gen3.org/resources/user/gen3-client/",
-        "gen3Workspaces": "https://gen3.org/resources/user/analyze-data/"
+        "gen3Client": "https://docs.gen3.org/gen3-resources/user-guide/access-data/#download-files-using-the-gen3-client",
+        "gen3Workspaces": "https://docs.gen3.org/gen3-resources/user-guide/analyze-data/"
       }
     },
     "pageTitle": {

--- a/src/Discovery/index.tsx
+++ b/src/Discovery/index.tsx
@@ -46,8 +46,6 @@ const populateStudiesWithConfigInfo = (studies, config) => {
   });
 };
 
-let allStudies;
-
 const DiscoveryWithMDSBackend: React.FC<{
     userAggregateAuthMappings: any,
     config: DiscoveryConfig,
@@ -130,11 +128,7 @@ const DiscoveryWithMDSBackend: React.FC<{
           }),
         );
       }
-      const result = _.union(rawStudiesRegistered, rawStudiesUnregistered);
-      if (numberOfBatchesLoaded > 0) {
-        allStudies = result;
-      }
-      return allStudies || result;
+      return _.union(rawStudiesRegistered, rawStudiesUnregistered);
     }
     fetchRawStudies().then((rawStudies) => {
       let studiesToSet;

--- a/src/Discovery/index.tsx
+++ b/src/Discovery/index.tsx
@@ -46,6 +46,8 @@ const populateStudiesWithConfigInfo = (studies, config) => {
   });
 };
 
+let allStudies;
+
 const DiscoveryWithMDSBackend: React.FC<{
     userAggregateAuthMappings: any,
     config: DiscoveryConfig,
@@ -128,7 +130,11 @@ const DiscoveryWithMDSBackend: React.FC<{
           }),
         );
       }
-      return _.union(rawStudiesRegistered, rawStudiesUnregistered);
+      const result = _.union(rawStudiesRegistered, rawStudiesUnregistered);
+      if (numberOfBatchesLoaded > 0) {
+        allStudies = result;
+      }
+      return allStudies || result;
     }
     fetchRawStudies().then((rawStudies) => {
       let studiesToSet;

--- a/src/Submission/SubmissionHeader.jsx
+++ b/src/Submission/SubmissionHeader.jsx
@@ -18,7 +18,7 @@ class SubmissionHeader extends React.Component {
   }
 
   openGen3Tutorials = () => {
-    window.open('https://gen3.org/resources/user/gen3-client/', '_blank');
+    window.open('https://docs.gen3.org/gen3-resources/operator-guide/submit-unstructured-data/#gen3-client-instructions-for-uploading-data', '_blank');
   }
 
   render() {


### PR DESCRIPTION
Change link-outs to documentation from legacy documentation at [gen3.org](http://gen3.org/) to new mkdocs documentation at [docs.gen3.org](http://docs.gen3.org/)