### PR TITLE
HP-1956 fix: discovery table checkbox enabled bug

### DIFF
--- a/src/Discovery/DiscoveryListView.tsx
+++ b/src/Discovery/DiscoveryListView.tsx
@@ -64,11 +64,11 @@ const DiscoveryListView: React.FunctionComponent<Props> = (props: Props) => {
                 (props.config.features.exportToWorkspace.enableDownloadManifest || props.config.features.exportToWorkspace.enableDownloadZip)
                   ? 'download'
                   : '',
-                'open in workspace'
+                'open in workspace',
               ]
                 .filter(Boolean)
                 .join(' or ')
-              }`}
+            }`}
             overlayStyle={{ maxWidth: '150px' }}
           >
             {node}
@@ -79,7 +79,7 @@ const DiscoveryListView: React.FunctionComponent<Props> = (props: Props) => {
           props.onResourcesSelected(selectedRows);
         },
         getCheckboxProps: (record) => {
-          let disabled;
+          let disabled:boolean;
           // if auth is enabled, disable checkbox if user doesn't have access
           if (props.config.features.authorization.enabled) {
             disabled = (record[props.accessibleFieldName] !== AccessLevel.ACCESSIBLE) && (record[props.accessibleFieldName] !== AccessLevel.MIXED);
@@ -102,7 +102,11 @@ const DiscoveryListView: React.FunctionComponent<Props> = (props: Props) => {
           if (!record[manifestFieldName] || record[manifestFieldName].length === 0) {
             // put some hard-coded field names here, so that only checkboxes in proper table rows will be enabled
             // TODO: this can be addressed by the cart feature
-            if (enableExportFullMetadata && (!record.external_file_metadata || record.external_file_metadata.length === 0)) {
+            // if export full metadata is not enabled, disable the checkbox if no manifest
+            if (!enableExportFullMetadata) {
+              disabled = true;
+            // otherwise, check if there is external file metadata
+            } else if (!record.external_file_metadata || record.external_file_metadata.length === 0) {
               disabled = true;
             }
           }


### PR DESCRIPTION
<!--
External to CTDS: Please make sure you have reviewed the Gen3 contributor guidelines before submitting a PR: https://uc-cdis.github.io/gen3-docs/docs/Contributor%20Guidelines

Internal to CTDS: Add your JIRA ticket number to the PR title and make sure you have reviewed the developer guidelines before submitting a PR: https://github.com/uc-cdis/gen3.org/blob/master/content/resources/developer/dev-introduction-archived.md

- Describe what this pull request does.
- Add short descriptive bullet points for each section if relevant. Keep in mind that they will be parsed automatically to generate official release notes.
- Test manually.
- Maintain or increase the test coverage (if relevant).
- Update the documentation, or justify if not needed.
-->

Link to JIRA ticket if there is one: https://ctds-planx.atlassian.net/browse/HP-1956

### New Features

### Breaking Changes

### Bug Fixes
- Discovery: fixed a bug causing checkbox in discovery table gets enabled incorrectly for studies doesn't have file manifest and external file metadata
### Improvements

### Dependency updates

### Deployment changes
<!-- This section should only contain important things devops should know when updating service versions. -->
