### PR TITLE
HP-1977 HP-1978 Feat/disco file list improve

### DIFF
--- a/src/Discovery/DiscoveryDetails/Components/FieldGrouping/TabField/DataDownloadList/DataDownloadList.test.tsx
+++ b/src/Discovery/DiscoveryDetails/Components/FieldGrouping/TabField/DataDownloadList/DataDownloadList.test.tsx
@@ -58,7 +58,7 @@ describe('DataDownloadList', () => {
     expect(screen.queryByTestId('actionButtons')).toBeInTheDocument();
   });
 
-  it('renders the component with titles and descriptions when sourceFieledData has file_names and descriptions', () => {
+  it('renders the component with titles and descriptions when sourceFieldData has file_names and descriptions', () => {
     const sourceFieldData = [
       [
         {

--- a/src/Discovery/DiscoveryDetails/Components/FieldGrouping/TabField/DataDownloadList/DataDownloadList.test.tsx
+++ b/src/Discovery/DiscoveryDetails/Components/FieldGrouping/TabField/DataDownloadList/DataDownloadList.test.tsx
@@ -4,6 +4,7 @@ import { render, screen } from '@testing-library/react';
 import DataDownloadList from './DataDownloadList';
 import { DiscoveryConfig } from '../../../../../DiscoveryConfig';
 import { DiscoveryResource } from '../../../../../Discovery';
+import { MAX_NUMBER_OF_ITEMS_IN_LIST } from './Utils/ProcessData';
 
 jest.mock('react-router-dom', () => ({
   useHistory: jest.fn().mockReturnValue(0),
@@ -141,5 +142,29 @@ describe('DataDownloadList', () => {
       screen.queryByTestId('dataDownloadFileList'),
     ).not.toBeInTheDocument();
     expect(screen.queryByTestId('actionButtons')).toBeInTheDocument();
+  });
+
+  // test for banner after MAX_NUMBER_OF_ITEMS_IN_LIST has been exceeded
+  it('Shows banner when max number of items in list is exceeded', () => {
+    const generateSourceFieldData = (count) => [
+      Array.from({ length: count }, (_, i) => ({
+        title: `Title ${i}`,
+        description: `Description ${i}`,
+      })),
+    ];
+
+    const sourceFieldData = generateSourceFieldData(MAX_NUMBER_OF_ITEMS_IN_LIST + 1);
+
+    const { getByText } = render(
+      <DataDownloadList
+        resourceFieldValueIsValid
+        isUserLoggedIn
+        discoveryConfig={testDiscoveryConfig as DiscoveryConfig}
+        sourceFieldData={sourceFieldData}
+        resourceInfo={testResourceInfo as unknown as DiscoveryResource}
+        missingRequiredIdentityProviders={[]}
+      />,
+    );
+    expect(getByText(`More than ${MAX_NUMBER_OF_ITEMS_IN_LIST} files found. Visit repository to view all files.`)).toBeInTheDocument();
   });
 });

--- a/src/Discovery/DiscoveryDetails/Components/FieldGrouping/TabField/DataDownloadList/DataDownloadList.tsx
+++ b/src/Discovery/DiscoveryDetails/Components/FieldGrouping/TabField/DataDownloadList/DataDownloadList.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { useHistory, useLocation } from 'react-router-dom';
-import { List } from 'antd';
+import { List, Alert } from 'antd';
 import DataDownloadListItem from './Interfaces/DataDownloadListItem';
 import './DataDownloadList.css';
 import ProcessData from './Utils/ProcessData';
@@ -32,9 +32,13 @@ const DataDownloadList = ({
   const history = useHistory();
   const location = useLocation();
 
-  const data: [] = resourceFieldValueIsValid
-    ? ProcessData(sourceFieldData)
-    : [];
+  let data = [];
+  let hasDataBeenTruncated = false;
+  if (resourceFieldValueIsValid) {
+    const resultFromProcessData = ProcessData(sourceFieldData);
+    data = resultFromProcessData.processedDataForDataDownloadList;
+    hasDataBeenTruncated = resultFromProcessData.dataForDataDownloadListHasBeenTruncated;
+  }
   const noData = data.length === 0;
 
   let userHasAccessToDownload = true;
@@ -67,6 +71,9 @@ const DataDownloadList = ({
         history={history}
         location={location}
       />
+      {hasDataBeenTruncated && (
+        <Alert type='info' message='More than 200 files found. Visit repository to view all files.' />
+      )}
       {!noData && resourceFieldValueIsValid && (
         <List
           itemLayout='horizontal'

--- a/src/Discovery/DiscoveryDetails/Components/FieldGrouping/TabField/DataDownloadList/DataDownloadList.tsx
+++ b/src/Discovery/DiscoveryDetails/Components/FieldGrouping/TabField/DataDownloadList/DataDownloadList.tsx
@@ -3,7 +3,7 @@ import { useHistory, useLocation } from 'react-router-dom';
 import { List, Alert } from 'antd';
 import DataDownloadListItem from './Interfaces/DataDownloadListItem';
 import './DataDownloadList.css';
-import ProcessData from './Utils/ProcessData';
+import { ProcessData, MAX_NUMBER_OF_ITEMS_IN_LIST } from './Utils/ProcessData';
 import ActionButtons from './ActionButtons/ActionButtons';
 import { DiscoveryConfig } from '../../../../../DiscoveryConfig';
 import { AccessLevel, DiscoveryResource, accessibleFieldName } from '../../../../../Discovery';
@@ -72,7 +72,7 @@ const DataDownloadList = ({
         location={location}
       />
       {hasDataBeenTruncated && (
-        <Alert type='info' message='More than 200 files found. Visit repository to view all files.' />
+        <Alert type='info' message={`More than ${MAX_NUMBER_OF_ITEMS_IN_LIST} files found. Visit repository to view all files.`} />
       )}
       {!noData && resourceFieldValueIsValid && (
         <List

--- a/src/Discovery/DiscoveryDetails/Components/FieldGrouping/TabField/DataDownloadList/Utils/ProcessData.test.ts
+++ b/src/Discovery/DiscoveryDetails/Components/FieldGrouping/TabField/DataDownloadList/Utils/ProcessData.test.ts
@@ -13,11 +13,12 @@ describe('ProcessData function', () => {
 
     const result = ProcessData(sourceFieldData);
 
-    expect(result).toEqual([
+    expect(result.processedDataForDataDownloadList).toEqual([
       { title: 'Title1', description: 'Description1' },
       { title: 'File1', description: 'Description2' },
       { title: 'Title2', description: 'Description3' },
     ]);
+    expect(result.dataForDataDownloadListHasBeenTruncated).toEqual(false);
   });
 
   it('logs items without title or file_name to console', () => {
@@ -37,5 +38,14 @@ describe('ProcessData function', () => {
     // Check if console.log was called with the correct messages
     expect(consoleLogSpy).toHaveBeenCalledWith('Item without title or file_name:', { other: 'Other1' });
     expect(consoleLogSpy).toHaveBeenCalledWith('Item without title or file_name:', { description: 'Description2' });
+  });
+
+  it('filters and processes large data (more than 200 entries)', () => {
+    const sourceFieldData = [Array.from({ length: 210 }, (_, i) => ({ title: `Title${i}`, description: `Description${i}` }))];
+
+    const result = ProcessData(sourceFieldData);
+
+    expect(result.processedDataForDataDownloadList.length).toEqual(200);
+    expect(result.dataForDataDownloadListHasBeenTruncated).toEqual(true);
   });
 });

--- a/src/Discovery/DiscoveryDetails/Components/FieldGrouping/TabField/DataDownloadList/Utils/ProcessData.test.ts
+++ b/src/Discovery/DiscoveryDetails/Components/FieldGrouping/TabField/DataDownloadList/Utils/ProcessData.test.ts
@@ -13,9 +13,10 @@ describe('ProcessData function', () => {
 
     const result = ProcessData(sourceFieldData);
 
+    // ensure entries are sorted by title
     expect(result.processedDataForDataDownloadList).toEqual([
-      { title: 'Title1', description: 'Description1' },
       { title: 'File1', description: 'Description2' },
+      { title: 'Title1', description: 'Description1' },
       { title: 'Title2', description: 'Description3' },
     ]);
     expect(result.dataForDataDownloadListHasBeenTruncated).toEqual(false);

--- a/src/Discovery/DiscoveryDetails/Components/FieldGrouping/TabField/DataDownloadList/Utils/ProcessData.test.ts
+++ b/src/Discovery/DiscoveryDetails/Components/FieldGrouping/TabField/DataDownloadList/Utils/ProcessData.test.ts
@@ -6,8 +6,12 @@ describe('ProcessData function', () => {
       [
         { title: 'Title1', description: 'Description1' },
         { file_name: 'File1', description: 'Description2' },
+        { file_name: '/File2', description: 'Description3' },
+        { file_name: '/Dir1/File1', description: 'Description2.1' },
+        { file_name: '/Dir1/File2', description: 'Description2.2' },
+        { file_name: '/Dir2/File3', description: 'Description2.3' },
         { other: 'Other1' },
-        { title: 'Title2', description: 'Description3' },
+        { title: 'Title2', description: 'Description4' },
       ],
     ];
 
@@ -15,9 +19,13 @@ describe('ProcessData function', () => {
 
     // ensure entries are sorted by title
     expect(result.processedDataForDataDownloadList).toEqual([
+      { title: '/File2', description: 'Description3' },
       { title: 'File1', description: 'Description2' },
       { title: 'Title1', description: 'Description1' },
-      { title: 'Title2', description: 'Description3' },
+      { title: 'Title2', description: 'Description4' },
+      { title: '/Dir1/File1', description: 'Description2.1' },
+      { title: '/Dir1/File2', description: 'Description2.2' },
+      { title: '/Dir2/File3', description: 'Description2.3' },
     ]);
     expect(result.dataForDataDownloadListHasBeenTruncated).toEqual(false);
   });

--- a/src/Discovery/DiscoveryDetails/Components/FieldGrouping/TabField/DataDownloadList/Utils/ProcessData.test.ts
+++ b/src/Discovery/DiscoveryDetails/Components/FieldGrouping/TabField/DataDownloadList/Utils/ProcessData.test.ts
@@ -42,7 +42,7 @@ describe('ProcessData function', () => {
   });
 
   it(`filters and processes large data (more than ${MAX_NUMBER_OF_ITEMS_IN_LIST} entries)`, () => {
-    const sourceFieldData = [Array.from({ length: 210 }, (_, i) => ({ title: `Title${i}`, description: `Description${i}` }))];
+    const sourceFieldData = [Array.from({ length: MAX_NUMBER_OF_ITEMS_IN_LIST + 1 }, (_, i) => ({ title: `Title${i}`, description: `Description${i}` }))];
 
     const result = ProcessData(sourceFieldData);
 

--- a/src/Discovery/DiscoveryDetails/Components/FieldGrouping/TabField/DataDownloadList/Utils/ProcessData.test.ts
+++ b/src/Discovery/DiscoveryDetails/Components/FieldGrouping/TabField/DataDownloadList/Utils/ProcessData.test.ts
@@ -1,4 +1,4 @@
-import ProcessData from './ProcessData';
+import { ProcessData, MAX_NUMBER_OF_ITEMS_IN_LIST } from './ProcessData';
 
 describe('ProcessData function', () => {
   it('filters and processes data correctly', () => {
@@ -41,12 +41,12 @@ describe('ProcessData function', () => {
     expect(consoleLogSpy).toHaveBeenCalledWith('Item without title or file_name:', { description: 'Description2' });
   });
 
-  it('filters and processes large data (more than 200 entries)', () => {
+  it(`filters and processes large data (more than ${MAX_NUMBER_OF_ITEMS_IN_LIST} entries)`, () => {
     const sourceFieldData = [Array.from({ length: 210 }, (_, i) => ({ title: `Title${i}`, description: `Description${i}` }))];
 
     const result = ProcessData(sourceFieldData);
 
-    expect(result.processedDataForDataDownloadList.length).toEqual(200);
+    expect(result.processedDataForDataDownloadList.length).toEqual(MAX_NUMBER_OF_ITEMS_IN_LIST);
     expect(result.dataForDataDownloadListHasBeenTruncated).toEqual(true);
   });
 });

--- a/src/Discovery/DiscoveryDetails/Components/FieldGrouping/TabField/DataDownloadList/Utils/ProcessData.ts
+++ b/src/Discovery/DiscoveryDetails/Components/FieldGrouping/TabField/DataDownloadList/Utils/ProcessData.ts
@@ -17,6 +17,7 @@ const ProcessData = (sourceFieldData:any) => {
     processedDataForDataDownloadList = processedDataForDataDownloadList.slice(0, MAX_NUMBER_OF_ITEMS_IN_LIST);
     dataForDataDownloadListHasBeenTruncated = true;
   }
+  processedDataForDataDownloadList = processedDataForDataDownloadList.sort((a, b) => a.title.localeCompare(b.title, undefined, { numeric: true, sensitivity: 'base' }));
   return { processedDataForDataDownloadList, dataForDataDownloadListHasBeenTruncated };
 };
 

--- a/src/Discovery/DiscoveryDetails/Components/FieldGrouping/TabField/DataDownloadList/Utils/ProcessData.ts
+++ b/src/Discovery/DiscoveryDetails/Components/FieldGrouping/TabField/DataDownloadList/Utils/ProcessData.ts
@@ -17,6 +17,22 @@ export const ProcessData = (sourceFieldData:any) => {
     processedDataForDataDownloadList = processedDataForDataDownloadList.slice(0, MAX_NUMBER_OF_ITEMS_IN_LIST);
     dataForDataDownloadListHasBeenTruncated = true;
   }
-  processedDataForDataDownloadList = processedDataForDataDownloadList.sort((a, b) => a.title.localeCompare(b.title, undefined, { numeric: true, sensitivity: 'base' }));
+  let rootLevelFiles:any = [];
+  let nonRootLevelFiles:any = [];
+  processedDataForDataDownloadList.forEach((element) => {
+    const titleParts = element.title.split('/');
+    if (titleParts.length > 2) {
+      nonRootLevelFiles.push(element);
+    } else {
+      rootLevelFiles.push(element);
+    }
+  });
+  if (rootLevelFiles.length) {
+    rootLevelFiles = rootLevelFiles.sort((a, b) => a.title.localeCompare(b.title, undefined, { numeric: true, sensitivity: 'base' }));
+  }
+  if (nonRootLevelFiles.length) {
+    nonRootLevelFiles = nonRootLevelFiles.sort((a, b) => a.title.localeCompare(b.title, undefined, { numeric: true, sensitivity: 'base' }));
+  }
+  processedDataForDataDownloadList = rootLevelFiles.concat(nonRootLevelFiles);
   return { processedDataForDataDownloadList, dataForDataDownloadListHasBeenTruncated };
 };

--- a/src/Discovery/DiscoveryDetails/Components/FieldGrouping/TabField/DataDownloadList/Utils/ProcessData.ts
+++ b/src/Discovery/DiscoveryDetails/Components/FieldGrouping/TabField/DataDownloadList/Utils/ProcessData.ts
@@ -1,6 +1,6 @@
-const MAX_NUMBER_OF_ITEMS_IN_LIST = 200;
+export const MAX_NUMBER_OF_ITEMS_IN_LIST = 5;
 
-const ProcessData = (sourceFieldData:any) => {
+export const ProcessData = (sourceFieldData:any) => {
   const dataWithOnlyTitlesOrFileNames = sourceFieldData[0].filter((item:any) => {
     if (!('title' in item || 'file_name' in item)) {
       console.debug('Item without title or file_name:', item);
@@ -20,5 +20,3 @@ const ProcessData = (sourceFieldData:any) => {
   processedDataForDataDownloadList = processedDataForDataDownloadList.sort((a, b) => a.title.localeCompare(b.title, undefined, { numeric: true, sensitivity: 'base' }));
   return { processedDataForDataDownloadList, dataForDataDownloadListHasBeenTruncated };
 };
-
-export default ProcessData;

--- a/src/Discovery/DiscoveryDetails/Components/FieldGrouping/TabField/DataDownloadList/Utils/ProcessData.ts
+++ b/src/Discovery/DiscoveryDetails/Components/FieldGrouping/TabField/DataDownloadList/Utils/ProcessData.ts
@@ -1,3 +1,5 @@
+const MAX_NUMBER_OF_ITEMS_IN_LIST = 200;
+
 const ProcessData = (sourceFieldData:any) => {
   const dataWithOnlyTitlesOrFileNames = sourceFieldData[0].filter((item:any) => {
     if (!('title' in item || 'file_name' in item)) {
@@ -5,12 +7,17 @@ const ProcessData = (sourceFieldData:any) => {
     }
     return 'title' in item || 'file_name' in item;
   });
-  const processedDataForDataDownloadList = dataWithOnlyTitlesOrFileNames.map((obj:any) => ({
+  let processedDataForDataDownloadList = dataWithOnlyTitlesOrFileNames.map((obj:any) => ({
     title: obj.title || obj.file_name,
     description: obj.description,
     guid: obj.object_id,
   }));
-  return processedDataForDataDownloadList;
+  let dataForDataDownloadListHasBeenTruncated = false;
+  if (processedDataForDataDownloadList.length > MAX_NUMBER_OF_ITEMS_IN_LIST) {
+    processedDataForDataDownloadList = processedDataForDataDownloadList.slice(0, MAX_NUMBER_OF_ITEMS_IN_LIST);
+    dataForDataDownloadListHasBeenTruncated = true;
+  }
+  return { processedDataForDataDownloadList, dataForDataDownloadListHasBeenTruncated };
 };
 
 export default ProcessData;

--- a/src/Discovery/DiscoveryDetails/Components/FieldGrouping/TabField/DataDownloadList/Utils/ProcessData.ts
+++ b/src/Discovery/DiscoveryDetails/Components/FieldGrouping/TabField/DataDownloadList/Utils/ProcessData.ts
@@ -1,4 +1,4 @@
-export const MAX_NUMBER_OF_ITEMS_IN_LIST = 5;
+export const MAX_NUMBER_OF_ITEMS_IN_LIST = 200;
 
 export const ProcessData = (sourceFieldData:any) => {
   const dataWithOnlyTitlesOrFileNames = sourceFieldData[0].filter((item:any) => {


### PR DESCRIPTION
<!--
External to CTDS: Please make sure you have reviewed the Gen3 contributor guidelines before submitting a PR: https://uc-cdis.github.io/gen3-docs/docs/Contributor%20Guidelines

Internal to CTDS: Add your JIRA ticket number to the PR title and make sure you have reviewed the developer guidelines before submitting a PR: https://github.com/uc-cdis/gen3.org/blob/master/content/resources/developer/dev-introduction-archived.md

- Describe what this pull request does.
- Add short descriptive bullet points for each section if relevant. Keep in mind that they will be parsed automatically to generate official release notes.
- Test manually.
- Maintain or increase the test coverage (if relevant).
- Update the documentation, or justify if not needed.
-->

Link to JIRA ticket if there is one: https://ctds-planx.atlassian.net/browse/HP-1977 https://ctds-planx.atlassian.net/browse/HP-1978

<img width="916" alt="Screenshot 2025-03-18 at 11 40 28 AM" src="https://github.com/user-attachments/assets/30c72250-88ca-4a4e-b0f7-cfd2a54300e7" />
Screenshot of the change
Note that the limit of 5 file here is for demo purposes only, the actual limit value is 200


### Improvements
- Discovery: the discovery details page's data download list component will only show the first 200 files in the manifest for direct download, and display a banner if the limit has reached
- Discovery: the discovery details page's data download list component will now sort the entries in the list by their titles
