### PR TITLE
render the email address instead of raw oidc id

### DIFF
--- a/src/components/layout/TopBar.jsx
+++ b/src/components/layout/TopBar.jsx
@@ -35,8 +35,8 @@ class TopBar extends Component {
 
   render() {
     const { user } = this.props;
-    // Prefer email, then preferred_username, then name, then username
-    const userLabel = (user && (user.email || user.preferred_username || user.name || user.username)) || '';
+    // Prefer: preferred_username > display_name > name > username > email
+    const userLabel = (user && (user.preferred_username || user.display_name || user.name || user.username || user.email)) || '';
     return (
       <div className='top-bar'>
         <div className='top-bar__header'>
@@ -222,6 +222,7 @@ TopBar.propTypes = {
     username: PropTypes.string,
     email: PropTypes.string,
     preferred_username: PropTypes.string,
+    display_name: PropTypes.string,
     name: PropTypes.string,
   }).isRequired,
   userAuthMapping: PropTypes.object.isRequired,

--- a/src/components/layout/TopBar.jsx
+++ b/src/components/layout/TopBar.jsx
@@ -34,6 +34,9 @@ class TopBar extends Component {
   isActive = (id) => this.props.activeTab === id;
 
   render() {
+    const { user } = this.props;
+    // Prefer email, then preferred_username, then name, then username
+    const userLabel = (user && (user.email || user.preferred_username || user.name || user.username)) || '';
     return (
       <div className='top-bar'>
         <div className='top-bar__header'>
@@ -113,7 +116,7 @@ class TopBar extends Component {
                   >
                     <TopIconButton
                       icon='user-circle'
-                      name={this.props.user.username}
+                      name={userLabel}
                       isActive={this.isActive('/identity')}
                     />
                   </Link>
@@ -130,7 +133,7 @@ class TopBar extends Component {
               this.props.user.username !== undefined && this.props.useProfileDropdown === true
               && (
                 <Popover
-                  title={this.props.user.username}
+                  title={userLabel}
                   placement='bottomRight'
                   content={(
                     <React.Fragment>
@@ -215,7 +218,12 @@ class TopBar extends Component {
 TopBar.propTypes = {
   topItems: PropTypes.array.isRequired,
   useProfileDropdown: PropTypes.bool,
-  user: PropTypes.shape({ username: PropTypes.string }).isRequired,
+  user: PropTypes.shape({
+    username: PropTypes.string,
+    email: PropTypes.string,
+    preferred_username: PropTypes.string,
+    name: PropTypes.string,
+  }).isRequired,
   userAuthMapping: PropTypes.object.isRequired,
   activeTab: PropTypes.string,
   onActiveTab: PropTypes.func,


### PR DESCRIPTION
<!--
External to CTDS: Please make sure you have reviewed the Gen3 contributor guidelines before submitting a PR: https://uc-cdis.github.io/gen3-docs/docs/Contributor%20Guidelines

Internal to CTDS: Add your JIRA ticket number to the PR title and make sure you have reviewed the developer guidelines before submitting a PR: https://github.com/uc-cdis/gen3.org/blob/master/content/resources/developer/dev-introduction-archived.md

- Describe what this pull request does.
- Add short descriptive bullet points for each section if relevant. Keep in mind that they will be parsed automatically to generate official release notes.
- Test manually.
- Maintain or increase the test coverage (if relevant).
- Update the documentation, or justify if not needed.
-->

### Improvements
Currently the Portal header and profile popover display the raw OIDC username claim (e.g. google-oauth2|12345678901234567890). This is confusing for users. Fence already returns the user’s email in /user. We should render the email address instead, falling back to other available claims.
**Before:**
<img width="364" height="124" alt="image" src="https://github.com/user-attachments/assets/e8aafc72-5521-4c7a-8453-1b684dc653ca" />
**After:**
<img width="341" height="121" alt="image" src="https://github.com/user-attachments/assets/09303b7c-7eb8-462d-8a7c-df4995fc6132" />


### Dependency updates

### Deployment changes
<!-- This section should only contain important things devops should know when updating service versions. -->
