### PR TITLE
optimize-NonTabbedDiscoveryDetails, don't display the group title/block is the group content is empty

### DIFF
--- a/src/Discovery/DiscoveryDetails/Components/NonTabbedDiscoveryDetails/NonTabbedDiscoveryDetails.tsx
+++ b/src/Discovery/DiscoveryDetails/Components/NonTabbedDiscoveryDetails/NonTabbedDiscoveryDetails.tsx
@@ -39,11 +39,15 @@ const NonTabbedDiscoveryDetails = ({ props }) => {
           {props.config.studyPageFields.fieldsToShow.map(
             (fieldGroup, i: number) => {
               const fieldGroupWrapperClassName = determineFieldGroupWrapperClassName(fieldGroup.groupWidth);
-              const hasNonEmptyField = fieldGroup.fields.some((field) => {
-                  const fieldValue = jsonpath.query(props.modalData, `$.${field.field}`);
-                  return (                          
-                    fieldValue[0].length > 0                           
-                  );
+              const hasNonEmptyField = fieldGroup.fields.some(({ field }) => {
+                const results = jsonpath.query(props.modalData, `$['${field}']`);
+                const v = results[0]; 
+                if (typeof v === 'string') return v.trim().length > 0;
+                if (Array.isArray(v)) return v.length > 0;
+                if (typeof v === 'number') return !Number.isNaN(v);
+                if (typeof v === 'boolean') return true;
+                if (typeof v === 'object') return Object.keys(v).length > 0;
+                return false;
               });
               return ( hasNonEmptyField &&
                 <div key={i} className={fieldGroupWrapperClassName}>


### PR DESCRIPTION
solve issue #1739

Link to JIRA ticket if there is one: 

### New Features

### Breaking Changes

### Bug Fixes

### Improvements
In NonTabbedDiscoveryDetails, only display the filed group with content, if the content of a field group is empty or none, the title and the empty block will not be displayed in the UI.

### Dependency updates

### Deployment changes
<!-- This section should only contain important things devops should know when updating service versions. -->
