### PR TITLE
MIDRC-921 Disable explorer file manifest download button for ES_MAX_QUERY_TERMS

### DIFF
--- a/docs/portal_config.md
+++ b/docs/portal_config.md
@@ -678,7 +678,7 @@ Below is an example, with inline comments describing what each JSON block config
       "service": "query_page"
     }
   },
-  "userAccessToSite": { // optional: user must have access to a resorces to acess the site, including public pages
+  "userAccessToSite": { // optional: user must have access to a resource to acess the site, including public pages
     "enabled": true,// optional: enable ristricted access
     "noAccessMessage": "Access to this site requires special permission.",// optional: defaults to this value, first email addresses will be turned into mailto link if used
     "deniedPageURL": "/access-denied",//optional: defaults to this value

--- a/src/GuppyDataExplorer/ExplorerButtonGroup/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerButtonGroup/index.jsx
@@ -676,16 +676,14 @@ Currently, in order to export a File PFB, \`enableLimitedFilePFBExport\` must be
       || !this.props.guppyConfig.manifestMapping.referenceIdFieldInResourceIndex) return;
     const caseField = this.props.guppyConfig.manifestMapping.referenceIdFieldInDataIndex;
     const caseFieldInFileIndex = this.props.guppyConfig.manifestMapping.referenceIdFieldInResourceIndex;
+    let fileCount;
     if (this.props.buttonConfig
       && this.props.buttonConfig.buttons
       && this.props.buttonConfig.buttons.some(
         (btnCfg) => isFileButton(btnCfg) && btnCfg.enabled)) {
       if (this.props.guppyConfig.fileCountField) {
         // if "fileCountField" is set, just ask for sum of file_count field
-        const totalFileCount = await this.getFileCountSum();
-        this.setState(() => ({
-          manifestEntryCount: totalFileCount,
-        }));
+        fileCount = await this.getFileCountSum();
       } else {
         // otherwise, just query subject index for subject_id list,
         // and query file index for manifest info.
@@ -702,34 +700,32 @@ Currently, in order to export a File PFB, \`enableLimitedFilePFBExport\` must be
             throw Error('guppyConfig.manifestMapping.resourceIndexType is not defined');
           }
           if (this.props.guppyConfig.manifestMapping.useFilterForCounts) {
-            const countResult = await this.props.getTotalCountsByTypeAndFilter(fileType,
+            fileCount = await this.props.getTotalCountsByTypeAndFilter(fileType,
               this.props.filter,
             );
-            this.setState({
-              manifestEntryCount: countResult, downloadingInProgress: { manifest: false },
-            });
           } else {
             let caseIDList = caseIDResult.map((i) => i[caseField]);
             caseIDList = _.uniq(caseIDList);
-            let countResult;
             if (caseIDList.length <= ES_MAX_QUERY_TERMS) {
-              countResult = await this.props.getTotalCountsByTypeAndFilter(fileType, {
+              fileCount = await this.props.getTotalCountsByTypeAndFilter(fileType, {
                 [caseFieldInFileIndex]: {
                   selectedValues: caseIDList,
                 },
               });
             } else {
-              // this will disable the button, preventing download attemps that would fail
-              countResult = 'too-many-terms';
+              fileCount = ES_MAX_QUERY_TERMS + 1; // to trigger 'too-many-terms' logic below
             }
-            this.setState({
-              manifestEntryCount: countResult, downloadingInProgress: { manifest: false },
-            });
           }
         } else {
           throw Error('Error when downloading data');
         }
       }
+
+      // this will disable the button, preventing download attemps that would fail
+      fileCount = fileCount <= ES_MAX_QUERY_TERMS ? fileCount : 'too-many-terms';
+      this.setState({
+        manifestEntryCount: fileCount, downloadingInProgress: { manifest: false },
+      });
     }
   };
 


### PR DESCRIPTION
<!--
External to CTDS: Please make sure you have reviewed the Gen3 contributor guidelines before submitting a PR: https://uc-cdis.github.io/gen3-docs/docs/Contributor%20Guidelines

Internal to CTDS: Add your JIRA ticket number to the PR title and make sure you have reviewed the developer guidelines before submitting a PR: https://github.com/uc-cdis/gen3.org/blob/master/content/resources/developer/dev-introduction-archived.md

- Describe what this pull request does.
- Add short descriptive bullet points for each section if relevant. Keep in mind that they will be parsed automatically to generate official release notes.
- Test manually.
- Maintain or increase the test coverage (if relevant).
- Update the documentation, or justify if not needed.
-->

Link to JIRA ticket if there is one: https://ctds-planx.atlassian.net/browse/MIDRC-921

Improves fix from https://github.com/uc-cdis/data-portal/pull/1670 to work for all the ways we generate the manifest file count.

[Slack thread for context](https://cdis.slack.com/archives/C019U0LSP9T/p1764789738651129?thread_ts=1764772396.570369&cid=C019U0LSP9T)

### Improvements
- Explorer page: Do not allow users to click "download manifest" button when the query to ElasticSearch would fail due to having too many terms in the query. Instead, let the user know: "too many rows to download at once; make a smaller selection"
