### PR TITLE
Update Gen3 URL references

### DIFF
--- a/data/config/brh.json
+++ b/data/config/brh.json
@@ -145,7 +145,7 @@
       "footerLogos": [
         {
           "src": "/src/img/gen3.png",
-          "href": "https://ctds.uchicago.edu/gen3",
+          "href": "https://gen3.org",
           "alt": "Gen3 Data Commons"
         },
         {

--- a/data/config/default.json
+++ b/data/config/default.json
@@ -166,7 +166,7 @@
     "footerLogos": [
       {
         "src": "/src/img/gen3.png",
-        "href": "https://ctds.uchicago.edu/gen3",
+        "href": "https://gen3.org",
         "alt": "Gen3 Data Commons"
       },
       {

--- a/data/config/gtex.json
+++ b/data/config/gtex.json
@@ -129,7 +129,7 @@
     "footerLogos": [
       {
         "src": "/src/img/gen3.png",
-        "href": "https://ctds.uchicago.edu/gen3",
+        "href": "https://gen3.org",
         "alt": "Gen3 Data Commons"
       },
       {

--- a/data/config/ndh.json
+++ b/data/config/ndh.json
@@ -119,7 +119,7 @@
     "footerLogos": [
       {
         "src": "/src/img/gen3.png",
-        "href": "https://ctds.uchicago.edu/gen3",
+        "href": "https://gen3.org",
         "alt": "Gen3 Data Commons"
       },
       {

--- a/data/config/va.json
+++ b/data/config/va.json
@@ -130,7 +130,7 @@
     "footerLogos": [
       {
         "src": "/src/img/gen3.png",
-        "href": "https://ctds.uchicago.edu/gen3",
+        "href": "https://gen3.org",
         "alt": "Gen3 Data Commons"
       },
       {

--- a/docs/portal_config.md
+++ b/docs/portal_config.md
@@ -176,7 +176,7 @@ Below is an example, with inline comments describing what each JSON block config
     "footerLogos": [ // optional; logos to be displayed in the footer, usually sponsors
       {
         "src": "/src/img/gen3.png", // required; src path for the image
-        "href": "https://ctds.uchicago.edu/gen3", // required; link for image
+        "href": "https://gen3.org", // required; link for image
         // The alt text for certain cross-commons logos, such as the Gen3 and CTDS logos, are non-configurable so as to avoid redundancy.
         // Note that this alt text is applied on the basis of link destination, not logo filename.
       },

--- a/src/localconf.js
+++ b/src/localconf.js
@@ -504,7 +504,7 @@ function buildConfig(opts) {
 
   const commonsWideAltText = {
     portalLogo: portalLogoAltText(),
-    'https://ctds.uchicago.edu/gen3': 'Gen3 Data Commons - information and resources',
+    'https://gen3.org': 'Gen3 Data Commons - information and resources',
     'https://ctds.uchicago.edu/': 'Center for Translational Data Science at the University of Chicago - information and resources',
 
   };


### PR DESCRIPTION
Replace https://ctds.uchicago.edu/gen3 with https://gen3.org