### PR TITLE
chore(updateAnalysisLink): Added external link indicator

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,1 +1,2 @@
 src/params.js
+src/img/icons/**/*.svg

--- a/docs/portal_config.md
+++ b/docs/portal_config.md
@@ -116,7 +116,8 @@ Below is an example, with inline comments describing what each JSON block config
         {
           "icon": "dictionary", // required; icon from /img/icons for the button
           "link": "/DD", // required; the link for the button
-          "name": "Dictionary" // required; text for the button
+          "name": "Dictionary", // required; text for the button
+          "newWindow": boolean // Optional: sets the link to open in a new window or tab
         },
         {
           "icon": "exploration",

--- a/docs/portal_config.md
+++ b/docs/portal_config.md
@@ -117,7 +117,7 @@ Below is an example, with inline comments describing what each JSON block config
           "icon": "dictionary", // required; icon from /img/icons for the button
           "link": "/DD", // required; the link for the button
           "name": "Dictionary", // required; text for the button
-          "newWindow": boolean // Optional: sets the link to open in a new window or tab
+          "newWindow": true // Optional: sets the link to open in a new window or tab
         },
         {
           "icon": "exploration",

--- a/src/components/ExternalLinkIndicator.tsx
+++ b/src/components/ExternalLinkIndicator.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+// import { ExternalLinkSVG } from '../img/icons/external-link-indicator.svg';
+import ExternalLinkIcon from '../img/icons/external-link-indicator.svg';
+
+// 2. Apply the type to the props object
+const ExternalLinkIndicator = ({ className = '' }) => (
+  <React.Fragment>
+    <span
+      aria-hidden='true'
+      className={`inline-block ${className}`.trim()}
+      data-testid='external-link-indicator'
+      aria-label='opens in a new window'
+      style={{ marginTop: '5px' }}
+    >
+      <ExternalLinkIcon />
+    </span>
+  </React.Fragment>
+);
+export default ExternalLinkIndicator;

--- a/src/components/ExternalLinkIndicator.tsx
+++ b/src/components/ExternalLinkIndicator.tsx
@@ -1,8 +1,6 @@
 import React from 'react';
-// import { ExternalLinkSVG } from '../img/icons/external-link-indicator.svg';
 import ExternalLinkIcon from '../img/icons/external-link-indicator.svg';
 
-// 2. Apply the type to the props object
 const ExternalLinkIndicator = ({ className = '' }) => (
   <React.Fragment>
     <span

--- a/src/components/ExternalLinkIndicator.tsx
+++ b/src/components/ExternalLinkIndicator.tsx
@@ -8,7 +8,6 @@ const ExternalLinkIndicator = ({ className = '' }) => (
       className={`inline-block ${className}`.trim()}
       data-testid='external-link-indicator'
       aria-label='opens in a new window'
-      style={{ marginTop: '5px' }}
     >
       <ExternalLinkIcon />
     </span>

--- a/src/components/ExternalLinkIndicator.tsx
+++ b/src/components/ExternalLinkIndicator.tsx
@@ -4,7 +4,6 @@ import ExternalLinkIcon from '../img/icons/external-link-indicator.svg';
 const ExternalLinkIndicator = ({ className = '' }) => (
   <React.Fragment>
     <span
-      aria-hidden='true'
       className={`inline-block ${className}`.trim()}
       data-testid='external-link-indicator'
       aria-label='opens in a new window'

--- a/src/components/ExternalLinkIndicator.tsx
+++ b/src/components/ExternalLinkIndicator.tsx
@@ -5,7 +5,6 @@ const ExternalLinkIndicator = ({ className = '' }) => (
   <React.Fragment>
     <span
       className={`inline-block ${className}`.trim()}
-      data-testid='external-link-indicator'
       aria-label='opens in a new window'
     >
       <ExternalLinkIcon />

--- a/src/components/layout/NavButton.jsx
+++ b/src/components/layout/NavButton.jsx
@@ -3,17 +3,12 @@ import PropTypes from 'prop-types';
 import { NavLink } from 'react-router-dom';
 import IconComponent from '../Icon';
 import './NavButton.less';
+import ExternalLinkIndicator from '../ExternalLinkIndicator';
 
-const NavButton = ({
-  dictIcons,
-  item,
-}) => {
+const NavButton = ({ dictIcons, item }) => {
   if (item.link.startsWith('http')) {
     return (
-      <a
-        href={item.link}
-        className={'body-typo nav-button'}
-      >
+      <a href={item.link} className={'body-typo nav-button'}>
         <div className='nav-button__icon'>
           <IconComponent iconName={item.icon} dictIcons={dictIcons} />
         </div>
@@ -26,11 +21,14 @@ const NavButton = ({
       className={'body-typo nav-button'}
       activeClassName='button-active'
       to={item.link}
+      target={item.newWindow ? '_blank' : '_self'}
+      rel='noopener noreferrer'
     >
       <div className='nav-button__icon'>
         <IconComponent iconName={item.icon} dictIcons={dictIcons} />
       </div>
       {item.name}
+      {item.newWindow && <ExternalLinkIndicator />}
     </NavLink>
   );
 };

--- a/src/img/icons/external-link-indicator.svg
+++ b/src/img/icons/external-link-indicator.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="15"
+fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor"
+style='display: inline-block; margin-bottom: -2px; margin-left: 2px;'>
+    <path stroke-linecap="round" stroke-linejoin="round" d="M13.5 6H5.25A2.25 2.25 0 0 0 3 8.25v10.5A2.25 2.25 0 0 0 5.25 21h10.5A2.25 2.25 0 0 0 18 18.75V10.5m-10.5 6L21 3m0 0h-5.25M21 3v5.25"/>
+  </svg>

--- a/src/img/icons/external-link-indicator.svg
+++ b/src/img/icons/external-link-indicator.svg
@@ -1,5 +1,12 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="16" height="15"
-fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor"
-style='display: inline-block; margin-bottom: -2px; margin-left: 2px;'>
-    <path stroke-linecap="round" stroke-linejoin="round" d="M13.5 6H5.25A2.25 2.25 0 0 0 3 8.25v10.5A2.25 2.25 0 0 0 5.25 21h10.5A2.25 2.25 0 0 0 18 18.75V10.5m-10.5 6L21 3m0 0h-5.25M21 3v5.25"/>
-  </svg>
+<svg
+  xmlns='http://www.w3.org/2000/svg'
+  width='16'
+  height='15'
+  fill='none'
+  viewBox='0 0 24 24'
+  strokeWidth='2'
+  stroke='currentColor'
+  style='display: inline-block; margin-bottom: -2px; margin-left: 2px;'
+>
+  <path strokeLinecap='round' strokeLinejoin='round' d='M13.5 6H5.25A2.25 2.25 0 0 0 3 8.25v10.5A2.25 2.25 0 0 0 5.25 21h10.5A2.25 2.25 0 0 0 18 18.75V10.5m-10.5 6L21 3m0 0h-5.25M21 3v5.25' />
+</svg>


### PR DESCRIPTION
Link to JIRA ticket if there is one:
https://ctds-planx.atlassian.net/browse/HP-2677

<img width="720" height="355" alt="output" src="https://github.com/user-attachments/assets/b1af5625-6c62-4df3-8f57-06bb2007f385" />

**Note**
Navigation section of gitops.json will need to be updated with an optional newWindow boolean set to true for any navigation links that need to be opened in a new window, i.e. 
```
      {
          "name": "Example Analyses",
          "link": "/resource-browser",
          "newWindow": true,
          "icon": "bar-chart",
          "tooltip": "Learn how to use Jupyter Notebooks to explore and visualize data available on the HEAL platform by running a static tutorial notebook, or use one of these examples as a launching point for your own custom analysis."
        },
```

### Improvements
- Example Analyses tab: Link now opens in new tab with external link indicator
