### PR TITLE
Rename dicomServerUrl with DicomServerURL to match with portalConfig

### DIFF
--- a/src/GuppyDataExplorer/ExplorerVisualization/index.jsx
+++ b/src/GuppyDataExplorer/ExplorerVisualization/index.jsx
@@ -241,7 +241,7 @@ class ExplorerVisualization extends React.Component {
                 fields: tableColumns,
                 ordered: tableColumnsOrdered,
                 linkFields: this.props.tableConfig.linkFields || [],
-                dicomServerUrl: this.props.tableConfig.dicomServerUrl,
+                dicomServerURL: this.props.tableConfig.dicomServerURL,
                 dicomViewerUrl: this.props.tableConfig.dicomViewerUrl,
                 dicomViewerId: this.props.tableConfig.dicomViewerId,
               }}


### PR DESCRIPTION
<!--
External to CTDS: Please make sure you have reviewed the Gen3 contributor guidelines before submitting a PR: https://uc-cdis.github.io/gen3-docs/docs/Contributor%20Guidelines

Internal to CTDS: Add your JIRA ticket number to the PR title and make sure you have reviewed the developer guidelines before submitting a PR: https://github.com/uc-cdis/gen3.org/blob/master/content/resources/developer/dev-introduction-archived.md

- Describe what this pull request does.
- Add short descriptive bullet points for each section if relevant. Keep in mind that they will be parsed automatically to generate official release notes.
- Test manually.
- Maintain or increase the test coverage (if relevant).
- Update the documentation, or justify if not needed.
-->

Link to JIRA ticket if there is one: [MIDRC-1294](https://ctds-planx.atlassian.net/browse/MIDRC-1294)

### New Features

### Breaking Changes

### Bug Fixes
* Rename `tableConfig.dicomServerUrl` to `tableConfig.dicomServerURL` to match with [portalConfig](https://github.com/uc-cdis/data-portal/blob/ca6938338e22481ae235b854a653cd32f194fd73/docs/portal_config.md#L275C10-L275C24). 
### Improvements

### Dependency updates

### Deployment changes
<!-- This section should only contain important things devops should know when updating service versions. -->


[MIDRC-1294]: https://ctds-planx.atlassian.net/browse/MIDRC-1294?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ