### PR TITLE
override fast-uri to ^3.1.5 (CVE-2026-18446)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21094,9 +21094,9 @@
       }
     },
     "node_modules/fast-uri": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
-      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
       "funding": [
         {
           "type": "github",
@@ -21106,7 +21106,8 @@
           "type": "opencollective",
           "url": "https://opencollective.com/fastify"
         }
-      ]
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/fast-url-parser": {
       "version": "1.1.3",

--- a/package.json
+++ b/package.json
@@ -185,7 +185,8 @@
       "react-router": "$react-router-dom"
     },
     "markdown-it": "^14.1.1",
-    "linkify-it": "^5.0.2"
+    "linkify-it": "^5.0.2",
+    "fast-uri": "^3.1.5"
   },
   "jest": {
     "verbose": true,


### PR DESCRIPTION
<!--
External to CTDS: Please make sure you have reviewed the Gen3 contributor guidelines before submitting a PR: https://uc-cdis.github.io/gen3-docs/docs/Contributor%20Guidelines

Internal to CTDS: Add your JIRA ticket number to the PR title and make sure you have reviewed the developer guidelines before submitting a PR: https://github.com/uc-cdis/gen3.org/blob/master/content/resources/developer/dev-introduction-archived.md

- Describe what this pull request does.
- Add short descriptive bullet points for each section if relevant. Keep in mind that they will be parsed automatically to generate official release notes.
- Test manually.
- Maintain or increase the test coverage (if relevant).
- Update the documentation, or justify if not needed.
-->

Link to JIRA ticket if there is one: [PPS-4500](https://ctds-planx.atlassian.net/browse/PPS-4500)

### New Features

### Breaking Changes

### Bug Fixes

### Improvements

### Dependency updates
bump fast-uri to ^3.1.5
### Deployment changes
<!-- This section should only contain important things devops should know when updating service versions. -->


[PPS-4500]: https://ctds-planx.atlassian.net/browse/PPS-4500?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ